### PR TITLE
return 501 on accound edit pages

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,11 @@ Rails.application.routes.draw do
     root 'home#show'
 
     if Feature.active?(:registration)
+      scope '/users' do
+        match '/', to: not_implemented, via: ['put', 'patch']
+        match '/edit', to: not_implemented, via: 'get'
+      end
+
       devise_for :users, only: [:registrations],
                  controllers:  { registrations: 'registrations' }
     else

--- a/spec/requests/registration_spec.rb
+++ b/spec/requests/registration_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+RSpec.describe 'Registration routing', type: :request do
+  around :each do |example|
+    Feature.run_with_activated(:registration) do
+      Rails.application.reload_routes!
+
+      example.run
+    end
+
+    Rails.application.reload_routes!
+  end
+
+  it '501 on user updating account details' do
+    get("/en/users/edit")
+    expect(response.status).to eq(501)
+  end
+
+  it '501 on user updating account details' do
+    put("/en/users")
+    expect(response.status).to eq(501)
+  end
+
+  it '501 on user updating account details' do
+    patch("/en/users")
+    expect(response.status).to eq(501)
+  end
+end


### PR DESCRIPTION
this is so we fallback to the old website if the user wants to edit their account
as the account page is yet to be implemented
