### PR TITLE
Remove type from SearchResult

### DIFF
--- a/app/decorators/search_result_decorator.rb
+++ b/app/decorators/search_result_decorator.rb
@@ -6,18 +6,7 @@ class SearchResultDecorator < Draper::Decorator
   end
 
   def path
-    return object.link if defined?(object.link)
-
-    case object.type
-      when 'article', 'guide'
-        h.article_path(object.id, locale: I18n.locale)
-      when 'action-plan'
-        h.action_plan_path(object.id, locale: I18n.locale)
-      when 'category'
-        h.category_path(object.id, locale: I18n.locale)
-      when 'campaign', 'news', 'tool', 'video'
-        "/#{I18n.locale}/#{object.type.pluralize}/#{object.id}"
-    end
+    object.link
   end
 
   def title

--- a/lib/core/entities/search_result.rb
+++ b/lib/core/entities/search_result.rb
@@ -2,8 +2,8 @@ require 'core/entities/entity'
 
 module Core
   class SearchResult < Entity
-    attr_accessor :title, :description, :type, :link, :snippet
+    attr_accessor :title, :description, :link, :snippet
 
-    validates_presence_of :title, :description, :type
+    validates_presence_of :title, :description
   end
 end

--- a/lib/core/repositories/search/google_custom_search_engine/response_item_mapper.rb
+++ b/lib/core/repositories/search/google_custom_search_engine/response_item_mapper.rb
@@ -23,10 +23,6 @@ module Core::Repositories
           metatags.map { |m| m['og:description'] }.compact.first || ''
         end
 
-        def type
-          link_tokens[SECOND_TO_LAST_INDEX].singularize
-        end
-
         def link
           data['link']
         end
@@ -38,7 +34,6 @@ module Core::Repositories
         def mapped_item_response
           {
             id:          id,
-            type:        type,
             description: description,
             title:       title,
             link:        link,

--- a/spec/decorators/search_result_decorator_spec.rb
+++ b/spec/decorators/search_result_decorator_spec.rb
@@ -50,79 +50,12 @@ describe SearchResultDecorator do
   end
 
   describe '#path' do
-    let(:locale) { 'en' }
-    before { allow(I18n).to receive(:locale) { locale } }
+    let(:link) { 'link' }
 
-    %w{article guide}.each do |type|
-      context "and it is of type '#{type}'" do
-        before { allow(search_result).to receive(:type) { type } }
+    before { allow(search_result).to receive(:link) { link } }
 
-        it 'calls the article path helper' do
-          expect(helpers).to receive(:article_path).with(search_result.id, locale: locale)
-          subject.path
-        end
-      end
-
-      context 'when search result contains link' do
-        let(:link) { 'link' }
-        before { allow(search_result).to receive(:link) { link } }
-
-        it 'retuns the link' do
-          expect(subject.path).to be(link)
-        end
-      end
-    end
-
-    context "and it is of type 'action-plan'" do
-      before { allow(search_result).to receive(:type) { 'action-plan' } }
-
-      it 'calls the action_plan path helper' do
-        expect(helpers).to receive(:action_plan_path).with(search_result.id, locale: locale)
-        subject.path
-      end
-    end
-
-    context "and it is of type 'category'" do
-      before { allow(search_result).to receive(:type) { 'category' } }
-
-      it 'calls the category path helper' do
-        expect(helpers).to receive(:category_path).with(search_result.id, locale: locale)
-        subject.path
-      end
-    end
-
-    context "and is of the not yet supported type" do
-      context "'campaign'" do
-        before { allow(search_result).to receive(:type) { 'campaign' } }
-
-        it 'returns the expected path' do
-          expect(subject.path).to eq "/#{locale}/campaigns/#{search_result.id}"
-        end
-      end
-
-      context "'news'" do
-        before { allow(search_result).to receive(:type) { 'news' } }
-
-        it 'returns the expected path' do
-          expect(subject.path).to eq "/#{locale}/news/#{search_result.id}"
-        end
-      end
-
-      context "'tool'" do
-        before { allow(search_result).to receive(:type) { 'tool' } }
-
-        it 'returns the expected path' do
-          expect(subject.path).to eq "/#{locale}/tools/#{search_result.id}"
-        end
-      end
-
-      context "'video'" do
-        before { allow(search_result).to receive(:type) { 'video' } }
-
-        it 'returns the expected path' do
-          expect(subject.path).to eq "/#{locale}/videos/#{search_result.id}"
-        end
-      end
+    it 'retuns the link' do
+      expect(subject.path).to be(link)
     end
   end
 end

--- a/spec/lib/core/entities/search_result_spec.rb
+++ b/spec/lib/core/entities/search_result_spec.rb
@@ -5,9 +5,7 @@ module Core
   describe SearchResult do
     subject { described_class.new(double, attributes) }
 
-    let(:attributes) { { title:       double,
-                         description: double,
-                         type:        double } }
+    let(:attributes) { { title: double, description: double } }
 
     it { should respond_to :title }
     it { should respond_to :title= }
@@ -15,11 +13,7 @@ module Core
     it { should respond_to :description }
     it { should respond_to :description= }
 
-    it { should respond_to :type }
-    it { should respond_to :type= }
-
     it { should validate_presence_of(:title) }
     it { should validate_presence_of(:description) }
-    it { should validate_presence_of(:type) }
   end
 end

--- a/spec/lib/core/repositories/search/google_custom_search_engine/response_item_mapper_spec.rb
+++ b/spec/lib/core/repositories/search/google_custom_search_engine/response_item_mapper_spec.rb
@@ -41,10 +41,6 @@ module Core::Repositories::Search
         expect(subject[:description]).to eq(description)
       end
 
-      it 'maps the type correctly' do
-        expect(subject[:type]).to eq(type)
-      end
-
       it 'maps the link correctly' do
         expect(subject[:link]).to eq(link)
       end


### PR DESCRIPTION
Since google search is providing the full path we don't need the type attribute to build the link url any more
