### PR TITLE
Add blog links

### DIFF
--- a/app/views/shared/_directory.html.erb
+++ b/app/views/shared/_directory.html.erb
@@ -8,4 +8,11 @@
     <p class="directory__description"><%= item.description %></p>
   </div>
   <% end %>
+  <div class="directory__item">
+    <%= heading_tag(level: heading_level ||= 3, class: 'directory__title') do %>
+      <%= link_to t("home.show.blog_title"), t("footer.blog_link"), class: 'directory__link' %>
+    <% end %>
+
+    <p class="directory__description"><%= t("home.show.blog_description") %></p>
+  </div>
 </div>

--- a/app/views/shared/_footer_primary.html.erb
+++ b/app/views/shared/_footer_primary.html.erb
@@ -35,7 +35,7 @@
           </li>
 
           <li class="footer-primary__list-item">
-            <a href="<%= t('footer.news_link') %>"><%= t('footer.news') %></a>
+            <a href="<%= t('footer.blog_link') %>"><%= t('footer.blog') %></a>
           </li>
         </ul>
       </nav>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -243,7 +243,7 @@ cy:
     partners: Partneriaid
     partners_link: /cy/categories/Partners
     blog: Eich blog Cyngor Ariannol
-    blog_link: https://blog.moneyadviceservice.org
+    blog_link: https://blog.moneyadviceservice.org.uk
     tools_and_resources: Offer a chyfrifianellau
     tools_and_resources_link: /cy/categories/tools-and-calculators
     site_map: Map safle

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -197,6 +197,8 @@ cy:
           text: Ble i gael cyngor am ddim ynghylch dyled
           image: free-debt-advice.jpg
           content: Cewch wybod ble i gael cymorth cyfrinachol am ddim os ydych yn cael trafferthion â dyled.
+      blog_title: Eich blog Cyngor Ariannol
+      blog_description: Awgrymiadau, newyddion a safbwyntiau ar bopeth sydd ynghlwm ag arian, o forgeisi a chynilion i gyllido a budd-daliadau.
 
   opt_out:
     title: Edrychwch ar hyn ar ein gwefan flaenorol
@@ -240,8 +242,8 @@ cy:
     media_centre_link: /cy/static/canolfan-gyfryngau
     partners: Partneriaid
     partners_link: /cy/categories/Partners
-    news: Newyddion ac erthyglau
-    news_link: /cy/news
+    blog: Eich blog Cyngor Ariannol
+    blog_link: https://blog.moneyadviceservice.org
     tools_and_resources: Offer a chyfrifianellau
     tools_and_resources_link: /cy/categories/tools-and-calculators
     site_map: Map safle

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -242,7 +242,7 @@ en:
     partners: Partners
     partners_link: /en/categories/partners
     blog: Your Money Advice blog
-    blog_link: https://blog.moneyadviceservice.org
+    blog_link: https://blog.moneyadviceservice.org.uk
     tools_and_resources: Tools & calculators
     tools_and_resources_link: /en/categories/tools-and-calculators
     site_map: Sitemap

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -195,6 +195,8 @@ en:
           text: Where to go to get free debt advice
           image: free-debt-advice.jpg
           content: Find out where you can get free, confidential help if you are struggling with debt.
+      blog_title: Your Money Advice blog
+      blog_description: Tips, news and views on all things money from mortgages and savings to budgeting and benefits
 
   opt_out:
     title: View on our previous website
@@ -239,8 +241,8 @@ en:
     media_centre_link: /en/static/media-centre
     partners: Partners
     partners_link: /en/categories/partners
-    news: News & features
-    news_link: /en/news
+    blog: Your Money Advice blog
+    blog_link: https://blog.moneyadviceservice.org
     tools_and_resources: Tools & calculators
     tools_and_resources_link: /en/categories/tools-and-calculators
     site_map: Sitemap


### PR DESCRIPTION
Adds links to the blog in the category section of the home page and primary footer. This is hard coded for now as the blog is going live on Monday and there is no easy way (or know one knows how) to add a new category in the Category Manager Application. Since that category data is being migrated to the CMS in the next week, this will also be added when that is done so it's dynamic like the others.