### PR TITLE
Altering clear input module to use keyup rather than keydown.

### DIFF
--- a/app/assets/javascripts/components/ClearInput.js
+++ b/app/assets/javascripts/components/ClearInput.js
@@ -5,7 +5,7 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
   var ClearInput,
       defaultConfig = {
         uiEvents: {
-          'keydown [data-dough-clear-input]' : 'updateResetButton',
+          'keyup [data-dough-clear-input]' : 'updateResetButton',
           'click [data-dough-clear-input-button]' : 'resetForm'
         }
       };

--- a/spec/javascripts/tests/ClearInput_spec.js
+++ b/spec/javascripts/tests/ClearInput_spec.js
@@ -18,28 +18,28 @@ describe('clear input field without initial value', function () {
     });
 
     it('shows the reset button when entering text into the input', function () {
-      this.$input.val('Debt').trigger('keydown');
+      this.$input.val('Debt').trigger('keyup');
       expect(this.$button).to.have.class('is-active');
     });
 
     it('hides the reset button when it is clicked', function () {
-      this.$input.val('Debt').trigger('keydown');
+      this.$input.val('Debt').trigger('keyup');
       expect(this.$button).to.have.class('is-active');
       this.$button.trigger('click');
       expect(this.$button).to.not.have.class('is-active');
     });
 
     it('hides the reset button when text is cleared', function () {
-      this.$input.val('Debt').trigger('keydown');
+      this.$input.val('Debt').trigger('keyup');
       expect(this.$button).to.have.class('is-active');
-      this.$input.val('').trigger('keydown');
+      this.$input.val('').trigger('keyup');
       expect(this.$button).to.not.have.class('is-active');
     });
 
     it('focuses back on the input box when the text is cleared', function () {
-      this.$input.val('Debt').trigger('keydown');
+      this.$input.val('Debt').trigger('keyup');
       expect(this.$button).to.have.class('is-active');
-      this.$input.val('').trigger('keydown');
+      this.$input.val('').trigger('keyup');
       expect(this.$button).to.not.have.class('is-active');
       expect(this.$input.filter(':focus')).to.exist;
     });
@@ -74,12 +74,12 @@ describe('clear input field without initial value', function () {
       });
 
       it('hides the reset button when text is cleared', function () {
-        this.$input.val('').trigger('keydown');
+        this.$input.val('').trigger('keyup');
         expect(this.$button).to.not.have.class('is-active');
       });
 
       it('focuses back on the input box when the text is cleared', function () {
-        this.$input.val('').trigger('keydown');
+        this.$input.val('').trigger('keyup');
         expect(this.$button).to.not.have.class('is-active');
         expect(this.$input.filter(':focus')).to.exist;
       });


### PR DESCRIPTION
- When firing a keydown event the browser returns the value of the
  text box BEFORE the latest character is added.
- When clearing the text box, the X wasn't dissappearing because
  it was still returning the value of the text before it was cleared
- altering it to keyup will return the very latest value of the textbox
  fixing this issue
