### PR TITLE
Return empty array when BreadcrumbReader doesn't find the node

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -11,7 +11,7 @@ class ArticlesController < ApplicationController
     end
 
     @breadcrumb_trails = @article.categories.map do |category|
-      Core::BreadcrumbsReader.new(category.id, category_tree).call << category
+      Core::BreadcrumbsReader.new(category.id, category_tree).call { [] } << category
     end
 
     render Feature.active?(:left_hand_nav) ? :show_v2 : :show


### PR DESCRIPTION
This is a quick fix. We have a technical deb task to refactor BreadcrumbReader class
