### PR TITLE
Restore Konacha for JavaScript unit tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,11 +67,12 @@ group :production do
 end
 
 group :test, :development do
-  gem 'ejs'
-  gem 'dotenv-rails'
-  gem 'mas-development_dependencies', github: 'moneyadviceservice/mas-development_dependencies'
-  gem 'chai-jquery-rails'
   gem 'byebug'
+  gem 'chai-jquery-rails'
+  gem 'dotenv-rails'
+  gem 'ejs'
+  gem 'konacha'
+  gem 'mas-development_dependencies', github: 'moneyadviceservice/mas-development_dependencies'
   gem 'rspec-rails', '~> 3.0'
   gem 'sqlite3' # the database is not used yet, so sqlite is sufficient
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.7.0)
+    colorize (0.7.3)
     columnize (0.3.6)
     compass (0.12.5)
       chunky_png (~> 1.2)
@@ -195,6 +196,12 @@ GEM
       execjs
     json (1.8.1)
     kgio (2.9.2)
+    konacha (3.2.3)
+      actionpack (>= 3.1, < 5)
+      capybara
+      colorize
+      railties (>= 3.1, < 5)
+      sprockets
     kss (0.5.0)
     launchy (2.4.2)
       addressable (~> 2.3)
@@ -393,6 +400,7 @@ DEPENDENCIES
   html_validation
   jquery-rails
   jshint_ruby
+  konacha
   kss
   link_header
   listen (~> 2.0)

--- a/config/initializers/konacha.rb
+++ b/config/initializers/konacha.rb
@@ -1,0 +1,4 @@
+Konacha.configure do |config|
+  require 'capybara/poltergeist'
+  config.driver = :poltergeist
+end if defined?(Konacha)

--- a/lib/tasks/konacha.rake
+++ b/lib/tasks/konacha.rake
@@ -1,0 +1,8 @@
+namespace 'spec' do
+  desc 'Run the code examples in spec/javascript'
+  task :javascript => :environment do
+    exit 1 unless ::Konacha.run
+  end
+end
+
+task(:spec).enhance ['spec:javascript']


### PR DESCRIPTION
We lost Konacha when we upgraded MAS Development Dependencies for RSpec 3 support. Re-instating, and adding a story to our backlog to update our tests to run under the now standardised Karma.

cc/ @aduggin @stevenwilkin 
