### PR TITLE
Rename pagination parameter 'page' to 'page_number'

### DIFF
--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -3,7 +3,7 @@ class NewsController < ApplicationController
   decorates_assigned :news, with: NewsDecorator
 
   def index
-    @news = Core::NewsReader.new(params[:page]).call do
+    @news = Core::NewsReader.new(params[:page_number]).call do
       not_found
     end
 

--- a/app/views/news/_pagination.html.erb
+++ b/app/views/news/_pagination.html.erb
@@ -1,12 +1,12 @@
 <div class="pagination">
   <% if news.prev_page? %>
-    <%= link_to news_path(page: news.prev_page), class: 'button button--compact t-button--previous' do %>
+    <%= link_to news_path(page_number: news.prev_page), class: 'button button--compact t-button--previous' do %>
       <span class="icon icon--left-chevron"></span>
       <span class="button--compact__text"><%= t('news.index.newer')%></span>
     <% end %>
   <% end %>
   <% if news.next_page? %>
-     <%= link_to news_path(page: news.next_page), class: 'button button--compact t-button--next' do %>
+     <%= link_to news_path(page_number: news.next_page), class: 'button button--compact t-button--next' do %>
       <span class="button--compact__text"><%= t('news.index.older')%></span>
       <span class="icon icon--right-chevron"></span>
     <% end %>

--- a/features/step_definitions/news_index_steps.rb
+++ b/features/step_definitions/news_index_steps.rb
@@ -8,7 +8,7 @@ When(/^I visit the news page$/) do
 end
 
 When(/^I visit the last news page$/) do
-  news_page.load(locale: 'en', page: '30')
+  news_page.load(locale: 'en', page_number: '30')
 end
 
 Then(/^I should( not)? see the 'Older' button$/) do |negate|

--- a/features/support/ui/pages/news.rb
+++ b/features/support/ui/pages/news.rb
@@ -2,7 +2,7 @@ require_relative '../page'
 
 module UI::Pages
   class News < UI::Page
-    set_url '{/locale}/news{?page}'
+    set_url '{/locale}/news{?page_number}'
 
     elements :items_titles, '.heading-small'
     elements :items_intros, '.t-news-intro'


### PR DESCRIPTION
Rename 'page' to 'page_number' to keep consistence with public website urls
