### PR TITLE
Revert "festive open hours"

### DIFF
--- a/app/views/shared/_contact_panels.html.erb
+++ b/app/views/shared/_contact_panels.html.erb
@@ -27,9 +27,11 @@
           </div>
         </div>
 
-        <div class="t-chat-opening-times">
-          <%= t('contact_panels.chat.festive_html') %>
-        </div>
+        <ul class="t-chat-opening-times contact-panel__list unstyled-list">
+          <% chat_opening_hours.periods.each do |period| %>
+            <li class="contact-panel__additional-info"><%= period.html_safe %></li>
+          <% end %>
+        </ul>
 
         <% if translation?('contact_panels.chat.smallprint') %>
           <p class="smallprint t-welsh-smallprint">* <%= t('contact_panels.chat.smallprint') %></p>
@@ -52,7 +54,7 @@
             <%= t('contact.telephone_number') %></a>
         </p>
 
-        <%= t('contact_panels.call_us.festive_html') %>
+        <%= t('contact_panels.call_us.opening_times_html') %>
 
         <p class="smallprint">* <%= t('contact_panels.call_us.smallprint') %></p>
       </div>

--- a/app/views/static_pages/contact_us.html.erb
+++ b/app/views/static_pages/contact_us.html.erb
@@ -133,17 +133,11 @@
 
       <%= heading_tag 'Our opening hours are', level: 2, class: 'heading-extra-small' %>
 
-      <p>The Money Advice Service will be running a reduced service over the Christmas period:</p>
-
       <ul class="unstyled-list">
-        <li>24th December, web chat and call centre available 9am to 5pm</li>
-        <li>25th December, web chat and call centre closed</li>
-        <li>26th December, web chat available 9am to 5pm</li>
-        <li>31st December, web chat and call centre available 9am to 5pm</li>
-        <li>1st January, web chat and call centre closed</li>
+        <li class="unstyled-list__item">Monday to Friday, 8am to 8pm</li>
+        <li class="unstyled-list__item">Saturday, 9am to 1pm</li>
+        <li class="unstyled-list__item">Sunday and Bank Holidays, closed</li>
       </ul>
-
-      <p>We will be open during our standard hours on all other days.</p>
 
       <%= heading_tag 'Call our Money Advice Line on', level: 2, class: 'heading-extra-small' %>
       <ul class="unstyled-list">

--- a/app/views/static_pages/cysylltu_a_ni.html.erb
+++ b/app/views/static_pages/cysylltu_a_ni.html.erb
@@ -133,18 +133,11 @@
       </p>
 
       <%= heading_tag 'Ein Horiau agor yw', level: 2, class: 'heading-extra-small' %>
-
-      <p>Bydd y Gwasanaeth Cynghori Ariannol yn rhedeg gwasanaeth cyfyngedig dros gyfnod y Nadolig.</p>
-
       <ul class="unstyled-list">
-        <li>24 Rhagfyr, gwe-sgwrs a'r ganolfan alwadau ar gael 9am hyd at 5pm</li>
-        <li>25 Rhagfyr, gwe-sgwrs a'r ganolfan alwadau wedi cau</li>
-        <li>26 Rhagfyr, gwe-sgwrs ar gael 9am hyd at 5pm</li>
-        <li>31 Rhagfyr, gwe-sgwrs a'r ganolfan alwadau ar gael 9am hyd at 5pm</li>
-        <li>1 Ionawr, gwe-sgwrs a'r ganolfan alwadau wedi cau</li>
+        <li class="unstyled-list__item">Llun i Wener, 8am i 8pm</li>
+        <li class="unstyled-list__item">Dydd Sadwrn, 9am i 1pm</li>
+        <li class="unstyled-list__item">Dydd Sul a Gwyliau Banc, ar gau</li>
       </ul>
-
-      <p>Byddwn ar agor yn ol yr arfer ar unrhyw ddiwrnod arall.</p>
 
       <%= heading_tag 'Ffoniwch ein Llinell Cynghori Ariannol ar', level: 2, class: 'heading-extra-small' %>
       <ul class="unstyled-list">

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,8 +27,6 @@ module Frontend
     config.chat_opening_hours = OpeningHours.new('8:00 AM', '10:00 PM')
     config.chat_opening_hours.update(:sat, '09:00 AM', '10:00 PM')
     config.chat_opening_hours.update(:sun, '10:00 AM', '10:00 PM')
-    config.chat_opening_hours.closed("Dec 25, 2014")
-    config.chat_opening_hours.closed("Jan 1, 2015")
 
     config.middleware.use 'CaptureRequestId' # capture X-Request-ID header
     config.middleware.use 'OverrideHead' # convert HEAD requests to GET and return an empty body

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -112,7 +112,6 @@ cy:
   contact_panels:
     chat:
       title: Gwe-sgwrs
-      festive_html: <p>Bydd y Gwasanaeth Cynghori Ariannol yn rhedeg gwasanaeth cyfyngedig dros gyfnod y Nadolig.</p><p>I weld ein horiau agor dros y Nadolig, ewch i'n tudalen <a href="https://www.moneyadviceservice.org.uk/cy/static/cysylltu-a-ni">cysylltu a ni</a>.</p>
       available:
         call_to_action: Lansio sgwrs
         description: A oes gennych chi gwestiwn? Bydd ein cynghorwyr yn eich arwain i'r cyfeiriad cywir.
@@ -132,7 +131,6 @@ cy:
     call_us:
       title: Ffoniwch ni
       description: Ffoniwch ni am gyngor ariannol am ddim a diduedd.
-      festive_html: <p>Bydd y Gwasanaeth Cynghori Ariannol yn rhedeg gwasanaeth cyfyngedig dros gyfnod y Nadolig.</p><p>I weld ein horiau agor dros y Nadolig, ewch i'n tudalen <a href="https://www.moneyadviceservice.org.uk/cy/static/cysylltu-a-ni">cysylltu a ni</a>.</p>
       opening_times_html: |
         <ul class="contact-panel__list">
           <li class="contact-panel__additional-info">Llun i Wener, 8am i 8pm</li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -110,7 +110,6 @@ en:
   contact_panels:
     chat:
       title: Web chat
-      festive_html: <p>The Money Advice Service will be running a reduced service over the Christmas period.</p><p>For Christmas opening hours, please visit our <a href='https://www.moneyadviceservice.org.uk/en/static/contact-us'>contact us</a> page.</p>
       available:
         call_to_action: Launch chat
         description: Got a question? Our advisers will point you in the right direction.
@@ -129,7 +128,6 @@ en:
     call_us:
       title: Call us
       description: Give us a call for free and impartial money advice.
-      festive_html: <p>The Money Advice Service will be running a reduced service over the Christmas period.</p><p>For Christmas opening hours, please visit our <a href="https://www.moneyadviceservice.org.uk/en/static/contact-us">contact us</a> page.</p>
       opening_times_html: |
         <ul class="contact-panel__list">
           <li class="contact-panel__additional-info">Monday to Friday, 8am to 8pm</li>


### PR DESCRIPTION
Actually reverting the commit rather than the merge commit.  This is to put the normal (non-holiday) hours back in place on the site.
This reverts commit de6d6e82aa848382bd80b908638e68d1e2e69204.