### PR TITLE
Add method to generate a "Home" breadcrumb trail

### DIFF
--- a/app/domain/breadcrumb_trail.rb
+++ b/app/domain/breadcrumb_trail.rb
@@ -21,4 +21,8 @@ class BreadcrumbTrail
 
     categories.map(&Breadcrumb.public_method(:new))
   end
+
+  def self.home
+    [Breadcrumb.new(HomeCategory.new)]
+  end
 end

--- a/spec/domain/breadcrumb_trail_spec.rb
+++ b/spec/domain/breadcrumb_trail_spec.rb
@@ -60,3 +60,10 @@ RSpec.describe BreadcrumbTrail, '.build' do
     specify { expect(subject.map(&:title)).to eq([HomeCategory.new.title]) }
   end
 end
+
+
+RSpec.describe BreadcrumbTrail, '.home' do
+  subject { described_class.home }
+
+  specify { expect(subject.map(&:title)).to eq([HomeCategory.new.title]) }
+end


### PR DESCRIPTION
This is one for @pvcarrera's News Index page and @jongilbraith's Contact page

Put this in your controller action:

``` ruby
@breadcrumbs = BreadcrumbTrail.home
```
