### PR TITLE
Remove default list icon

### DIFF
--- a/app/assets/stylesheets/components/_lists.scss
+++ b/app/assets/stylesheets/components/_lists.scss
@@ -61,6 +61,10 @@
   padding: 0;
   margin: 0;
   list-style-type: none;
+  
+  > li:before{
+    content: none;
+  }
 }
 
 .list--unstyled-icon:before {


### PR DESCRIPTION
Previous
Icon appears when `.list--unstyled` is applied

Now
Icon is hidden when `.list--unstyled` is applied
