### PR TITLE
Filter flash to only display info, success and error messages.

### DIFF
--- a/app/views/shared/_alerts.html.erb
+++ b/app/views/shared/_alerts.html.erb
@@ -1,4 +1,4 @@
-<% flash.each do |name, msg| %>
+<% flash.to_hash.slice('info', 'success', 'error').each do |name, msg| %>
   <div class="global-alert global-alert--<%= name %>">
     <div class="global-alert__content-container">
       <strong class="global-alert__heading"><%= name.titleize %></strong>


### PR DESCRIPTION
Avoid displaying [flash commands](https://github.com/moneyadviceservice/public_website/blob/master/app/controllers/commands/command_helper.rb) set by the public website.

![screen shot 2014-07-16 at 15 11 25](https://cloud.githubusercontent.com/assets/966819/3601852/67ee4328-0d05-11e4-9612-5327f26fb68b.png)

@amansinghb good catch!
