### PR TITLE
Switch to the MAS fork of `html_validation`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,7 @@ group :test do
   gem 'chronic'
   gem 'codeclimate-test-reporter', require: false
   gem 'faker'
-  gem 'html_validation'
+  gem 'html_validation', github: 'moneyadviceservice/html_validation', ref: '3fb1b65'
   gem 'rspec_junit_formatter'
   gem 'sqlite3'
   gem 'tidy-html5', github: 'moneyadviceservice/tidy-html5-gem'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: git://github.com/moneyadviceservice/html_validation.git
+  revision: 3fb1b655a1f5d2963345d980ec819b3e17e9a187
+  ref: 3fb1b65
+  specs:
+    html_validation (1.1.1)
+
+GIT
   remote: git://github.com/moneyadviceservice/mas-development_dependencies.git
   revision: de00ee49c85b92f24cc4bb1de273c991ae90b964
   specs:
@@ -239,7 +246,6 @@ GEM
       guard (>= 1.1.0)
     hashie (2.0.5)
     hike (1.2.3)
-    html_validation (1.1.1)
     http_parser.rb (0.6.0)
     i18n (0.6.11)
     i18n-js (3.0.0.mas)
@@ -506,7 +512,7 @@ DEPENDENCIES
   guard-rspec
   guard-sass
   guard-shell
-  html_validation
+  html_validation!
   jquery-rails
   jshint_ruby
   kss


### PR DESCRIPTION
Until http://git.io/NXcCJg gets merged. This removes the deprecation
messages from the `html_validation` RSpec matcher when run under RSpec
3.
