### PR TITLE
Fix iframe issue when javascript is turned off

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -52,11 +52,10 @@
 
 </head>
 <body>
-
-  <%# Google Tag Manager %>
   <noscript>
-    <%= tag :iframe, { src:   "//www.googletagmanager.com/ns.html?id=#{Rails.application.config.google_tag_manager_id}",
-                       style: 'display:none;visibility:hidden', width: 0, height: 0 } %>
+    <iframe src="//www.googletagmanager.com/ns.html?id=<%= Rails.application.config.google_tag_manager_id %>"
+            height="0" width="0" style="display:none;visibility:hidden"
+            title="Google Tag Manager"></iframe>
   </noscript>
   <script>
     (function (w, d, s, l, i) {


### PR DESCRIPTION
Turning off javascript in Chrome resulted in the noscript version of the google tag manager iframe being rendered as text in Chrome and resulted in all pages being blank white when refreshed in all browsers.

Hard coding a  iframe element instead of using a ROR tag helper has fixed this. The tag helper was outputting a self closing tag instead of a seperate closing tag.

I have also added a title attribute to the iframe which is required for accessibility purposes and have removed an unnecessary comment to reduce clutter in the base template.

@andrewgarner @andrewtennison 
