### PR TITLE
Unconstrained engine layout

### DIFF
--- a/app/controllers/rio_controller.rb
+++ b/app/controllers/rio_controller.rb
@@ -1,4 +1,13 @@
 class RioController < EmbeddedToolsController
+  def parent_template
+    if syndicated_tool_request?
+      response.headers['X-Frame-Options'] = 'ALLOWALL'
+      'layouts/engine_syndicated'
+    else
+      'layouts/engine_unconstrained'
+    end
+  end
+
   protected
 
   def category_id

--- a/app/views/layouts/engine.html.erb
+++ b/app/views/layouts/engine.html.erb
@@ -12,7 +12,11 @@
 <% end %>
 
 <%= render layout: 'layouts/unconstrained' do %>
-  <%= yield :engine_content %>
+  <div class="l-constrained">
+    <div class="l-container-tool">
+      <%= yield :engine_content %>
+    </div>
+  </div>
 
   <% if display_category_directory? %>
     <div class="l-tool-nav">

--- a/app/views/layouts/engine_unconstrained.html.erb
+++ b/app/views/layouts/engine_unconstrained.html.erb
@@ -13,15 +13,4 @@
 
 <%= render layout: 'layouts/unconstrained' do %>
   <%= yield :engine_content %>
-
-  <% if display_category_directory? %>
-    <div class="l-tool-nav">
-      <div class="l-constrained">
-        <section class="tool-nav">
-          <%= render 'shared/directory',
-                     items: category_navigation, heading_level: 4 %>
-        </section>
-      </div>
-    </div>
-  <% end %>
 <% end %>


### PR DESCRIPTION
- This allows engines to be not width constrained and use the full width of the page.
- Rio will use this