### PR TITLE
Vertical align content in table cells

### DIFF
--- a/app/assets/stylesheets/components/editorial/_tables.scss
+++ b/app/assets/stylesheets/components/editorial/_tables.scss
@@ -40,18 +40,16 @@ tr:nth-child(even) {
   background-color: $color-table-background-alt;
 }
 
-th {
+th, td {
+  vertical-align: top;
   padding: $baseline-unit*2;
   border: 1px solid $color-table-border;
+  width: auto;
+}
 
+th {
   > p {
     font-weight: bold;
     // NOTE that this is here to override sloppy formatting in the tables where p tags is not bolded.
   }
-}
-
-td {
-  padding: $baseline-unit*2;
-  border: 1px solid $color-table-border;
-  width: auto;
 }


### PR DESCRIPTION
Content in tables is currently vertically centred and content can become unreadable on small screens. Have changed to be top aligned to improve readability

@alexwllms 
