### PR TITLE
template page with only header and footer [work in progress]

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -4,6 +4,10 @@ class HomeController < ApplicationController
 
   end
 
+  def blank
+  	
+  end
+
   def display_menu_button_in_header?
     false
   end

--- a/app/views/home/blank.html.erb
+++ b/app/views/home/blank.html.erb
@@ -1,0 +1,1 @@
+<!-- content goes here -->

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
 
   scope '/:locale', locale: /en|cy/ do
     root 'home#show'
+    get 'blank', to: 'home#blank'
 
     if Feature.active?(:registration)
       scope '/users' do


### PR DESCRIPTION
Setting a blank content template to be used by the annuities folks on their own 'version' of the site.  There is almost certainly more work to do with this, we might need to make a static version of this for them.
