### PR TITLE
Another attempt to resolve intermittent JS test failure

### DIFF
--- a/features/step_definitions/cookie_disclosure_steps.rb
+++ b/features/step_definitions/cookie_disclosure_steps.rb
@@ -48,6 +48,7 @@ end
 
 When(/^I close the cookie message$/) do
   current_page.footer_cookie_message.close_button.click
+  sleep(5) if Capybara.current_driver == :poltergeist
 end
 
 When(/^I click on the "Cookie Policy" link in the footer$/) do


### PR DESCRIPTION
Added an explicit five second wait after clicking a javascript link to leave time for dom changes.
