### PR TITLE
Rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,8 @@ Metrics/MethodLength:
   Max: 15
 Style/ClassAndModuleChildren:
   Enabled: false
+Style/CollectionMethods:
+  Enabled: false
 Style/DotPosition:
   EnforcedStyle: leading
 Style/FormatString:


### PR DESCRIPTION
This rules are different in Rubocop default and Hound default so I'm adding them explicitly to our project rules
