### PR TITLE
Store flash messages in a different session variable

### DIFF
--- a/config/initializers/session_ext.rb
+++ b/config/initializers/session_ext.rb
@@ -1,0 +1,26 @@
+module ActionDispatch
+  class Request
+    class Session
+      alias_method :original_accessor, :[]
+      alias_method :original_mutator, :[]=
+
+      def [](key)
+        original_accessor(alternate_key_for_flash(key))
+      end
+
+      def []=(key, value)
+        original_mutator(alternate_key_for_flash(key), value)
+      end
+
+      private
+
+      def alternate_key_for_flash(key)
+        if key == 'flash'
+          'flash_responsive'
+        else
+          key
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This should solve the problem we've seen in QA when testing the new login/logout feature.

From my analysis this is due to the difference in how Rails 3 and Rails 4 store flash messages in the session. Rails 4 can deal with the format used by Rails 3 but not the other way around, hence the whitescreens/500s we were seeing intermittently.

This is a monkey patch and has no testing but seems to do the trick. Any feedback would be more than welcome.
