### PR TITLE
Make the error thrown by JsHint more informative

### DIFF
--- a/lib/asset_pipeline/processors/js_hint.rb
+++ b/lib/asset_pipeline/processors/js_hint.rb
@@ -1,13 +1,15 @@
+require_relative 'js_hint/errors_found'
+
 module AssetPipeline
   module Processors
     class JsHint < Sprockets::Processor
-      class ErrorsFound < StandardError; end
 
       REGEX = /#{Regexp.quote(Rails.root.to_s)}\/app\/assets\/.*.js(:?.erb)?\z/
 
       def evaluate(context, locals)
         if context.pathname.to_s =~ REGEX
-          raise ErrorsFound if JshintRuby.run(data, jshint_options).errors.present?
+          errors = JshintRuby.run(data, jshint_options).errors
+          raise ErrorsFound.new(errors) if errors.present?
         end
         data
       end

--- a/lib/asset_pipeline/processors/js_hint/errors_found.rb
+++ b/lib/asset_pipeline/processors/js_hint/errors_found.rb
@@ -1,0 +1,30 @@
+module AssetPipeline
+  module Processors
+    class JsHint < Sprockets::Processor
+      class ErrorsFound < StandardError
+
+        attr_accessor :errors
+
+        def initialize(errors)
+          @errors = errors.compact
+        end
+
+        def to_s
+          "#{error_count} #{'error'.pluralize(error_count)} found on " +
+          "#{line_count} #{'line'.pluralize(line_count)}. " +
+          "Run 'rake jshint' for a complete report."
+        end
+
+        private
+
+        def error_count
+          errors.length
+        end
+
+        def line_count
+          errors.collect { |e| e['line'] }.uniq.length
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Includes the number of errors and number of lines and refers to the rake task that you need to run to get the full details.
