### PR TITLE
Don’t explicitly minify embedded modernizr

### DIFF
--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -49,7 +49,7 @@
   <script type="text/javascript">
 
     <%# // Inline custom Modernizr %>
-    <%= raw Uglifier.compile(Rails.application.assets['frontend-assets/vendor/assets/modernizr/modernizr.js']) %>
+    <%= raw Rails.application.assets['frontend-assets/vendor/assets/modernizr/modernizr.js'] %>
 
     <%# // Required for Google Tag Manager %>
     var dataLayer = [


### PR DESCRIPTION
In production, it will be minified already.
