### PR TITLE
Delete duplicate Cucumber Rake tasks

### DIFF
--- a/lib/tasks/cucumber.rake
+++ b/lib/tasks/cucumber.rake
@@ -1,6 +1,11 @@
 begin
   require 'cucumber/rake/task'
 
+  # cucumber tasks are also defined in some of the the engines causing
+  # the features to be run multiple times, delete these duplicates
+  tasks = Rake.application.instance_variable_get('@tasks')
+  tasks.reject! { |task, deps| task =~ /cucumber/ }
+
   namespace :cucumber do
     ::Cucumber::Rake::Task.new({ ok: 'test:prepare' },
                                'Run features that should pass') do |t|


### PR DESCRIPTION
If you grep though [the output of a test run](https://go.test.moneyadviceservice.org.uk/go/files/responsive_commit/1387/test_and_build/1/test/cruise-output/console.log) for _Feature: View an action plan_ you will see that **it's being run 4 times**, along with the other features.

When you check where the Cucumber Rake tasks are being defined you can see that as well as in `frontend` they are also defined in `mortgage_calculator`, `savings_calculator` and `mas-feedback`, hence the multiple runs:

```
$ rake -W cucumber | grep all
rake cucumber:all                   /Users/swilkin/code/money_advice_service/frontend/.bundle/ruby/2.1.0/gems/mortgage_calculator-1.0.1.585/lib/tasks/cucumber.rake:36:in `block in <top (required)>'
rake cucumber:all                   /Users/swilkin/code/money_advice_service/frontend/.bundle/ruby/2.1.0/gems/savings_calculator-1.0.0.129/lib/tasks/cucumber.rake:36:in `block in <top (required)>'
rake cucumber:all                   /Users/swilkin/code/money_advice_service/frontend/.bundle/ruby/2.1.0/gems/mas-feedback-1.0.1.41/lib/tasks/cucumber.rake:36:in `block in <top (required)>'
rake cucumber:all                   /Users/swilkin/code/money_advice_service/frontend/lib/tasks/cucumber.rake:24:in `block in <top (required)>'
```

This change ensures these tasks are only defined and therefore run, once.
