### PR TITLE
Stub AdvicePlans::StartTaskCommand

### DIFF
--- a/config/initializers/advice_plans.rb
+++ b/config/initializers/advice_plans.rb
@@ -1,6 +1,7 @@
 module AdvicePlans
-  class StartTaskCommand
-    def method_missing(*args)
+  def self.const_missing(name)
+    Class.new do
+      def method_missing(*args); end
     end
   end
 end


### PR DESCRIPTION
We are sharing sessions with the desktop website. The Advice Plans engine stores command objects in the session. Rails attempts to fetch the whole session graph causing a `uninitialized constant AdvicePlans`error.

This commit introduces a stub for the Advice Plans module that allows us to continue to share the session.

See https://github.com/moneyadviceservice/advice_plans/blob/master/app/controllers/advice_plans/tasks_controller.rb#L35
