### PR TITLE
Add autoprefixer-rails to the frontend

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'sass-rails', '~> 4.0.0.rc1'
 gem 'turbolinks'
 gem 'uglifier', '>= 1.3.0'
 gem 'unicorn-rails'
+gem 'autoprefixer-rails'
 
 group :development do
   gem 'mas-development_dependencies', github: 'moneyadviceservice/mas-development_dependencies'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,8 @@ GEM
     addressable (2.3.5)
     arel (5.0.0)
     atomic (1.1.14)
+    autoprefixer-rails (1.0.20140109)
+      execjs
     builder (3.2.2)
     capybara (2.2.0)
       mime-types (>= 1.16)
@@ -230,6 +232,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  autoprefixer-rails
   coffee-rails (~> 4.0.0)
   draper (~> 1.3.0)
   foreman


### PR DESCRIPTION
As discussed with @novotnyjakub this will later belong to **_mas-assets**_.
@aduggin feel free to add the set of rules in this branch.

[AL D]: I've checked the default configuration and the following browsers are supported which is inline with our browser support:

Browsers:
  Android: 4.1, 4, 2.3
  Chrome: 31, 30
  Firefox: 26, 25, 24
  IE: 11, 10, 9, 8
  iOS: 7, 6.1
  Opera: 17, 16, 12.1
  Safari: 7, 6.1

Looks good to go: @andrewgarner 
