### PR TITLE
add require config to style guide

### DIFF
--- a/app/assets/javascripts/styleguide.js
+++ b/app/assets/javascripts/styleguide.js
@@ -1,2 +1,3 @@
+//= require require_config
 //= require 'styleguide/kss'
 //= require 'styleguide/navigation'


### PR DESCRIPTION
LIVE Styleguide javascript broken. Asset path wrong as require config not included in styleguide.js

@andrewgarner @MMartins-MAS 
