### PR TITLE
Remove CRM check in development

### DIFF
--- a/lib/core/repository/customers/fake.rb
+++ b/lib/core/repository/customers/fake.rb
@@ -38,7 +38,7 @@ module Core
         end
 
         def valid_for_authentication?(id)
-          find(id: id)
+          true
         end
       end
     end

--- a/spec/lib/core/repository/customers/fake_spec.rb
+++ b/spec/lib/core/repository/customers/fake_spec.rb
@@ -72,19 +72,11 @@ module Core
     end
 
     describe '#valid_for_authentication?' do
-      context 'when customer exists' do
-        it 'returns true' do
-          user = User.new(first_name: 'Phil')
-          customer_id = subject.create(user)
+      let(:user) { User.new(first_name: 'Phil') }
+      let(:customer_id) { subject.create(user) }
 
-          expect(subject.valid_for_authentication?(customer_id)).to be_truthy
-        end
-      end
-
-      context 'when customer does not exist' do
-        it 'returns false' do
-          expect(subject.valid_for_authentication?('customer_id')).to be_falsey
-        end
+      it 'returns true' do
+        expect(subject.valid_for_authentication?(customer_id)).to be_truthy
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -106,6 +106,7 @@ RSpec.describe User, type: :model do
     context 'when user does not exist in crm' do
       it 'returns false' do
         subject.active = 1
+        allow_any_instance_of(Core::Repository::Customers::Fake).to receive(:valid_for_authentication?) { false }
         expect(subject.valid_for_authentication?).to be_falsey
       end
     end
@@ -113,6 +114,7 @@ RSpec.describe User, type: :model do
     context 'when user is not active' do
       it 'returns false' do
         subject.active = 0
+        allow_any_instance_of(Core::Repository::Customers::Fake).to receive(:valid_for_authentication?) { true }
         expect(subject.valid_for_authentication?).to be_falsey
       end
     end


### PR DESCRIPTION
In development we do not want to check the user exists in the in-memory CRM
Otherwise when you restart the server the in-memory CRM is cleared and previous
registrations will not work

This allows any previously registered user in development to continue to work
