### PR TITLE
Hiding menu on debt management

### DIFF
--- a/app/controllers/debt_management_controller.rb
+++ b/app/controllers/debt_management_controller.rb
@@ -7,6 +7,10 @@ class DebtManagementController < ApplicationController
   def faq
   end
 
+  def display_menu_button_in_header?
+    false
+  end
+
   def hide_contact_panels?
     true
   end


### PR DESCRIPTION
Otherwise we get JS errors on small view when Menu button is pressed (as there is no Menu).
