### PR TITLE
Update to latest cream

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,10 +151,9 @@ GEM
       compass (>= 0.12.2)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
-    cream (0.0.3)
+    cream (0.0.4)
       faraday (~> 0.8.7)
       faraday_middleware (~> 0.9.0)
-      hashie (~> 2.0.5)
       mechanize (= 2.5.1)
     css_parser (1.3.5)
       addressable


### PR DESCRIPTION
`advice_plans` and `mas-mailer` still depend on `hashie` but it's a step closer to getting it removed from this app.
