### PR TITLE
Adding default flags to colours, to allow engine override

### DIFF
--- a/app/assets/stylesheets/lib/variables/_colours.scss
+++ b/app/assets/stylesheets/lib/variables/_colours.scss
@@ -13,7 +13,7 @@ $color-green-tertiary: #115329 !default;
 $color-green-quaternary: rgba(51, 105, 19, 0.7) !default;
 
 $color-green-paler: #f5f7f8 !default;
-$color-green-pale: #F7FBEC !default;
+$color-green-pale: #f7fbec !default;
 $color-green-light: #b9dd48 !default;
 $color-green-medium: #81c724 !default;
 $color-green-bright: #adcf3f !default;


### PR DESCRIPTION
Same as with the grid defaults, adding these flags allows engines to override colours where necessary.

Could argue that this shouldn't ever have to happen, but with the guidelines still in flux and impending deadlines, we need to find a way to push these through for the short term.
