### PR TITLE
Remove 'cms' suffix from env variable mas cms url

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 MAS_PUBLIC_WEBSITE_URL=https://www.moneyadviceservice.org.uk/:locale/
-MAS_CMS_URL=http://localhost:3000/cms/
+MAS_CMS_URL=http://localhost:3000/
 MAS_CONTENT_SERVICE_URL=http://localhost:8080/content-service/
 GOOGLE_API_KEY=AIzaSyCydfZlpTZlIUUUSbtab5t0oOE-y1GzHy0
 GOOGLE_API_CX_EN=011931388747222259444:razn90vopwc


### PR DESCRIPTION
I was testing the preview article and the article itself locally with CMS and frontend application and I saw that I need to remove this cms to work. So let's change that in the origin :).
