### PR TITLE
update pensions_calculator version. Update syndication layout.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -410,7 +410,7 @@ GEM
     parser (2.2.0.pre.5)
       ast (>= 1.1, < 3.0)
       slop (~> 3.4, >= 3.4.5)
-    pensions_calculator (0.2.0.510)
+    pensions_calculator (0.2.0.512)
       autoprefixer-rails
       dough-ruby
       meta-tags

--- a/app/views/layouts/engine_syndicated.html.erb
+++ b/app/views/layouts/engine_syndicated.html.erb
@@ -9,7 +9,9 @@
   <% end %>
   <div id="main" tabindex="-1">
     <div class="l-constrained">
-      <%= yield :engine_content %>
+      <div class="l-container-tool">
+        <%= yield :engine_content %>
+      </div>
     </div>
   </div>
   <% content_for(:javascripts) do %>


### PR DESCRIPTION
Small PR to update the version of the Pensions Calculator on frontend. This has an additional change of altering the layout used when syndicating tools via frontend to match the DOM structure and styling as used during normal engine rendering.
