### PR TITLE
Handle requests we have no implementation for

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,4 +39,6 @@ Rails.application.routes.draw do
       end
     end
   end
+
+  match '*path', via: %W(get post), to: -> env { [501, {}, []] }
 end

--- a/spec/requests/not_implemented_spec.rb
+++ b/spec/requests/not_implemented_spec.rb
@@ -1,0 +1,9 @@
+require_relative '../spec_helper'
+
+describe 'Request we have no implementation for' do
+  it 'returns a 501 response' do
+    get('/unsupported')
+
+    expect(response.status).to eq(501)
+  end
+end


### PR DESCRIPTION
Adds a catch-all route that will return a 501 for any requests the frontend app doesn't have an implementation for.

We will handle these in Nginx by attempting to handle the request from another backend (aka the Public Website).
