### PR TITLE
Fix potential ReferenceError in non-browser env

### DIFF
--- a/app/assets/javascripts/modules/log.js
+++ b/app/assets/javascripts/modules/log.js
@@ -5,7 +5,10 @@ define(['globals'], function(globals) {
   var opts = ['log', 'info', 'warn', 'error'],
       l = opts.length,
       logs = {},
-      logged = [];
+      logged = [],
+      useConsole = typeof window !== 'undefined' && window.console &&
+        globals.bootstrap.env && typeof Function.prototype.bind === 'function' &&
+        globals.bootstrap.env === 'development';
 
   function logIt(name, options) {
     logged.push([name, options, type]);
@@ -13,14 +16,10 @@ define(['globals'], function(globals) {
 
   while (l--) {
     var type = l;
-    logs[opts[l]] =
-      (window && window.console && globals.bootstrap.env &&
-        globals.bootstrap.env === 'development') ?
-          console[opts[l]].bind && console[opts[l]].bind(console) :
-        logIt;
+    logs[opts[l]] = useConsole ? console[opts[l]].bind(console) : logIt;
   }
 
-  if (window) window.logged = logged;
+  if (typeof window !== 'undefined') window.logged = logged;
 
   return logs;
 });


### PR DESCRIPTION
Testing for `window` would throw if undeclared.
Also, avoid repeating feature check.

Also, as it stands `type` as used in `logIt` would always be `0`. Perhaps `logIt` should be curried when patched to `console.x`?
