### PR TITLE
Create a fake category repository and use it when features are run

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -2,5 +2,8 @@ ENV['RAILS_ENV']  = 'test'
 ENV['RAILS_ROOT'] = File.expand_path('../../../', __FILE__)
 
 require 'mas/development_dependencies/cucumber/env'
+require 'core/repositories/categories/fake'
 
 I18n.available_locales = [:en, :cy]
+
+Core::Registries::Repository[:category] = Core::Repositories::Categories::Fake.new

--- a/lib/core/repositories/categories/fake.rb
+++ b/lib/core/repositories/categories/fake.rb
@@ -1,0 +1,31 @@
+module Core::Repositories
+  module Categories
+    class Fake
+      def all
+        categories
+      end
+
+      def find(id)
+        categories.find { |category| category['id'] == id }
+      end
+
+      private
+
+      def categories
+        [{
+          'id' => 'category-1',
+          'title' => 'Category 1',
+          'subCategories' => [
+            'id' => 'subcategory-1',
+            'title' => 'Subcategory 1',
+            'subCategories' => []
+          ]
+        },{
+          'id' => 'category-2',
+          'title' => 'Category 2',
+          'subCategories' => []
+        }]
+      end
+    end
+  end
+end

--- a/spec/lib/core/repositories/categories/fake_spec.rb
+++ b/spec/lib/core/repositories/categories/fake_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+require 'core/repositories/categories/fake'
+
+describe Core::Repositories::Categories::Fake do
+  let(:valid_id) { 'category-1' }
+  let(:invalid_id) { 'fake' }
+
+  describe '#all' do
+    subject { described_class.new.all }
+
+    it { should be_a(Array) }
+    specify { expect(subject.first['id']).to eq(valid_id) }
+  end
+
+  describe '#find' do
+    context 'when the category exists' do
+      subject { described_class.new.find(valid_id) }
+
+      it { should be_a(Hash) }
+      specify { expect(subject['id']).to eq(valid_id) }
+    end
+
+    context 'when the category is non-existent' do
+      subject { described_class.new.find(invalid_id) }
+
+      it { should be_nil }
+    end
+  end
+end


### PR DESCRIPTION
This is a rough first version of using a fake repository during test runs.

Currently our features are using VCR to mock out API calls for `Article` and `ActionPlan` content however they are using manually crafted cassettes which aren't easily modified to support replaying the API calls for `Category` data.

Considering we're abstracting API access with repositories we can simply choose to use a repository containing static data rather than coercing our test setup to mock out additional HTTP requests.

As discussed with @andrewgarner the intention is to replace our current use of VCR in this app with fake repositories.

The shortcoming of this first pass is that the data is hardcoded in the class but it could be extended to load from a YAML file and/or to have methods to programatically add and remove contents.
