### PR TITLE
Use moneyadvice/csslint_ruby gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ group :assets do
   gem 'autoprefixer-rails'
   gem 'coffee-rails', '~> 4.0.0'
   gem 'jshint_ruby'
-  gem 'csslint_ruby', '~> 0.0.1'
+  gem 'csslint_ruby', github: 'moneyadviceservice/csslint_ruby'
   gem 'compass-rails'
   gem 'jquery-rails'
   gem 'sass-rails', '~> 4.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: git://github.com/moneyadviceservice/csslint_ruby.git
+  revision: 0d7c9b22f4a679268ade55919079fcdd822d4440
+  specs:
+    csslint_ruby (0.0.1)
+      execjs
+
+GIT
   remote: git://github.com/moneyadviceservice/meta-tags.git
   revision: 93558e60c65ea3a1542d5a7523fda729db3344bc
   branch: alternate-url
@@ -68,7 +75,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.3.6)
     arel (5.0.0)
-    autoprefixer-rails (1.1.20140403)
+    autoprefixer-rails (1.1.20140410)
       execjs
     builder (3.2.2)
     byebug (2.7.0)
@@ -114,8 +121,6 @@ GEM
       sprockets (<= 2.11.0)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
-    csslint_ruby (0.0.1)
-      execjs
     cucumber (1.3.14)
       builder (>= 2.1.2)
       diff-lcs (>= 1.1.3)
@@ -383,7 +388,7 @@ DEPENDENCIES
   codeclimate-test-reporter
   coffee-rails (~> 4.0.0)
   compass-rails
-  csslint_ruby (~> 0.0.1)
+  csslint_ruby!
   dotenv-rails
   draper (~> 1.3.0)
   ejs

--- a/app/assets/stylesheets/components/_survey.scss
+++ b/app/assets/stylesheets/components/_survey.scss
@@ -3,13 +3,13 @@
   Override of 3rd party CSS to improve styling of collapse / close buttons on survey
 */
 
-/* @codingStandardsIgnoreStart */
+/* @lintingIgnoreBegin */
 #webklipper-publisher-widget-container-survey-minimize-div,
 #webklipper-publisher-widget-container-survey-close-div {
   background-color: #fff !important;
   border-radius: 4px;
 }
-/* @codingStandardsIgnoreEnd */
+/* @lintingIgnoreEnd */
 
 /*
 

--- a/app/assets/stylesheets/styleguide/_sg_example.scss
+++ b/app/assets/stylesheets/styleguide/_sg_example.scss
@@ -106,7 +106,7 @@
   min-height: 70px;
 }
 
-/* @codingStandardsIgnoreStart */
+/* @lintingIgnoreBegin */
 
 // high contrast background for icons
 #section-icons .styleguide-element {
@@ -208,4 +208,4 @@
 
   }
 }
-/* @codingStandardsIgnoreEnd */
+/* @lintingIgnoreEnd */

--- a/lib/asset_pipeline/processors/css_lint.rb
+++ b/lib/asset_pipeline/processors/css_lint.rb
@@ -8,7 +8,7 @@ module AssetPipeline
 
       def evaluate(context, locals)
         if context.pathname.to_s =~ REGEX
-          lint_results = CsslintRuby.run(remove_ignored_code(data), settings)
+          lint_results = CsslintRuby.run(data, settings)
           raise CssLintError.new(format_errors(lint_results)) if lint_results.errors.present?
         end
         data
@@ -19,10 +19,6 @@ module AssetPipeline
       def format_errors(lint_results)
         error = lint_results.errors.first
         "error: #{error['message']}\n For more info run: rake csslint"
-      end
-
-      def remove_ignored_code(data)
-        data.gsub(/\/\* #{IGNORED_TAG}Start \*\/.+?\/\* #{IGNORED_TAG}End \*\//m, '')
       end
 
       def settings

--- a/lib/tasks/csslint.rake
+++ b/lib/tasks/csslint.rake
@@ -9,7 +9,7 @@ task :csslint => :environment do
   Rails.application.assets.each_file do |pathname|
     if pathname.basename.to_s =~ /\A[^_][a-zA-Z0-9_.]+.scss\z/
       css = Rails.application.assets[pathname]
-      results = CsslintRuby.run(comment_ignore_code(css.to_s), lint_options)
+      results = CsslintRuby.run(css.to_s, lint_options)
 
       puts pathname
 
@@ -26,14 +26,4 @@ task :csslint => :environment do
       end
     end
   end
-end
-
-def comment_ignore_code(data)
-  commented_code = data.sub('IgnoreStart */', 'IgnoreStart')
-  commented_code.sub('/* @codingStandardsIgnoreEnd', '@codingStandardsIgnoreEnd')
-  remove_sass_comments(commented_code)
-end
-
-def remove_sass_comments(data)
-  data.each_line.reject {|line| line =~/line \d+/ }.join
 end

--- a/spec/lib/asset_pipeline/processors/css_lint_spec.rb
+++ b/spec/lib/asset_pipeline/processors/css_lint_spec.rb
@@ -48,9 +48,9 @@ module AssetPipeline
         context 'when css contains ignore annotations' do
           let(:css) do
             "body {
-               /* @codingStandardsIgnoreStart */
+               /* @lintingIgnoreBegin */
               display: unkown-property;
-              /* @codingStandardsIgnoreEnd */
+              /* @lintingIgnoreEnd */
               color: red;
             }"
           end


### PR DESCRIPTION
The code related with removing ignored code has been moved to the moneyadvice/csslint_ruby gem. I've also done a pull request with this changes to the original csslint_ruby repository.
