### PR TITLE
Make the root_path named root include the locale

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,11 +8,11 @@ class ValidArticle
 end
 
 Rails.application.routes.draw do
-  root 'home#show'
+  get '/' => 'home#show'
   resource :beta_opt_out, only: [:create, :destroy], path: 'opt-out'
 
   scope '/:locale', locale: /en|cy/ do
-    get '/' => 'home#show'
+    root 'home#show'
     resources :action_plans, only: 'show'
     resources :articles,
               only:        'show',


### PR DESCRIPTION
I simple fix to remove the `/?locale=en` href in the site header

@andrewgarner @pvcarrera 
