### PR TITLE
Configure chat opening hours

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'meta-tags'
 gem 'mysql2'
 gem 'nokogiri'
 gem 'nunes'
+gem 'opening_hours'
 gem 'psych', '>= 2.0.5' # https://www.ruby-lang.org/en/news/2014/03/29/heap-overflow-in-yaml-uri-escape-parsing-cve-2014-2525/
 gem 'rouge'
 gem 'rubytree'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -241,6 +241,8 @@ GEM
     nokogiri (1.6.2.1)
       mini_portile (= 0.6.0)
     nunes (0.3.1)
+    opening_hours (0.0.7)
+      activesupport
     orm_adapter (0.5.0)
     pensions_calculator (0.2.0.303)
       autoprefixer-rails
@@ -437,6 +439,7 @@ DEPENDENCIES
   mysql2
   nokogiri
   nunes
+  opening_hours
   pensions_calculator (~> 0.2)
   psych (>= 2.0.5)
   rails (~> 4.1)

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,6 +20,10 @@ module Frontend
     config.crazy_egg_url         = '//dnn506yrbagrg.cloudfront.net/pages/scripts/0018/4438.js'
     config.google_tag_manager_id = 'GTM-WVFLH9'
 
+    config.chat_opening_hours = OpeningHours.new('8:00 AM', '10:00 PM')
+    config.chat_opening_hours.update(:sat, '09:00 AM', '10:00 PM')
+    config.chat_opening_hours.update(:sun, '10:00 AM', '10:00 PM')
+
     config.middleware.use 'CaptureRequestId' # capture X-Request-ID header
     config.middleware.use 'OverrideHead' # convert HEAD requests to GET and return an empty body
     config.middleware.use 'RouteProbe' # respond to requests probing for a implemented route


### PR DESCRIPTION
Adds the opening hours for chat. We can use this to dynamically generate opening hour information in our views and to programatically decide if chat is available.

@stevenwilkin 
