### PR TITLE
Duplicate news and tools links

### DIFF
--- a/app/views/shared/_footer_site_links.html.erb
+++ b/app/views/shared/_footer_site_links.html.erb
@@ -2,6 +2,12 @@
   <div class="l-constrained l-padded">
     <ul class="footer-site-links__internal-links unstyled-list">
       <li>
+        <a href="<%= t('footer.tools_and_resources_link') %>"><%= t('footer.tools_and_resources') %></a>
+      </li>
+      <li>
+        <a href="<%= t('footer.news_link') %>"><%= t('footer.news') %></a>
+      </li>
+      <li>
         <a href="<%= t('footer.our_debt_work_link') %>"><%= t('footer.our_debt_work') %></a>
       </li>
       <li>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -126,6 +126,10 @@ cy:
     media_centre_link: /cy/static/canolfan-gyfryngau
     partners: Partneriaid
     partners_link: /cy/categories/Partners
+    news: Newyddion ac erthyglau
+    news_link: /cy/news
+    tools_and_resources: Offer ac adnoddau
+    tools_and_resources_link: /cy/categories/tools--resources
     site_map: Map safle
     site_map_link: /cy/static/canolfan-gyfryngau
     our_debt_work: Ein gwaith dyledion

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -127,6 +127,10 @@ en:
     media_centre_link: /en/static/media-centre
     partners: Partners
     partners_link: /en/categories/partners
+    news: News & features
+    news_link: /en/news
+    tools_and_resources: Tools & resources
+    tools_and_resources_link: /en/categories/tools--resources
     site_map: Site map
     site_map_link: /en/sitemap
     our_debt_work: Our debt work


### PR DESCRIPTION
This add the  'Tools and Resources' and 'News and Features' links to the footer in preparation of removing them from the primary navigation.

@andrewgarner @amansinghb 
