### PR TITLE
Update swapClass method

### DIFF
--- a/app/assets/javascripts/modules/mas_collapsable.js
+++ b/app/assets/javascripts/modules/mas_collapsable.js
@@ -25,15 +25,8 @@ define(['log', 'jquery'], function (Global, $) {
     }
   };
 
-  $.fn.swapClass = function(from,to){
-    var c = this[0].className;
-    if( c.indexOf(to) !== -1 ){
-      return;
-    }else if( c.indexOf(from) === -1 ){
-      this[0].className = c + ' ' + to;
-    }else{
-      this[0].className = c.replace(from,to);
-    }
+  $.fn.swapClass = function(from, to){
+    this.removeClass(from).addClass(to);
   };
 
   var Collapsible = function(opts){


### PR DESCRIPTION
Simplifies swapClass method using jQuery removeClass().addClass()
chaining to fix issue where swapped classes merge into classes already
present, e.g. is-activenav-tasks’.
