### PR TITLE
Make failing cucumber fail CI

### DIFF
--- a/config/initializers/disable_minitest_hook.rb
+++ b/config/initializers/disable_minitest_hook.rb
@@ -1,0 +1,16 @@
+# Minitest hijacks the exit code set by cucumber.
+# Minitest.autorun sets up a series of at_exit hooks that
+# interfere with it.
+
+# In certain circumstances, this will make `rake cucumber`
+# exit with 0 every time, making our build pass erroneously.
+
+# Since we don't use minitest in any capacity and it seems
+# to only be here to make life interesting - we're going to
+# patch it out.
+
+if defined? Minitest
+  Minitest.module_eval do
+    def self.autorun; end
+  end
+end

--- a/test.sh
+++ b/test.sh
@@ -19,4 +19,4 @@ bowndler install --production --config.interactive=false
 
 RAILS_ENV=development rake karma:install karma:run_once
 rake spec
-bundle exec cucumber
+rake cucumber

--- a/test.sh
+++ b/test.sh
@@ -19,4 +19,4 @@ bowndler install --production --config.interactive=false
 
 RAILS_ENV=development rake karma:install karma:run_once
 rake spec
-rake cucumber
+bundle exec cucumber


### PR DESCRIPTION
Call cucumber directly to make it return a non-zero exit status.

Previously, running `test.sh` would run `rake cucumber`, which always returns a zero exit code (for some reason). This meant test failures wouldn't fail CI.