### PR TITLE
mount Retirement Income Options engine

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ gem 'decision_trees', '~> 2.0.0'
 gem 'feedback', '~> 0.3.0'
 gem 'mortgage_calculator', '~> 1.3.5'
 gem 'pensions_calculator', '~> 0.2'
+gem 'rio', git: 'git@github.com:moneyadviceservice/rio.git'
 gem 'savings_calculator', '~> 1.1.0'
 
 group :assets do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,13 @@ GIT
   specs:
     tidy-html5 (0.1.1)
 
+GIT
+  remote: git@github.com:moneyadviceservice/rio.git
+  revision: eab48916be23d5530a87e728a3fcbd8aa07fb279
+  specs:
+    rio (0.0.3)
+      rails (~> 4.1)
+
 GEM
   remote: https://rubygems.org/
   remote: http://gems.test.mas/
@@ -687,6 +694,7 @@ DEPENDENCIES
   psych (>= 2.0.5)
   rack-livereload
   rails (= 4.1.8)
+  rio!
   rouge
   rspec-rails (~> 3.0)
   rspec_junit_formatter

--- a/app/controllers/rio_controller.rb
+++ b/app/controllers/rio_controller.rb
@@ -1,0 +1,7 @@
+class RioController < EmbeddedToolsController
+  protected
+
+  def category_id
+    'managing-money'
+  end
+end

--- a/config/initializers/rio.rb
+++ b/config/initializers/rio.rb
@@ -1,0 +1,1 @@
+Rio.parent_controller = '::RioController'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,6 +73,11 @@ Rails.application.routes.draw do
     mount PensionsCalculator::Engine => '/tools/:tool_id',
           constraints: ToolMountPoint.for(:pensions_calculator)
 
+    Feature.with(:rio) do
+      mount Rio::Engine => '/tools/:tool_id',
+          constraints: ToolMountPoint.for(:rio)
+    end
+
     Feature.with(:savings_calculator) do
       mount SavingsCalculator::Engine => '/tools/:tool_id',
           constraints: ToolMountPoint.for(:savings_calculator)

--- a/lib/tool_mount_point.rb
+++ b/lib/tool_mount_point.rb
@@ -7,6 +7,7 @@ require_relative '../lib/tool_mount_point/debt_free_day_calculator'
 require_relative '../lib/tool_mount_point/decision_trees'
 require_relative '../lib/tool_mount_point/mortgage_calculator'
 require_relative '../lib/tool_mount_point/pensions_calculator'
+require_relative '../lib/tool_mount_point/rio'
 require_relative '../lib/tool_mount_point/savings_calculator'
 
 module ToolMountPoint

--- a/lib/tool_mount_point/rio.rb
+++ b/lib/tool_mount_point/rio.rb
@@ -1,0 +1,6 @@
+module ToolMountPoint
+  class Rio < Base
+    EN_ID = 'rio'
+    CY_ID = 'rio-welsh'
+  end
+end

--- a/spec/requests/tool_integration/rio_spec.rb
+++ b/spec/requests/tool_integration/rio_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe 'RIO', type: :request, features: [:rio] do
+  %W(
+    /en/tools/#{ToolMountPoint::Rio::EN_ID}
+    /cy/tools/#{ToolMountPoint::Rio::CY_ID}
+  ).each do |path|
+    describe path do
+      before do
+        get path
+      end
+
+      specify { expect(response).to be_ok }
+    end
+  end
+end


### PR DESCRIPTION
- Unfortunately I can't use the gem version and have to add the git version. As there is already a gem named `rio` on rubygems. We are not on a recent enough version of bundler where the source on a gem can be specified
- The `category_id` has yet to be decided and is subject to change