### PR TITLE
Generate requirejs config in ruby

### DIFF
--- a/app/assets/javascripts/require_config.js.erb
+++ b/app/assets/javascripts/require_config.js.erb
@@ -14,48 +14,53 @@
 //= depend_on_asset modules/mas_scrollTracking
 //= depend_on_asset modules/mas_collapsable
 
-<% def requirejs_path(asset) ; javascript_path(asset).sub(/.js\z/, ''); end %>
+<%
+  def requirejs_path(asset)
+    javascript_path(asset).sub(/.js\z/, '')
+  end
+
+  requirejs_config = {
+    baseUrl: Rails.application.config.assets.prefix,
+    paths: {
+      # Translation JSON files
+      en: requirejs_path('translations/en'),
+      cy: requirejs_path('translations/cy'),
+      i18nTokens: requirejs_path('translations/' + I18n.locale.to_s),
+
+      # External dependancies
+      jquery: requirejs_path('jquery/dist/jquery'),
+      waypoints: requirejs_path('jquery-waypoints/waypoints'),
+      ujs: requirejs_path('jquery-ujs/src/rails'),
+      eventsWithPromises: requirejs_path('eventsWithPromises/src/eventsWithPromises'),
+      rsvp: requirejs_path('rsvp/rsvp.amd'),
+
+      # Internal modules
+      globals: requirejs_path('modules/globals'),
+      common: requirejs_path('modules/common'),
+      log: requirejs_path('modules/log'),
+      i18n: requirejs_path('modules/i18n'),
+      pubsub: requirejs_path('modules/mas_pubsub'),
+      scrollTracking: requirejs_path('modules/mas_scrollTracking'),
+      collapsable: requirejs_path('modules/mas_collapsable'),
+
+      # Engines
+      pensionsCalculatorConfig: requirejs_path('pensions_calculator/require_config'),
+      pensionsCalculator: requirejs_path('pensions_calculator/application'),
+    },
+    shim: {
+      ujs: ['jquery']
+    }
+  }
+
+  # Dough
+  requirejs_config[:paths].merge!({
+    featureDetect: requirejs_path('frontend-assets/js/lib/featureDetect'),
+    componentLoader: requirejs_path('frontend-assets/js/lib/componentLoader'),
+    DoughBaseComponent: requirejs_path('frontend-assets/js/components/DoughBaseComponent'),
+    RangeInput: requirejs_path('frontend-assets/js/components/RangeInput'),
+    TabSelector: requirejs_path('frontend-assets/js/components/TabSelector'),
+  })
+%>
 
 // RequireJS config
-requirejs.config({
-  baseUrl: '<%= Rails.application.config.assets.prefix %>',
-  paths: {
-    // Translation JSON files
-    en: '<%= requirejs_path('translations/en') %>',
-    cy: '<%= requirejs_path('translations/cy') %>',
-
-    i18nTokens: '<%= requirejs_path('translations/' + I18n.locale.to_s) %>',
-
-    // External dependancies
-    jquery: '<%= requirejs_path('jquery/dist/jquery') %>',
-    waypoints: '<%= requirejs_path('jquery-waypoints/waypoints') %>',
-    ujs: '<%= requirejs_path('jquery-ujs/src/rails') %>',
-    eventsWithPromises: '<%= requirejs_path('eventsWithPromises/src/eventsWithPromises') %>',
-
-    // Internal modules
-    DoughBaseComponent: '<%= requirejs_path('frontend-assets/js/components/DoughBaseComponent') %>',
-    featureDetect: '<%= requirejs_path('frontend-assets/js/lib/featureDetect') %>',
-
-    globals: '<%= requirejs_path('modules/globals') %>',
-    common: '<%= requirejs_path('modules/common') %>',
-    log: '<%= requirejs_path('modules/log') %>',
-    i18n: '<%= requirejs_path('modules/i18n') %>',
-
-    pubsub: '<%= requirejs_path('modules/mas_pubsub') %>',
-    scrollTracking: '<%= requirejs_path('modules/mas_scrollTracking') %>',
-    collapsable: '<%= requirejs_path('modules/mas_collapsable') %>',
-
-    rsvp: '<%= requirejs_path('rsvp/rsvp.amd') %>',
-
-    componentLoader: '<%= requirejs_path('frontend-assets/js/lib/componentLoader') %>',
-    RangeInput: '<%= requirejs_path('frontend-assets/js/components/RangeInput') %>',
-    TabSelector: '<%= requirejs_path('frontend-assets/js/components/TabSelector') %>',
-
-    // Engines
-    pensionsCalculatorConfig: '<%= requirejs_path('pensions_calculator/require_config') %>',
-    pensionsCalculator: '<%= requirejs_path('pensions_calculator/application') %>'
-  },
-  shim: {
-    'ujs': ['jquery']
-  }
-});
+requirejs.config(<%= JSON.pretty_generate(requirejs_config) %>);


### PR DESCRIPTION
This is a precursor to removing the need for applications to reference
specific Dough components directly
