### PR TITLE
Restrict background image height at 400-480px width

### DIFF
--- a/app/assets/stylesheets/components/page_specific/_trust_banner.scss
+++ b/app/assets/stylesheets/components/page_specific/_trust_banner.scss
@@ -5,10 +5,15 @@
 .trust-banner {
   position: relative;
   height: 240px;
-  background: image_url('illustrated_people.png') 100% 100% no-repeat;
+  background: image_url('illustrated_people.png') 50% 100% no-repeat;
   background-size: 100%;
 
+  @include respond-to(25.25em) {
+    background-size: auto 157px;
+  }
+
   @include respond-to($mq-s) {
+    background-position: 100% 100%;
     background-size: 40%;
     height: auto;
   }


### PR DESCRIPTION
I have added in a MQ to constrain the height of the trust banner background image so it does not overlap the header text.

@aduggin @amansinghb 
