### PR TITLE
Add rel attributes to news pagination

### DIFF
--- a/app/views/news/_pagination.html.erb
+++ b/app/views/news/_pagination.html.erb
@@ -1,13 +1,15 @@
 <div class="pagination">
   <% if news.prev_page? %>
-    <%= link_to news_path(page_number: news.prev_page), class: 'button button--compact t-button--previous' do %>
+    <%= link_to news_path(page_number: news.prev_page),
+                rel: 'prev', class: 'button button--compact t-button--previous' do %>
       <span class="icon icon--left-chevron"></span>
-      <span class="button--compact__text"><%= t('news.index.newer')%></span>
+      <span class="button--compact__text"><%= t('news.index.newer') %></span>
     <% end %>
   <% end %>
   <% if news.next_page? %>
-     <%= link_to news_path(page_number: news.next_page), class: 'button button--compact t-button--next' do %>
-      <span class="button--compact__text"><%= t('news.index.older')%></span>
+    <%= link_to news_path(page_number: news.next_page),
+                rel: 'next', class: 'button button--compact t-button--next' do %>
+      <span class="button--compact__text"><%= t('news.index.older') %></span>
       <span class="icon icon--right-chevron"></span>
     <% end %>
   <% end %>


### PR DESCRIPTION
Adds `rel="next"` and `rel="prev"` attributes to the pagination anchor tags.

See story https://moneyadviceservice.tpondemand.com/entity/2656
