### PR TITLE
[WIP][DISCUSSION] Form required fields

### DIFF
--- a/app/views/styleguide/forms.html.erb
+++ b/app/views/styleguide/forms.html.erb
@@ -1,19 +1,14 @@
 <h1>Forms</h1>
 
-
 <h2>Fieldsets, Legends, and Form Elements</h2>
 
-<p>Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Nullam dignissim
-  convallis est. Quisque aliquam. Donec faucibus. Nunc iaculis suscipit dui. Nam
-  sit amet sem. Aliquam libero nisi, imperdiet at, tincidunt nec, gravida
-  vehicula, nisl. Praesent mattis, massa quis luctus fermentum, turpis mi
-  volutpat justo, eu volutpat enim diam eget metus.</p>
+<p>* Indicates required fields</p>
 
 <form class="form" novalidate>
 
   <div class="form__row">
-    <label for="text_field" class="form__label-heading">Text Field</label>
-    <input type="text" id="text_field">
+    <label for="text_field" class="form__label-heading">Text Field * <span class="visually-hidden">required</span></label>
+    <input type="text" id="text_field" aria-required="true">
   </div>
 
   <div class="form__row">


### PR DESCRIPTION
@moneyadviceservice/frontend 

I've added in a required field indicator to the form examples. With my implementation, NVDA and JAWS announce the required field twice.

Our options:
1. CURRENT _visually-hidden_ and _aria-required_. Supported by legacy/current/future ATs by utilising visually hidden text and the official aria attribute. "required" announced twice.
2. _visually-hidden_. Supported by legacy/current/future ATs by using visually hidden text. "required" announced once.
3. _aria-required_. Supported only by current/future ATs with ARIA support. "required" announced once.
