### PR TITLE
Advice plan command

### DIFF
--- a/config/initializers/advice_plans.rb
+++ b/config/initializers/advice_plans.rb
@@ -1,7 +1,7 @@
 module AdvicePlans
+  StartTaskCommand = Struct.new(:current_owner, :plan_slug, :task_id, :options)
+
   def self.const_missing(name)
-    Class.new do
-      def method_missing(*args); end
-    end
+    const_set(name, Class.new)
   end
 end


### PR DESCRIPTION
Second attempt at resolving #276 - `AdvicePlans::StartTaskCommand` must be a struct.
