### PR TITLE
Add variant of TabSelector to style guide 

### DIFF
--- a/app/views/styleguide/components_common.html.erb
+++ b/app/views/styleguide/components_common.html.erb
@@ -83,6 +83,10 @@
   <%= render 'styleguide/shared/table' %>
 <% end %>
 
+<%= styleguide_section sections['Tab selector collapsable'] do %>
+  <%= render 'styleguide/shared/tab_selector_collapsable' %>
+<% end %>
+
 <%= styleguide_section sections['Tab selector'] do %>
   <%= render 'styleguide/shared/tab_selector' %>
 <% end %>

--- a/app/views/styleguide/shared/_tab_selector_collapsable.html.erb
+++ b/app/views/styleguide/shared/_tab_selector_collapsable.html.erb
@@ -1,0 +1,35 @@
+<div class="tab-selector tab-selector--collapsable" data-dough-component="TabSelector" data-dough-tab-selector-config='{"collapseInSmallViewport": true}'>
+  <div data-dough-tab-selector-triggers-outer class="tab-selector__triggers-outer">
+    <div data-dough-tab-selector-triggers-inner class="tab-selector__triggers-inner">
+      <div class="tab-selector__trigger-container is-active" data-dough-tab-selector-trigger-container>
+        <a class="tab-selector__trigger" href="#panel-1" data-dough-tab-selector-trigger="1">panel 1
+          <span class="tab-selector__item-info">Summary 1</span></a>
+      </div>
+      <div class="tab-selector__trigger-container is-inactive" data-dough-tab-selector-trigger-container>
+        <a class="tab-selector__trigger" href="#panel-2" data-dough-tab-selector-trigger="2">panel 2
+          <span class="tab-selector__item-info">Summary 2</span></a>
+      </div>
+      <div class="tab-selector__trigger-container is-inactive" data-dough-tab-selector-trigger-container>
+        <a class="tab-selector__trigger" href="#panel-3" data-dough-tab-selector-trigger="3">panel 3
+          <span class="tab-selector__item-info">Summary 3</span></a>
+      </div>
+    </div>
+  </div>
+  <div class="tab-selector__target is-active" id="panel-1" data-dough-tab-selector-target="1">
+    <h2 class="tab-selector__target-heading">Panel 1</h2>
+    Content
+  </div>
+  <div class="tab-selector__target is-inactive" id="panel-2" data-dough-tab-selector-target="2">
+    <h2 class="tab-selector__target-heading">Panel 2</h2>
+    <p>
+      <a href="#panel-1" class="is-active" data-dough-tab-selector-trigger="1">panel 1</a> or <a href="#panel-2" class="is-inactive" data-dough-tab-selector-trigger="2">panel 2</a>
+    </p>
+    <p>
+      <a href="#panel-3" class="is-inactive" data-dough-tab-selector-trigger="3">panel 3</a>
+    </p>
+  </div>
+  <div class="tab-selector__target is-inactive" id="panel-3" data-dough-tab-selector-target="3">
+    <h2 class="tab-selector__target-heading">Panel 3</h2>
+  </div>
+
+</div>


### PR DESCRIPTION
doesn't collapse at small viewport widths

dependant on this Dough PR: https://github.com/moneyadviceservice/dough/pull/159/files
