### PR TITLE
Track newsletter sign-ups

### DIFF
--- a/app/views/newsletter_subscriptions/show.js.erb
+++ b/app/views/newsletter_subscriptions/show.js.erb
@@ -4,6 +4,14 @@
       errorClass = 'is-errored';
 
   <% if @success %>
+    require(['common'], function (MAS) {
+      MAS.publish('analytics:trigger', {
+        category: 'Newsletter SignUp',
+        event: 'Click',
+        label: 'Successful'
+      });
+    });
+
     $newsletterForm
       .attr({'role':'alert', 'aria-live': 'polite'})
       .removeClass(errorClass)
@@ -11,6 +19,14 @@
 
     $newsletterInput.attr({'aria-invalid' : false });
   <% else %>
+    require(['common'], function (MAS) {
+      MAS.publish('analytics:trigger', {
+        category: 'Newsletter SignUp',
+        event: 'Click',
+        label: 'Not successful'
+      });
+    });
+
     var newsletterErrorID = 'newsletter_error',
         $error;
 


### PR DESCRIPTION
This will fix the issue with the sign-up form being submitted by Google Tag Manager
even though our JS tries to prevent the page refresh. The tag will need to be removed
from GTM when this goes live.
