### PR TITLE
Show breadcrumbs on static pages

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -7,5 +7,7 @@ class StaticPagesController < ApplicationController
     @static_page = Core::StaticPageReader.new(params[:id]).call do
       not_found
     end
+
+    @breadcrumbs = [Breadcrumb.new(nil)]
   end
 end

--- a/app/views/static_pages/show.html.erb
+++ b/app/views/static_pages/show.html.erb
@@ -2,6 +2,10 @@
                  canonical:   static_page.canonical_url,
                  alternate:   static_page.alternate_options) %>
 
+<% content_for(:context_bar) do %>
+  <%= render 'shared/breadcrumbs', breadcrumbs: @breadcrumbs %>
+<% end %>
+
 <div class="l-main editorial">
   <main role="main">
     <h1><%= title static_page.title %></h1>

--- a/features/breadcrumbs.feature
+++ b/features/breadcrumbs.feature
@@ -11,6 +11,10 @@ Feature: Article breadcrumbs
     When I read an action plan belonging to a single category
     Then I can see breadcrumbs for the action plan
 
+  Scenario: Breadcrumb on a static page
+    When I read a static page
+    Then I can see breadcrumbs for the static page
+
  Scenario: Breadcrumb on an category page
     When I read a category
     Then I can see breadcrumbs for the category

--- a/features/step_definitions/breadcrumbs_steps.rb
+++ b/features/step_definitions/breadcrumbs_steps.rb
@@ -10,6 +10,10 @@ Given(/^I read an action plan belonging to multiple categories$/) do
   browse_to_action_plan action_plan_in_multiple_categories
 end
 
+Given(/^I read a static page$/) do
+  static_page.load(locale: 'en', id: 'privacy')
+end
+
 Given(/^I read a category$/) do
   browse_to_category(category, 'en')
 end
@@ -28,6 +32,10 @@ end
 
 Then(/^I can see breadcrumbs for the action plan$/) do
   expect(action_plan_page.breadcrumbs.text).to eq(current_action_plan.context)
+end
+
+Then(/^I can see breadcrumbs for the static page$/) do
+  expect(static_page.breadcrumbs.text).to eq('Home')
 end
 
 Then(/^I can see breadcrumbs for the category$/) do

--- a/features/support/ui/pages/static.rb
+++ b/features/support/ui/pages/static.rb
@@ -6,5 +6,6 @@ module UI::Pages
 
     element :intro, 'p.intro'
     element :content, '.l-main'
+    element :breadcrumbs, '.l-context-bar'
   end
 end


### PR DESCRIPTION
Seeing as the static pages don't belong within categories I'm assuming that the only valid breadcrumb to show  is that for the home page

@andrewgarner @pvcarrera @jongilbraith 
