### PR TITLE
Excluding 2 rules from html-inspector to reduce noise

### DIFF
--- a/app/assets/javascripts/html_inspector.js
+++ b/app/assets/javascripts/html_inspector.js
@@ -1,3 +1,5 @@
 //= require html-inspector/html-inspector
 
-HTMLInspector.inspect();
+HTMLInspector.inspect({
+  excludeRules: ["unused-classes", "script-placement"]
+})


### PR DESCRIPTION
Excluding 'unused classes' - we will always have the font loader classes on the html element
Excluding 'script placement' - we have a few of these due to live reload and chrome

@alexwllms @andrewtennison 
