### PR TITLE
fix search-bar styling bug

### DIFF
--- a/app/assets/stylesheets/components/_search_box.scss
+++ b/app/assets/stylesheets/components/_search_box.scss
@@ -31,8 +31,8 @@
   @extend .button--unstyled;
   position: absolute;
   bottom: 0;
-  right: 0;
-  width: 52px;
+  right: -10px;
+  width: 62px;
   height: 42px;
   font-size: 24px;
   color: $color-search-text;


### PR DESCRIPTION
added padding back in
made button wider to improve hit area on mobile - issue on ios if you dont hit button gives select menu

@aduggin @alexwllms 
