### PR TITLE
A different approach to loading html-inspector.

### DIFF
--- a/app/assets/javascripts/html_inspector.js
+++ b/app/assets/javascripts/html_inspector.js
@@ -1,5 +1,0 @@
-//= require html-inspector/html-inspector
-
-HTMLInspector.inspect({
-  excludeRules: ["unused-classes", "script-placement"]
-})

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -138,7 +138,12 @@
 
   <% if Rails.env.development? %>
     <!--[if (gt IE 9)|!(IE)]><!-->
-    <%= javascript_include_tag 'html_inspector' %>
+    <%= javascript_include_tag 'html-inspector/html-inspector' %>
+    <script>
+      HTMLInspector.inspect({
+        excludeRules: ["unused-classes", "script-placement"]
+      })
+    </script>
     <!--<![endif]-->
   <% end %>
 


### PR DESCRIPTION
As implemented with @andrewtennison, this is in preparation for JsHint integration and avoids pulling the html-inspector library in via the asset pipeline.
