### PR TITLE
precompile assets requires MAS_RAILS_SECRET_TOKEN

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -5,4 +5,4 @@ test:
   secret_key_base: feb8b387ecb54f93a2d34c5be13283e043bbe34412c35c919ac8e1fe9e60131fc2f320d55700f89c5f0abf14bbfda345c93ed3e9f5d0c9683282f25938e190fc
 
 production:
-  secret_key_base: <%= ENV['MAS_RAILS_SECRET_TOKEN'] %>
+  secret_key_base: <%= ENV['MAS_RAILS_SECRET_TOKEN'] || 'blank' %>


### PR DESCRIPTION
This is needed by devise which was previously not loaded as behind
feature toggles

assets:precompile rake task does not seem to set this variable

I'm hoping this will fix the build
