### PR TITLE
Transfer initial tables to a migration so that all migrations can run

### DIFF
--- a/db/migrate/20130524000000_create_initial_tables.rb
+++ b/db/migrate/20130524000000_create_initial_tables.rb
@@ -1,0 +1,80 @@
+class CreateInitialTables < ActiveRecord::Migration
+  def change
+    create_table "csr_users" do |t|
+      t.string   "email",                  default: "", null: false
+      t.string   "encrypted_password",     default: "", null: false
+      t.string   "reset_password_token"
+      t.datetime "reset_password_sent_at"
+      t.datetime "remember_created_at"
+      t.integer  "sign_in_count",          default: 0
+      t.datetime "current_sign_in_at"
+      t.datetime "last_sign_in_at"
+      t.string   "current_sign_in_ip"
+      t.string   "last_sign_in_ip"
+      t.string   "csr_id",                              null: false
+      t.datetime "created_at",                          null: false
+      t.datetime "updated_at",                          null: false
+      t.string   "first_name"
+      t.string   "last_name"
+    end
+
+    add_index "csr_users", ["email"], name: "index_csr_users_on_email", unique: true, using: :btree
+    add_index "csr_users", ["reset_password_token"], name: "index_csr_users_on_reset_password_token", unique: true, using: :btree
+
+
+    create_table "sessions" do |t|
+      t.string   "session_id", null: false
+      t.text     "data"
+      t.datetime "created_at", null: false
+      t.datetime "updated_at", null: false
+    end
+
+    add_index "sessions", ["session_id"], name: "index_sessions_on_session_id", using: :btree
+    add_index "sessions", ["updated_at"], name: "index_sessions_on_updated_at", using: :btree
+
+
+    create_table "users" do |t|
+      t.string   "email",                              default: "",    null: false
+      t.string   "encrypted_password",                 default: ""
+      t.string   "reset_password_token"
+      t.datetime "reset_password_sent_at"
+      t.integer  "sign_in_count",                      default: 0
+      t.datetime "current_sign_in_at"
+      t.datetime "last_sign_in_at"
+      t.string   "current_sign_in_ip"
+      t.string   "last_sign_in_ip"
+      t.datetime "created_at",                                         null: false
+      t.datetime "updated_at",                                         null: false
+      t.boolean  "accept_terms_conditions"
+      t.string   "first_name"
+      t.string   "last_name"
+      t.string   "password_salt"
+      t.string   "post_code"
+      t.string   "age_range"
+      t.string   "gender"
+      t.boolean  "newsletter_subscription",            default: false
+      t.string   "customer_id"
+      t.text     "health_check_result"
+      t.boolean  "active",                             default: true
+      t.date     "date_of_birth"
+      t.string   "confirmation_token"
+      t.datetime "confirmed_at"
+      t.datetime "confirmation_sent_at"
+      t.string   "unconfirmed_email"
+      t.string   "csr_id"
+      t.string   "invitation_token",        limit: 60
+      t.datetime "invitation_sent_at"
+      t.datetime "invitation_accepted_at"
+      t.integer  "invitation_limit"
+      t.integer  "invited_by_id"
+      t.string   "invited_by_type"
+      t.integer  "failed_attempts",                    default: 0
+      t.string   "unlock_token"
+      t.datetime "locked_at"
+    end
+
+    add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree
+    add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
+    add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,40 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140702134657) do
+ActiveRecord::Schema.define(version: 20130807092501) do
+
+  create_table "budget_planner_budgets", force: true do |t|
+    t.binary   "data",               null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer  "user_id"
+    t.string   "commited_from"
+    t.string   "last_commited_from"
+  end
+
+  add_index "budget_planner_budgets", ["user_id"], name: "index_budget_planner_budgets_on_user_id", using: :btree
+
+  create_table "budget_planner_legacy_budgets", force: true do |t|
+    t.binary   "data",        null: false
+    t.string   "legacy_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.datetime "accessed_at"
+  end
+
+  add_index "budget_planner_legacy_budgets", ["legacy_id"], name: "index_budget_planner_legacy_budgets_on_legacy_id", unique: true, using: :btree
+
+  create_table "budget_planner_wip_budgets", force: true do |t|
+    t.binary   "data",             null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer  "user_id"
+    t.integer  "source_budget_id"
+    t.string   "source_website"
+    t.datetime "commited_at"
+  end
+
+  add_index "budget_planner_wip_budgets", ["user_id"], name: "index_budget_planner_wip_budgets_on_user_id", using: :btree
 
   create_table "csr_users", force: true do |t|
     t.string   "email",                  default: "", null: false
@@ -34,7 +67,6 @@ ActiveRecord::Schema.define(version: 20140702134657) do
   add_index "csr_users", ["email"], name: "index_csr_users_on_email", unique: true, using: :btree
   add_index "csr_users", ["reset_password_token"], name: "index_csr_users_on_reset_password_token", unique: true, using: :btree
 
-
   create_table "sessions", force: true do |t|
     t.string   "session_id", null: false
     t.text     "data"
@@ -44,7 +76,6 @@ ActiveRecord::Schema.define(version: 20140702134657) do
 
   add_index "sessions", ["session_id"], name: "index_sessions_on_session_id", using: :btree
   add_index "sessions", ["updated_at"], name: "index_sessions_on_updated_at", using: :btree
-
 
   create_table "users", force: true do |t|
     t.string   "email",                              default: "",    null: false


### PR DESCRIPTION
Fixes a problem where migrations from engines are not run after a
db:schema:load, or the schema.rb loses the initial tables when
running db:migrate.

All of the base tables were defined only in the schema.rb and the version
timestamp was newer than the timestamps in the migrations in the mounted
engines.

Schema load assumes that schema.rb includes all migrations earlier than
the schema version (timestamp), and populates the schema_migration table
to reflect this.

The solution here is to pull all of the tables in schema.rb out into a
migration with a version timestamp earlier than the migrations in all
currently attached engines. Having done this:
- rake db:migrate and db:schema:load are be equivalent assuming no new migrations are pending
- Migrations are consistently the one way to add any schema definitions to the database
## Alternative Solutions We Considered

One other solution we considered was to simply take the `version` out of schema.rb.

Pros:
- Smallest change to fix
- rake db:migrate would now work after a db:schema:load

Cons:
- rake db:schema:load would only load the locally defined initial tables and none of those required by the engines
- rake db:migrate would overwrite schema.rb after every migration and developers would need to remember to revert it and not accidentally commit it.
- Having some tables in migrations and others only in schema.rb seems inconsistent and makes it confusing to work out what the correct work flow is for initialising the database.
