### PR TITLE
Remove validates_timeliness

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,6 @@ gem 'rouge'
 gem 'rubytree'
 gem 'statsd-ruby'
 gem 'uglifier', '>= 1.3.0'
-gem 'validates_timeliness'
 
 gem 'budget_planner', '~> 4.0'
 gem 'car_cost_tool', '~> 1.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -547,7 +547,6 @@ GEM
     thread_safe (0.3.4)
     tilt (1.4.1)
     timecop (0.7.1)
-    timeliness (0.3.7)
     timers (1.1.0)
     treetop (1.4.15)
       polyglot
@@ -571,8 +570,6 @@ GEM
     validate_url (1.0.0)
       activemodel (>= 3.0.0)
       addressable
-    validates_timeliness (3.0.14)
-      timeliness (~> 0.3.6)
     vcr (2.9.2)
     warden (1.2.3)
       rack (>= 1.0)
@@ -676,6 +673,5 @@ DEPENDENCIES
   timecop
   uglifier (>= 1.3.0)
   unicorn-rails
-  validates_timeliness
   vcr
   webmock

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,6 +18,7 @@ class User < ActiveRecord::Base
   before_validation :uppercase_post_code
 
   validates_with Validators::Email, attributes: [:email]
+  validates_with Validators::DateOfBirth, attributes: [:date_of_birth]
   validates :email, uniqueness: true
   validates :post_code, presence: true,
                         format: { with: /\A[A-Z]{1,2}\d{1,2}[A-NP-Z]? ?\d[A-Z]{2}\z/, if: 'post_code.present?' },
@@ -31,7 +32,6 @@ class User < ActiveRecord::Base
                         allow_blank: true,
                         length: { maximum: 24 }
   validates :gender, inclusion: { in: %w(female male) }, allow_nil: true
-  validates :date_of_birth, timeliness: { before: Date.today, allow_nil: true, type: :date }
   validates :age_range, inclusion: { in: VALID_AGE_RANGES }, allow_nil: true
 
   before_save :fake_send_confirmation_email

--- a/lib/validators.rb
+++ b/lib/validators.rb
@@ -1,5 +1,6 @@
 module Validators
   extend ActiveSupport::Autoload
 
+  autoload :DateOfBirth
   autoload :Email
 end

--- a/lib/validators/date_of_birth.rb
+++ b/lib/validators/date_of_birth.rb
@@ -1,0 +1,13 @@
+module Validators
+  class DateOfBirth < ActiveModel::EachValidator
+    def validate_each(record, attribute, value)
+      if value.nil?
+        original = record.attributes_before_type_cast[attribute.to_s]
+        record.errors.add(attribute, 'invalid date') if original.present?
+        return
+      end
+
+      record.errors.add(attribute, 'must be in the past') unless value.past?
+    end
+  end
+end


### PR DESCRIPTION
This library has been abandoned, has been producing deprecation warnings and is only used to validate a single field so remove it and perform the validation ourselves.

This is of arguable value but the deprecation warnings were annoying me. Also, the validator is only tested by the model specs.

Any opinions?
