### PR TITLE
Make missing translations raise exceptions.

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -44,6 +44,9 @@ Rails.application.configure do
   config.raise_feedback_delivery_errors = false
   config.article_feedback_email   = 'content.feedback@moneyadviceservice.org.uk'
   config.technical_feedback_email = 'matt.lucht@moneyadviceservice.org.uk'
+
+  # Missing translations should raise exceptions
+  config.action_view.raise_on_missing_translations = true
 end
 
 WebMock.disable_net_connect!(allow_localhost: true)


### PR DESCRIPTION
Discussed as preferable to #819 

This fails a bunch of tests that we'll need to get fixed before we merge this.

I'll be following those up. Currently, these are missing:

```
cy.home.show.view_all_link_expanded
```
