### PR TITLE
Responsive Video and link fixes

### DIFF
--- a/app/assets/stylesheets/components/_editorial.scss
+++ b/app/assets/stylesheets/components/_editorial.scss
@@ -6,9 +6,24 @@
 
 .editorial {
 
-  img, 
-  iframe {
+  img {
     max-width:100%;
+  }
+
+  .video-wrapper { //http://alistapart.com/article/creating-intrinsic-ratios-for-video
+    clear:both;
+    position: relative;
+    padding-bottom: 56.25%; /* 16:9 */
+    padding-top: 25px;
+    height: 0;
+
+    iframe {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+    }
   }
 
   a:not([href*="moneyadviceservice"]):after {
@@ -16,6 +31,13 @@
     @extend .icon--externalLink;
     color: $color-link-external;
     padding-left: 5px;
+    display:inline-block; // hide the underline when hovering over the link
+  }
+
+  // override for links that do not contain moneyadviceservice but are not external links
+  a[href^="/"]:after,
+  a[href^="#"]:after{
+    display:none;
   }
 
   a[href$=".doc"] {
@@ -26,6 +48,7 @@
       @extend .icon;
       @extend .icon--doc;
       padding-right: 5px;
+      display:inline-block; // hide the underline when hovering over the link
     }
   }
 

--- a/app/views/styleguide/shared/_guide.html.erb
+++ b/app/views/styleguide/shared/_guide.html.erb
@@ -130,11 +130,13 @@
     holiday.</a>
 </p>
 
+<div class="video-wrapper">
 <iframe frameborder="0" height="413" width="680" src="https://www.youtube.com/embed/glFy-NkCnu8"> &amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;lt;span
   id="XinhaEditingPostion"&amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;gt;&amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;lt;/span&amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;gt;&amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;lt;span
   id="XinhaEditingPostion"&amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;gt;&amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;lt;/span&amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;gt;&amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;lt;span
   id="XinhaEditingPostion"&amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;gt;&amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;lt;/span&amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;gt;
 </iframe>
+</div>
 
 <a title="Christmas transcript" href="https://www.moneyadviceservice.org.uk/files/the-cost-of-christmas-video-transcript.doc">Read
   a transcript of the video (doc)</a>


### PR DESCRIPTION
The video on the guide page in the style guide is now responsive by adding a wrapper element:
 /en/styleguide/pages/guide

I've also fixed a couple of link issues - internal links showing the external link icon and the icons showing an underline on hover

@alexwllms 
