### PR TITLE
Adding container tool layout for engines

### DIFF
--- a/app/assets/stylesheets/layout/common/_tool.scss
+++ b/app/assets/stylesheets/layout/common/_tool.scss
@@ -1,0 +1,3 @@
+.l-container-tool {
+  @include column(12);
+}

--- a/app/views/layouts/engine.html.erb
+++ b/app/views/layouts/engine.html.erb
@@ -15,7 +15,9 @@
   </div>
 
   <div class="l-constrained">
-    <%= yield :engine_content %>
+    <div class="l-container-tool">
+      <%= yield :engine_content %>
+    </div>
   </div>
 
   <% if display_category_directory? %>


### PR DESCRIPTION
Ensures that engines mounted on frontend align with the grid. Currently pensions calculator does this at an engine level, so this just moves that logic a level up to the parent app.

I'll submit another PR to remove that from pensions calc now.
