### PR TITLE
Removing autofill overrides and disabling autocomplete on search

### DIFF
--- a/app/assets/stylesheets/components/common/_search.scss
+++ b/app/assets/stylesheets/components/common/_search.scss
@@ -22,11 +22,6 @@
       color: $color-search-text;
     }
 
-    &:-webkit-autofill {
-      // hack to remove Chrome's yellow background on autofill
-      -webkit-box-shadow: 0 0 0 1000px $color-white inset;
-    }
-
     &:focus::-webkit-input-placeholder {
       color: transparent;
     }

--- a/app/views/shared/_search.html.erb
+++ b/app/views/shared/_search.html.erb
@@ -1,6 +1,6 @@
 <form data-dough-component="ClearInput" action="<%= main_app.search_results_path %>" method="get" role="search" class="search">
   <label class="visually-hidden" for="search"><%= t('search_box.label') %></label>
-  <input data-dough-clear-input class="search__input" id="search" required type="search" name="query" value="<%= params[:query] %>"
+  <input data-dough-clear-input class="search__input" id="search" required type="search" name="query" value="<%= params[:query] %>" autocomplete="off"
     placeholder="<%= t('search_box.placeholder') %>" />
 
   <button data-dough-clear-input-button type="reset" class="search__clear">


### PR DESCRIPTION
Per discussion offline, we feel that users do not use autofill functionality for search fields and have opted to disable this functionality for ours. This follows many other use cases (including Google.com).
