### PR TITLE
Double padding around cookie message close button.

### DIFF
--- a/app/assets/stylesheets/components/_cookie_message.scss
+++ b/app/assets/stylesheets/components/_cookie_message.scss
@@ -22,7 +22,7 @@
 }
 
 .cookie-message__close-button {
-  padding: 3px $baseline-unit $baseline-unit $baseline-unit;
+  padding: $baseline-unit $baseline-unit*2 $baseline-unit*2 $baseline-unit*2;
   position: absolute;
   top: 0;
   right: 0;


### PR DESCRIPTION
Button was right up against the edge and being interfered with by scroll bars.  We now also have larger tap area.

I've uploaded a few screengrabs on [the target process ticket](https://moneyadviceservice.tpondemand.com/RestUI/TpView.aspx?acid=E10E3BF21A3627FAEC297AE412030D57#bug/975) to see the change.
