### PR TITLE
ClearInput - fixing failed unit tests

### DIFF
--- a/app/assets/javascripts/components/ClearInput.js
+++ b/app/assets/javascripts/components/ClearInput.js
@@ -3,14 +3,15 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
   'use strict';
 
   var ClearInput,
-      uiEvents = {
-      'keydown [data-dough-clear-input]' : 'updateResetButton',
-      'click [data-dough-clear-input-button]' : 'resetForm'
+      defaultConfig = {
+        uiEvents: {
+          'keydown [data-dough-clear-input]' : 'updateResetButton',
+          'click [data-dough-clear-input-button]' : 'resetForm'
+        }
       };
 
   ClearInput = function($el, config) {
-    this.uiEvents = uiEvents;
-    ClearInput.baseConstructor.call(this, $el, config);
+    ClearInput.baseConstructor.call(this, $el, config, defaultConfig);
 
     this.$resetInput = this.$el.find('[data-dough-clear-input]');
     this.$resetButton = this.$el.find('[data-dough-clear-input-button]');


### PR DESCRIPTION
Fixing issue which has crept to LIVE environment which resulted in the clear input script not firing it's events

There was a change a few weeks ago to the DoughBaseComponents.js, in which
uiEvents were now taken from the config which is passed in when the component
is created. Clear input was not updated to follow this new convention
