### PR TITLE
fix want to talk panel in Safari

### DIFF
--- a/app/assets/stylesheets/components/page_specific/_want_to_talk.scss
+++ b/app/assets/stylesheets/components/page_specific/_want_to_talk.scss
@@ -19,6 +19,7 @@
 
 .want-to-talk--fixed {
   position: fixed;
+  position: -webkit-sticky;
   top: 0;
 }
 


### PR DESCRIPTION
In safari this was overlapping with page content when scolling down the
page

Tested in Chrome, Safari, Firefox, IE8, IE9