### PR TITLE
Unpin the frontend-assets dough commit

### DIFF
--- a/bower.json.erb
+++ b/bower.json.erb
@@ -3,7 +3,7 @@
   "private": true,
   "ignore": ["*", "!app/assets/**/*", "!vendor/assets/fonts/*"],
   "dependencies": {
-    "frontend-assets": "git://github.com/moneyadviceservice/dough#8be1ff5",
+    "frontend-assets": "git://github.com/moneyadviceservice/dough",
     "html-inspector": "0.7.0",
     "sinonjs": "1.7.3",
     "html5shiv": "3.7.0",


### PR DESCRIPTION
Relevant changes that were being pinned to avoid have been rolled back in dough.

@gjvis @andrewgarner 
