### PR TITLE
Reinstate the + icon on .icon--toggle

### DIFF
--- a/app/assets/stylesheets/components/common/_icon.scss
+++ b/app/assets/stylesheets/components/common/_icon.scss
@@ -234,14 +234,14 @@
 
 .icon--plus {
   background-position: -685px -73px;
-  width: 20px;
+  width: 16px;
   height: 20px;
 }
 
 .icon--minus {
   background-position: -742px -73px;
-  width: 20px;
-  height: 20px;
+  width: 16px;
+  height: 16px;
 }
 
 .icon--home {

--- a/app/assets/stylesheets/components/common/_icon_2x.scss
+++ b/app/assets/stylesheets/components/common/_icon_2x.scss
@@ -116,14 +116,14 @@
 
   .icon--plus {
     background-position: -339px -55px;
-    width: 20px;
+    width: 16px;
     height: 20px;
   }
 
   .icon--minus {
     background-position: -367px -55px;
-    width: 20px;
-    height: 20px;
+    width: 16px;
+    height: 16px;
   }
 
   .icon--home {

--- a/app/assets/stylesheets/components/dough_theme/collapsable/_collapsable.scss
+++ b/app/assets/stylesheets/components/dough_theme/collapsable/_collapsable.scss
@@ -9,28 +9,16 @@
 
   .icon--toggle {
     background-position: -205px -75px;
-    width: 18px;
-    height: 16px;
     @include device-pixel-ratio() {
       background-position: -205px -10px;
     }
   }
 
-  .js & {
-
-  }
-
-  &.is-on {
-
-  }
-
   &.is-off {
     .icon--toggle {
-      background-position: -238px -76px;
-      width: 18px;
-      height: 12px;
+      background-position: -685px -73px;
       @include device-pixel-ratio() {
-        background-position: -238px -10px;
+        background-position: -339px -55px;
       }
     }
   }


### PR DESCRIPTION
Affects Category landing pages (https://www.moneyadviceservice.org.uk/en/categories/budgeting-and-managing-money) that are using Collapsable. Also tidies up `_icon.scss` and `_icon_2x.scss` by removing duplicate height/width and some empty selectors.