### PR TITLE
Make Cucumber detect missing translations

### DIFF
--- a/features/support/missing_translations.rb
+++ b/features/support/missing_translations.rb
@@ -1,0 +1,47 @@
+module FlagMissingTranslations
+  @missing_translations_should_fail = false
+  @missing_translations = []
+
+  class << self
+    include Capybara::DSL
+
+    def format_missing_translations(missing_translations = @missing_translations)
+      missing_translations.flatten.map do |translation|
+        key = translation[:title].split(': ').last
+        "Missing Translation: #{key}"
+      end.uniq
+    end
+
+    def missing_translations_should_fail?
+      @missing_translations_should_fail
+    end
+
+    def after_scenario
+      translation_missing_elems = all('.translation_missing').to_a
+      if translation_missing_elems.any?
+        @missing_translations << translation_missing_elems
+
+        if missing_translations_should_fail?
+          fail format_missing_translations(translation_missing_elems).join("\n")
+        end
+      end
+    end
+
+    def at_exit
+      if @missing_translations.any?
+        formatted_missing_translations = format_missing_translations
+
+        $stderr.puts "\n"
+        $stderr.puts '-------------------------------------------------------------'.color(:cyan)
+        $stderr.puts "There are #{formatted_missing_translations.length} untranslated strings. Please check your locales:".color(:cyan)
+        $stderr.puts '-------------------------------------------------------------'.color(:cyan)
+        $stderr.puts "\n"
+        $stderr.puts formatted_missing_translations.join("\n").color(:red)
+        $stderr.puts "\n"
+      end
+    end
+  end
+end
+
+After { FlagMissingTranslations.after_scenario }
+at_exit { FlagMissingTranslations.at_exit }


### PR DESCRIPTION
Hi all.

Came across [this gist.](https://gist.github.com/oriolgual/1067007) today, and thought it might be useful here.

I've cleaned it up to try to keep as much as possible out of the global scope, but I'm not too experienced with Cucumber so if I'm diverging from the idioms feel free to point it out. I also added a few minor things like colour and outputting to STDERR. Thinking about extracting this to a Gem so it can be used in the engines also.

At the moment it doesn't fail tests for missing translations, but the functionality is there and I'd recommend enabling it.

It currently flags up one missing translation: `cy.home.show.view_all_link_expanded`
