### PR TITLE
call bowndler update in build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -30,9 +30,9 @@ echo "Running Bower cache clean"
 echo "----"
 bower cache clean
 
-echo "Running Bower install (via bowndler)"
+echo "Running Bower update (via bowndler)"
 echo "----"
-bowndler install --production --config.interactive=false
+bowndler update --production --config.interactive=false
 
 echo "Precompiling assets"
 echo "----"


### PR DESCRIPTION
We're missing latest css/assets from dough despite using the latest dough-ruby, it seems to still be loading 3.x in the build output. Hopefully this will fix the problem.

Will this change cause any problems?
