### PR TITLE
Change the title on the empty search results page to “No results were found”

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -165,7 +165,7 @@ cy:
       page_title: Chwiliwch drwy'r Gwasanaeth Cynghori Ariannol
 
     index_no_results:
-      document_title: "%{query} - Chwilio"
+      document_title: Ni chafwyd unrhyw ganlyniadau chwilio
       page_title: Canlyniadau chwilio ar gyfer "%{query}"
       body: Ni chanfuwyd unrhyw ganlyniadau. Chwiliwch am rywbeth gwahanol.
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -166,7 +166,7 @@ en:
       page_title: Search the Money Advice Service
 
     index_no_results:
-      document_title: "%{query} - Search"
+      document_title: No search results found
       page_title: Search results for “%{query}”
       body: No results were found. Please try a different search.
 


### PR DESCRIPTION
The "no results" page uses it's own template and already has it's own entry in the translation files, so this is a quick change.
