### PR TITLE
CategoryNavigationReader only needs to be a PORO

### DIFF
--- a/lib/core/interactors/category_navigation_reader.rb
+++ b/lib/core/interactors/category_navigation_reader.rb
@@ -2,7 +2,7 @@ require 'core/entities/category'
 require 'core/registries/repository'
 
 module Core
-  class CategoryNavigationReader < Array
+  class CategoryNavigationReader
     def call(&block)
       categories = Registries::Repository[:category].all
 
@@ -11,7 +11,7 @@ module Core
         return
       end
 
-      replace(build_list(categories))
+      build_list(categories)
     end
 
     private


### PR DESCRIPTION
Currently `CategoryNavigationReader` subclasses array and `call` then replaces it's contents with the built categories, though we never refer back to our instance of the reader, instead capturing the returned array.
