### PR TITLE
Fix extends error due to typo

### DIFF
--- a/app/assets/stylesheets/components/editorial/_links.scss
+++ b/app/assets/stylesheets/components/editorial/_links.scss
@@ -1,6 +1,6 @@
 a:not([href*="moneyadviceservice"]):after {
   @extend .icon;
-  @extend .icon--externalLink;
+  @extend .icon--external-link;
   color: $color-link-external;
   padding-left: 5px;
 }


### PR DESCRIPTION
@alexwllms an extends was referencing an icon that was still camel case - have changed it to class BEM syntax
