### PR TITLE
Update Car cost tool to 1.0.1. Apply migration to schema.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem 'uglifier', '>= 1.3.0'
 gem 'validates_timeliness'
 
 gem 'budget_planner', '~> 4.0'
-gem 'car_cost_tool', '~> 0.4.0'
+gem 'car_cost_tool', '~> 1.0.1'
 gem 'debt_advice_locator', '~> 2.0'
 gem 'debt_free_day_calculator', '~> 2.0'
 gem 'mortgage_calculator', '~> 1.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,8 +126,9 @@ GEM
       capybara (>= 1.0, < 3)
       colorize
       launchy
-    car_cost_tool (0.4.0.80)
+    car_cost_tool (1.0.1.83)
       dough-ruby
+      font-awesome-rails (~> 4.1)
       nokogiri
       rails (~> 4.1)
       rest-client
@@ -268,6 +269,8 @@ GEM
     faraday_middleware (0.9.1)
       faraday (>= 0.7.4, < 0.10)
     ffi (1.9.3)
+    font-awesome-rails (4.2.0.0)
+      railties (>= 3.2, < 5.0)
     foreman (0.63.0)
       dotenv (>= 0.7)
       thor (>= 0.13.6)
@@ -619,7 +622,7 @@ DEPENDENCIES
   bowndler (~> 1.0)
   budget_planner (~> 4.0)
   byebug
-  car_cost_tool (~> 0.4.0)
+  car_cost_tool (~> 1.0.1)
   chai-jquery-rails
   chronic
   codeclimate-test-reporter

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140801133923) do
+ActiveRecord::Schema.define(version: 20141017134140) do
 
   create_table "budget_planner_budgets", force: true do |t|
     t.binary   "data",               null: false
@@ -59,7 +59,7 @@ ActiveRecord::Schema.define(version: 20140801133923) do
 
   create_table "car_cost_tool_fuel_prices", force: true do |t|
     t.string   "fuel_type"
-    t.decimal  "price_in_pence", precision: 10, scale: 0
+    t.decimal  "price_in_pence", precision: 10, scale: 6
     t.datetime "created_at"
     t.datetime "updated_at"
   end


### PR DESCRIPTION
Small PR to update car_cost_tool in frontend to the latest version. The PR is mainly to raise awareness to the ruby gem having an additional migration added to it, which enforces scale onto decimal which wasn't an apparent issue in SQLite3, but without it, will cause specs to fail when running against MySQL.
