### PR TITLE
Fix missing migration problem

### DIFF
--- a/db/migrate/20140515170453_create_initial_tables.rb
+++ b/db/migrate/20140515170453_create_initial_tables.rb
@@ -1,3 +1,15 @@
+#
+# This migration defines the basic set of tables needed to run the frontend and
+# is a subset of those already introduced by the old public_website.
+#
+# To prevent collisions when these migrations are run against an existing
+# database initialised from the public_website, the timestamp has been chosen
+# to match that of the last migration from public_website already applied to
+# the live database, which at the time this was created was:
+#
+#   20140515170453_make_users_lockable.rb
+#
+
 class CreateInitialTables < ActiveRecord::Migration
   def change
     create_table "csr_users" do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20130807092501) do
+ActiveRecord::Schema.define(version: 20140515170453) do
 
   create_table "budget_planner_budgets", force: true do |t|
     t.binary   "data",               null: false


### PR DESCRIPTION
There were two problems to solve here:

1) Database tables were not being created when loading the database from frontend. 

Because there wasn't a migration for the base set of tables, running `rake db:migrate` overwrote schema.rb and only loaded tables from engines. Vice versa, running only `rake db:schema:load` only loaded the contents of schema.rb and created no tables from the attached engines.

To solve this, the definitions from schema.rb have been moved to a migration.

2) A second problem was to ensure it was safe to run `rake db:migrate` from within frontend against an existing database already created from the old public_website sources (mimicking the situation with the live database).

The solution to this was to give the new migration in frontend the same timestamp as the last migration from public_website, so it would appear to have already been applied.
