### PR TITLE
fix #939 responsive tracking

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -74,6 +74,9 @@
       var el = d.getElementsByTagName('html')[0];
       el.className = el.className.replace('no-js', 'js js-' + MAS.supports.js);
 
+      var title = d.getElementsByTagName('title')[0];
+      title.innerHTML = title.innerHTML + ' | Responsive';
+
       <%#
       Fix for iPhone viewport scale bug  => http://www.blog.highub.com/mobile-2/a-fix-for-iphone-viewport-scale-bug
       vp = viewport / ua = useragent / gs = gesture start / sf = scaleFix


### PR DESCRIPTION
added JS to modify page title before GA initiates.

Aim is by changing page title with JS it should not effect seo but will allow google analytics to identify the page as unique therefore allowing journeys to be tracked across the new and old site continuously 

@aduggin @andrewgarner 
