### PR TITLE
Update newsletter subscription heading to H2

### DIFF
--- a/app/views/newsletter_subscriptions/_form.html.erb
+++ b/app/views/newsletter_subscriptions/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_tag(newsletter_subscription_path, class: 'newsletter', remote: true) do %>
   <%= hidden_field_tag :authenticity_token, form_authenticity_token -%>
-  <h3 class="newsletter__heading"><%= t('newsletter_subscriptions.heading') %></h3>
+  <h2 class="newsletter__heading"><%= t('newsletter_subscriptions.heading') %></h2>
   <ul class="list-benefits list-benefits--s">
     <% t('newsletter_subscriptions.benefits').each do |benefit| %>
       <li><%= benefit %></li>


### PR DESCRIPTION
Newsletter subscription heading was an H3. Changed to H2 to fix heading hierarchy

No CSS changes required as using BEM.

@alexwllms @ourmaninamsterdam 
