### PR TITLE
Update version of libyaml used

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'link_header'
 gem 'meta-tags', require: 'meta_tags', github: 'moneyadviceservice/meta-tags', branch: 'alternate-url'
 gem 'nokogiri'
 gem 'nunes'
+gem 'psych', '>= 2.0.5' # https://www.ruby-lang.org/en/news/2014/03/29/heap-overflow-in-yaml-uri-escape-parsing-cve-2014-2525/
 gem 'rouge'
 gem 'statsd-ruby'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,6 +252,7 @@ GEM
     pry-rescue (1.4.0)
       interception (>= 0.4)
       pry
+    psych (2.0.5)
     rack (1.5.2)
     rack-livereload (0.3.15)
       rack
@@ -407,6 +408,7 @@ DEPENDENCIES
   mysql2
   nokogiri
   nunes
+  psych (>= 2.0.5)
   rails (= 4.1.0)
   rouge
   rspec_junit_formatter


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2014/03/29/heap-overflow-in-yaml-uri-escape-parsing-cve-2014-2525/
