### PR TITLE
add syndicated layout

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,8 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   add_flash_types :success
 
+  layout :check_syndicated_layout
+
   include Authentication
   include Chat
   include Localisation
@@ -70,6 +72,14 @@ class ApplicationController < ActionController::Base
   end
 
   private
+
+  def check_syndicated_layout
+    if syndicated_tool_request?
+      'syndicated'
+    else
+      'application'
+    end
+  end
 
   def category_tree
     @category_tree ||= Core::CategoryTreeReader.new.call

--- a/app/views/layouts/syndicated.html.erb
+++ b/app/views/layouts/syndicated.html.erb
@@ -1,0 +1,5 @@
+<%= render layout: 'layouts/base' do %>
+  <a class="skip-to-link" href="<%= t('footer.accessibility_link') %>">Accessibility Statement</a>
+
+  <%= yield %>
+<% end %>

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,37 @@
+RSpec.describe ApplicationController, type: :controller do
+  context 'when syndicated request' do
+    controller do
+      def syndicated_tool_request?
+        true
+      end
+
+      def index
+        render inline: 'example', layout: true
+      end
+    end
+
+    subject { get :index }
+
+    it 'renders syndicated layout' do
+      expect(subject).to render_template('layouts/syndicated')
+    end
+  end
+
+  context 'when not a syndicated request' do
+    controller do
+      def syndicated_tool_request?
+        false
+      end
+
+      def index
+        render inline: 'example', layout: true
+      end
+    end
+
+    subject { get :index }
+
+    it 'renders application layout' do
+      expect(subject).to render_template('layouts/application')
+    end
+  end
+end


### PR DESCRIPTION
The requirement is when budget planner (or other tool) is syndicated (in an iframe) the user needs to be able to  authenticate. For example they want to save their data which then sends the user to a login screen. The old behaviour is shown in the screenshot below which uses public website and the old budget planner.

![old-bp-login](https://cloud.githubusercontent.com/assets/92580/5802942/a3962876-9ff1-11e4-95b3-62461e2657f1.png)

The light box/pop up dialog has been removed and is no longer available. I'm also not aware of such a dough component existing to replace it. Instead we send the user straight to the login page and then redirect them back to where they came from. See below..

![sign-in-with](https://cloud.githubusercontent.com/assets/92580/5803029/89c76454-9ff2-11e4-9e7e-f5114c16c05f.png)

However we do not want to render the entire site with header and footer when we are in the iframe we want to render the minimal amount in the iframe. The pull request will make the login page look like below...

![sign-in-without](https://cloud.githubusercontent.com/assets/92580/5803049/b0fa9212-9ff2-11e4-85ff-524effa9e39d.png)

Changes will need to be made to `scripts` repo to expose `/en|cy/users` when navigating this url from the `partner-tools` subdomain.

Is there a nicer way to implement this?
