### PR TITLE
Tweak engine locale param fix

### DIFF
--- a/config/initializers/engine_locale_fix.rb
+++ b/config/initializers/engine_locale_fix.rb
@@ -8,7 +8,13 @@ module Rails
 
         problem_engines = Rails::Engine.subclasses.keep_if do |engine|
           Rails.application.routes.routes.any? do |route|
-            route.app == engine && route.required_parts.include?(:locale)
+            app = if route.app.is_a?(ActionDispatch::Routing::Mapper::Constraints)
+              route.app.app
+            else
+              route.app
+            end
+
+            app == engine && route.required_parts.include?(:locale)
           end
         end
 


### PR DESCRIPTION
When a route has an object for it's constraints, `route.app` is an instance of `ActionDispatch::Routing::Mapper::Constraints` rather than the engine class (it's accessible in the `app` attribute of that object instead).

@gjvis 
