### PR TITLE
Add title attribute to video iframes

### DIFF
--- a/lib/html_processor/video_wrapper.rb
+++ b/lib/html_processor/video_wrapper.rb
@@ -5,9 +5,12 @@ module HTMLProcessor
     def process(*xpaths)
       doc.xpath(*xpaths).each do |node|
         node.parent.name == 'p' ? swap_node(node.parent) : swap_node(node)
+        node.set_attribute('title', 'Video') unless node.attribute('title')
       end
       super
     end
+
+    private
 
     def swap_node(node)
       node.replace(HTMLProcessor::VIDEO_TAG_WRAPPER).first << node

--- a/spec/decorators/content_item_decorator_spec.rb
+++ b/spec/decorators/content_item_decorator_spec.rb
@@ -86,6 +86,10 @@ RSpec.describe ContentItemDecorator do
 
         expect(nodes).to_not be_empty
       end
+
+      it 'adds title to the iframe' do
+        expect(html.search('//iframe[starts-with(@title, "Video")]')).to_not be_empty
+      end
     end
 
     context 'when the object contains a table' do

--- a/spec/lib/html_processors/video_wrapper_spec.rb
+++ b/spec/lib/html_processors/video_wrapper_spec.rb
@@ -4,14 +4,14 @@ require 'html_processor/video_wrapper'
 RSpec.describe HTMLProcessor::VideoWrapper do
   subject(:processor) { described_class.new(html) }
 
-  let(:html) {
+  let(:html) do
     <<-EOHTML
-<p>
-  <iframe frameborder="0" height="413" width="680" src="https://www.youtube.com/embed/3ciEDiokPkw">
-  </iframe>
-</p>
+      <p>
+        <iframe frameborder="0" height="413" width="680" src="https://www.youtube.com/embed/3ciEDiokPkw">
+        </iframe>
+      </p>
     EOHTML
-  }
+  end
 
   describe '.process' do
     subject(:processed_html) { processor.process(HTMLProcessor::VIDEO_IFRAME) }
@@ -19,9 +19,31 @@ RSpec.describe HTMLProcessor::VideoWrapper do
     let(:xpath) do
       '//div[@class="video-wrapper"]/*/iframe[starts-with(@src, "https://www.youtube.com/embed")]'
     end
+    let(:node) { Nokogiri::HTML(processed_html).xpath(xpath) }
 
     it 'wraps the given elements' do
-      expect(Nokogiri::HTML(processed_html).xpath(xpath).size).to eq(1)
+      expect(node.size).to eq(1)
+    end
+
+    context 'when title is not include' do
+      it 'adds the attribute title' do
+        expect(node).to_not be_nil
+      end
+    end
+
+    context 'when title is already included' do
+      let(:html) do
+        <<-EOHTML
+         <p>
+          <iframe title="Video: test video" frameborder="0" height="413" width="680" src="https://www.youtube.com/embed/3ciEDiokPkw">
+          </iframe>
+        </p>
+        EOHTML
+      end
+
+      it 'does not modify title attribute' do
+        expect(node.attribute('title').value).to eq('Video: test video')
+      end
     end
   end
 end


### PR DESCRIPTION
Adds the title attribute `title="Video"` to the video iframes coming without any title attribute. It would be better if content people could add the attribute to the iframe but this should fix the problem in the meantime.

@aduggin @andrewgarner 
