### PR TITLE
Update tools to pin to dough 4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,7 +56,7 @@ GEM
     ast (2.0.0)
     astrolabe (1.3.0)
       parser (>= 2.2.0.pre.3, < 3.0)
-    autoprefixer-rails (3.1.2.20141016)
+    autoprefixer-rails (4.0.1.1)
       execjs
     bcrypt (3.1.7)
     better_errors (1.1.0)
@@ -99,8 +99,8 @@ GEM
       capybara (>= 1.0, < 3)
       colorize
       launchy
-    car_cost_tool (1.0.3.94)
-      dough-ruby
+    car_cost_tool (1.0.3.96)
+      dough-ruby (~> 4.0)
       font-awesome-rails (~> 4.1)
       nokogiri
       rails (~> 4.1)
@@ -207,7 +207,7 @@ GEM
     dotenv (0.10.0)
     dotenv-rails (0.10.0)
       dotenv (= 0.10.0)
-    dough-ruby (4.0.0.222)
+    dough-ruby (4.0.0.224)
       activesupport
       rails (>= 3.2)
       sass-rails
@@ -361,7 +361,7 @@ GEM
       actionpack (>= 3.0.0)
     method_source (0.8.2)
     mime-types (1.25.1)
-    mini_portile (0.6.0)
+    mini_portile (0.6.1)
     minitest (5.4.3)
     modernizr-rails (2.6.3)
     mortgage_calculator (1.1.0.590)
@@ -379,10 +379,10 @@ GEM
     mysql2 (0.3.15)
     net-http-digest_auth (1.4)
     net-http-persistent (2.9.4)
-    netrc (0.7.7)
+    netrc (0.9.0)
     newrelic_rpm (3.9.5.251)
-    nokogiri (1.6.3.1)
-      mini_portile (= 0.6.0)
+    nokogiri (1.6.5)
+      mini_portile (~> 0.6.0)
     ntlm-http (0.1.1)
     nunes (0.3.1)
     opening_hours (0.0.7)
@@ -436,7 +436,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (2.0.0)
     raindrops (0.13.0)
-    rake (10.3.2)
+    rake (10.4.2)
     rb-fsevent (0.9.4)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
@@ -495,14 +495,14 @@ GEM
     rubyzip (1.1.6)
     safe_yaml (1.0.3)
     sass (3.2.19)
-    sass-rails (4.0.4)
+    sass-rails (4.0.5)
       railties (>= 4.0.0, < 5.0)
       sass (~> 3.2.2)
-      sprockets (~> 2.8, < 2.12)
+      sprockets (~> 2.8, < 3.0)
       sprockets-rails (~> 2.0)
-    savings_calculator (1.1.0.130)
+    savings_calculator (1.1.0.131)
       autoprefixer-rails
-      dough-ruby
+      dough-ruby (~> 4.0)
       jquery-rails
       mas-fonts
       mas-frontend-helpers
@@ -530,12 +530,12 @@ GEM
       spring (>= 0.9.1)
     spring-commands-rspec (1.0.2)
       spring (>= 0.9.1)
-    sprockets (2.11.3)
+    sprockets (2.12.3)
       hike (~> 1.2)
       multi_json (~> 1.0)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
-    sprockets-rails (2.2.1)
+    sprockets-rails (2.2.2)
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)


### PR DESCRIPTION
Updates `car_cost_tool` and `savings_calculator` to ensure they're pinned to Dough 4.x before we merge https://github.com/moneyadviceservice/dough/pull/208
