### PR TITLE
Change mechanism for identifying responsive site

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -38,7 +38,10 @@
   <script type="text/javascript">
 
     // Required for Google Tag Manager
-    dataLayer = [];
+    dataLayer = [{
+      'Responsive page': 'Yes',
+      'event': 'Responsive page'
+    }];
 
     // Any properties that require Ruby @ runtime
     var MAS = window.MAS || {};
@@ -73,9 +76,6 @@
       // Update className
       var el = d.getElementsByTagName('html')[0];
       el.className = el.className.replace('no-js', 'js js-' + MAS.supports.js);
-
-      var title = d.getElementsByTagName('title')[0];
-      title.innerHTML = title.innerHTML + ' | Responsive';
 
       <%#
       Fix for iPhone viewport scale bug  => http://www.blog.highub.com/mobile-2/a-fix-for-iphone-viewport-scale-bug


### PR DESCRIPTION
Spoke to Ammar about a better way to be able to identify/track responsive pages.  The original suggestion (appending '| Responsive' to the title of the page) would have been noticed by users (sighted and blind).  Ammar suggested adding the following code to each page:

dataLayer.push({
  'Responsive page': 'Yes',
  'event': 'Responsive page'
});

I've updated the page template to add this object to the dataLayer array.

@andrewtennison 
