### PR TITLE
Use a custom matcher for entity attributes

### DIFF
--- a/spec/lib/core/entity/article_spec.rb
+++ b/spec/lib/core/entity/article_spec.rb
@@ -12,21 +12,7 @@ module Core
       }
     end
 
-    it { is_expected.to respond_to :type }
-    it { is_expected.to respond_to :type= }
-
-    it { is_expected.to respond_to :title }
-    it { is_expected.to respond_to :title= }
-
-    it { is_expected.to respond_to :description }
-    it { is_expected.to respond_to :description= }
-
-    it { is_expected.to respond_to :body }
-    it { is_expected.to respond_to :body= }
-
-    it { is_expected.to respond_to :alternates }
-    it { is_expected.to respond_to :alternates= }
-
+    it { is_expected.to have_attributes(:type, :title, :description, :body, :alternates) }
     it { is_expected.to validate_presence_of(:title) }
     it { is_expected.to validate_presence_of(:body) }
 

--- a/spec/lib/core/entity/category_spec.rb
+++ b/spec/lib/core/entity/category_spec.rb
@@ -7,21 +7,7 @@ module Core
                          description: double,
                          contents:    double } }
 
-    it { is_expected.to respond_to :type }
-    it { is_expected.to respond_to :type= }
-
-    it { is_expected.to respond_to :parent_id }
-    it { is_expected.to respond_to :parent_id= }
-
-    it { is_expected.to respond_to :title }
-    it { is_expected.to respond_to :title= }
-
-    it { is_expected.to respond_to :description }
-    it { is_expected.to respond_to :description= }
-
-    it { is_expected.to respond_to :contents }
-    it { is_expected.to respond_to :contents= }
-
+    it { is_expected.to have_attributes(:type, :parent_id, :title, :description, :contents) }
     it { is_expected.to validate_presence_of(:title) }
 
     specify { expect(subject).to_not be_home }

--- a/spec/lib/core/entity/entity_spec.rb
+++ b/spec/lib/core/entity/entity_spec.rb
@@ -4,9 +4,7 @@ module Core
 
     let(:attributes) { Hash.new }
 
-    it { is_expected.to respond_to :id }
-    it { is_expected.not_to respond_to :id= }
-
+    it { is_expected.to have_read_only_attributes(:id) }
     it { is_expected.to validate_presence_of(:id) }
 
     context 'when passed unexpected data' do

--- a/spec/lib/core/entity/feedback/article_spec.rb
+++ b/spec/lib/core/entity/feedback/article_spec.rb
@@ -4,11 +4,7 @@ module Core
       let(:attributes) { double }
       subject(:article) { described_class.new(attributes) }
 
-      it { is_expected.to respond_to :useful }
-      it { is_expected.to respond_to :useful= }
-
-      it { is_expected.to respond_to :suggestions }
-      it { is_expected.to respond_to :suggestions= }
+      it { is_expected.to have_attributes(:useful, :suggestions) }
 
       describe '#recipient' do
         subject { article.recipient }

--- a/spec/lib/core/entity/feedback/base_spec.rb
+++ b/spec/lib/core/entity/feedback/base_spec.rb
@@ -3,14 +3,7 @@ module Core
     RSpec.describe Base do
       subject { described_class.new(double) }
 
-      it { is_expected.to respond_to :url }
-      it { is_expected.to respond_to :url= }
-
-      it { is_expected.to respond_to :user_agent }
-      it { is_expected.to respond_to :user_agent= }
-
-      it { is_expected.to respond_to :time }
-      it { is_expected.to respond_to :time= }
+      it { is_expected.to have_attributes(:url, :user_agent, :time) }
     end
   end
 end

--- a/spec/lib/core/entity/feedback/technical_spec.rb
+++ b/spec/lib/core/entity/feedback/technical_spec.rb
@@ -4,11 +4,7 @@ module Core
       let(:attributes) { double }
       subject(:technical) { described_class.new(attributes) }
 
-      it { is_expected.to respond_to :attempting }
-      it { is_expected.to respond_to :attempting= }
-
-      it { is_expected.to respond_to :occurred }
-      it { is_expected.to respond_to :occurred= }
+      it { is_expected.to have_attributes(:attempting, :occurred) }
 
       describe '#recipient' do
         subject { technical.recipient }

--- a/spec/lib/core/entity/news_article_spec.rb
+++ b/spec/lib/core/entity/news_article_spec.rb
@@ -5,7 +5,7 @@ module Core
     let(:date) { '2014-03-17T09:42:11+00:00' }
     let(:attributes) { { date: date } }
 
-    it { is_expected.to respond_to :date }
+    it { is_expected.to have_attributes(:date) }
 
     describe '#date' do
       it 'returns a date object' do

--- a/spec/lib/core/entity/news_collection_spec.rb
+++ b/spec/lib/core/entity/news_collection_spec.rb
@@ -2,8 +2,7 @@ module Core
   RSpec.describe NewsCollection do
     subject(:news_collection) { described_class.new() }
 
-    it { is_expected.to respond_to :items }
-    it { is_expected.to respond_to :page }
+    it { is_expected.to have_read_only_attributes(:items, :page) }
 
     it 'is a collection' do
       expect(subject.to_a).to be_kind_of(Array)

--- a/spec/lib/core/entity/other.rb
+++ b/spec/lib/core/entity/other.rb
@@ -6,13 +6,6 @@ module Core
       { title: double }
     end
 
-    it { is_expected.to respond_to :type }
-    it { is_expected.to respond_to :type= }
-
-    it { is_expected.to respond_to :title }
-    it { is_expected.to respond_to :title= }
-
-    it { is_expected.to respond_to :description }
-    it { is_expected.to respond_to :description= }
+    it { is_expected.to have_attributes(:type, :title, :description) }
   end
 end

--- a/spec/lib/core/entity/search_result_collection_spec.rb
+++ b/spec/lib/core/entity/search_result_collection_spec.rb
@@ -4,18 +4,8 @@ module Core
     let(:attributes) { { items: items } }
     subject(:result_collection) { described_class.new(attributes) }
 
-    it { is_expected.to respond_to :total_results }
-    it { is_expected.to respond_to :total_results= }
-
-    it { is_expected.to respond_to :page }
-    it { is_expected.to respond_to :page= }
-
-    it { is_expected.to respond_to :per_page }
-    it { is_expected.to respond_to :per_page= }
-
-    it { is_expected.to respond_to :items }
-
-    it { is_expected.to respond_to :query }
+    it { is_expected.to have_attributes(:total_results, :page, :per_page) }
+    it { is_expected.to have_read_only_attributes(:items, :query) }
 
     it 'is a collection' do
       expect(subject.to_a).to be_kind_of(Array)

--- a/spec/lib/core/entity/search_result_spec.rb
+++ b/spec/lib/core/entity/search_result_spec.rb
@@ -4,11 +4,7 @@ module Core
 
     let(:attributes) { { title: double, description: double } }
 
-    it { is_expected.to respond_to :title }
-    it { is_expected.to respond_to :title= }
-
-    it { is_expected.to respond_to :description }
-    it { is_expected.to respond_to :description= }
+    it { is_expected.to have_attributes(:title, :description) }
 
     it { is_expected.to validate_presence_of(:title) }
     it { is_expected.to validate_presence_of(:description) }

--- a/spec/lib/core/entity/static_page_spec.rb
+++ b/spec/lib/core/entity/static_page_spec.rb
@@ -10,20 +10,7 @@ module Core
       }
     end
 
-    it { is_expected.to respond_to :type }
-    it { is_expected.to respond_to :type= }
-
-    it { is_expected.to respond_to :title }
-    it { is_expected.to respond_to :title= }
-
-    it { is_expected.to respond_to :description }
-    it { is_expected.to respond_to :description= }
-
-    it { is_expected.to respond_to :body }
-    it { is_expected.to respond_to :body= }
-
-    it { is_expected.to respond_to :alternates }
-    it { is_expected.to respond_to :alternates= }
+    it { is_expected.to have_attributes(:type, :title, :description, :body, :alternates) }
 
     it { is_expected.to validate_presence_of(:title) }
     it { is_expected.to validate_presence_of(:body) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,6 +38,8 @@ end
 
 WebMock.disable_net_connect!(allow: 'codeclimate.com')
 
+Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+
 RSpec.configure do |c|
   c.include FactoryGirl::Syntax::Methods
   c.include PageValidations

--- a/spec/support/matchers/attribute_matcher.rb
+++ b/spec/support/matchers/attribute_matcher.rb
@@ -1,0 +1,23 @@
+RSpec::Matchers.define :have_attributes do |*attributes|
+  attributes.each do |attribute|
+    failure_message do |entity|
+      "#{entity.class} should have attribute #{attribute}"
+    end
+
+    match do |entity|
+      entity.respond_to?(attribute) and entity.respond_to?(:"#{attribute}=")
+    end
+  end
+end
+
+RSpec::Matchers.define :have_read_only_attributes do |*attributes|
+  attributes.each do |attribute|
+    failure_message do |entity|
+      "#{entity.class} should have read-only attribute #{attribute}"
+    end
+
+    match do |entity|
+      entity.respond_to?(attribute) and not entity.respond_to?(:"#{attribute}=")
+    end
+  end
+end


### PR DESCRIPTION
- entities are expected to respond to the accessor for each attribute
- entities shouldn't respond to the attribute setter if it has been marked as
  private (this pattern has emerged in the codebase)

@pvcarrera 
