### PR TITLE
Rename yield :scripts to :javascripts

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -157,7 +157,7 @@
 
   <%# START RequireJS load of application %>
   <%= javascript_include_tag 'requirejs/require', data: { main: javascript_path('application') } %>
-  <%= yield :scripts %>
+  <%= yield :javascripts %>
   <%# END RequireJS load of application %>
 
   <%# START WebEngage script for displaying user surveys %>

--- a/app/views/layouts/styleguide.html.erb
+++ b/app/views/layouts/styleguide.html.erb
@@ -8,7 +8,7 @@
   <%= yield :main %>
 <% end %>
 
-<% content_for :scripts do %>
+<% content_for :javascripts do %>
   <%= javascript_include_tag :styleguide %>
 <% end %>
 


### PR DESCRIPTION
In preparation for integrating engines, changed the name of the yield as discussed with @andrewgarner 
