### PR TITLE
Blacklist the partner page and all linked pages

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,25 @@
 class ValidArticle
   BLACKLIST = %w(about-our-debt-work am-ein-gwaith-dyled
-                 debt-publications cyhoeddiadau-ar-ddyledion)
+                 debt-publications cyhoeddiadau-ar-ddyledion
+                 partners-overview-parhub
+                 partner-reg-parhub
+                 syndicating-tools-parhub
+                 video-syndication-parhub
+                 toolkits-parhub pecynnau-cymorth-cyngor-ariannol
+                 linking-parhub
+                 examples-parhub
+                 licence-agreement-parhub)
+
+  def matches?(request)
+    BLACKLIST.exclude?(request.parameters['id'])
+  end
+end
+
+class ValidCategory
+  BLACKLIST = %w(partners
+                 partners-uc-banks
+                 partners-uc-landlords
+                 resources-for-professionals-working-with-young-people-and-parents)
 
   def matches?(request)
     BLACKLIST.exclude?(request.parameters['id'])
@@ -17,7 +36,8 @@ Rails.application.routes.draw do
     resources :articles,
               only: 'show',
               constraints: ValidArticle.new
-    resources :categories, only: 'show'
+    resources :categories, only: 'show',
+              constraints: ValidCategory.new
     resources :search_results, only: 'index', path: 'search'
 
     resource :cookie_notice_acceptance, only: :create, path: 'cookie-notice'

--- a/spec/requests/black_listed_resources_spec.rb
+++ b/spec/requests/black_listed_resources_spec.rb
@@ -1,9 +1,30 @@
 RSpec.describe 'Request blacklisted resource', :type => :request do
   %W(about-our-debt-work am-ein-gwaith-dyled
-     debt-publications cyhoeddiadau-ar-ddyledion).each do |article|
+     debt-publications cyhoeddiadau-ar-ddyledion
+     partners-overview-parhub
+     partner-reg-parhub
+     syndicating-tools-parhub
+     video-syndication-parhub
+     toolkits-parhub pecynnau-cymorth-cyngor-ariannol
+     linking-parhub
+     examples-parhub
+     licence-agreement-parhub).each do |article|
     context "request article #{article}" do
       it 'returns a 501 response' do
         get("/en/articles/#{article}")
+
+        expect(response.status).to eq(501)
+      end
+    end
+  end
+
+  %W(partners
+     partners-uc-banks
+     partners-uc-landlords
+     resources-for-professionals-working-with-young-people-and-parents).each do |category|
+    context "request category #{category}" do
+      it 'returns a 501 response' do
+        get("/en/categories/#{category}")
 
         expect(response.status).to eq(501)
       end


### PR DESCRIPTION
We noticed the other day that these were available on responsive when they shouldn't be.

Summary of changes
- The partners page is a category.
- All the linked items are articles but three of them appear to have been retired and have redirects to category pages.  In those cases, the destination categories have been blacklisted but not the articles themselves.
- Only one of the articles appears to have a welsh version.
- All the categories do have welsh versions but the IDs aren't localised so don't need to targeted specifically for blacklisting.
