### PR TITLE
Encodes connection url

### DIFF
--- a/lib/core/repository/news/public_website.rb
+++ b/lib/core/repository/news/public_website.rb
@@ -7,7 +7,7 @@ module Core::Repository
 
       def find(id)
         response = connection.get('/%{locale}/news/%{id}.json' %
-                                    { locale: I18n.locale, id: id })
+                                    { locale: I18n.locale, id: URI.encode(id) })
         attributes = response.body
         links      = response.headers['link'].try(:links) || []
 

--- a/spec/lib/core/repository/news/public_website_spec.rb
+++ b/spec/lib/core/repository/news/public_website_spec.rb
@@ -12,14 +12,24 @@ module Core::Repository::News
 
       let(:id) { 'tell-ma-were-listening' }
       let(:headers) { {} }
+      let(:body) { {} }
+      let(:status) { 200 }
 
       before do
-        allow(Core::Registry::Connection).to receive(:[]).with(:public_website) do
-          Core::ConnectionFactory::Http.build(url)
-        end
-
         stub_request(:get, "https://example.com/en/news/#{id}.json")
           .to_return(status: status, body: body, headers: headers)
+      end
+
+      context 'when id contains special characters' do
+        let(:id) { 'jobs-for-students-–-the-taxing-questions' }
+        let(:encoded_url) { '/en/news/jobs-for-students-%E2%80%93-the-taxing-questions.json' }
+        let(:response) { double(body: body, headers: headers) }
+
+        it 'encodes url' do
+          expect(connection).to receive(:get).with(encoded_url).and_return(response)
+
+          repository.find(id)
+        end
       end
 
       context 'when the type exists' do


### PR DESCRIPTION
Fixes the problem with urls like 'jobs-for-students-–-the-taxing-questions'
