### PR TITLE
Remove CI rspec config to the main file and move to CI test file

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,9 +1,2 @@
 --color
 --require spec_helper
---format html
---out tmp/spec.html
---format RspecJunitFormatter
---out tmp/spec.xml
---format progress
---profile
---deprecation-out log/rspec_deprecations.txt

--- a/test.sh
+++ b/test.sh
@@ -18,5 +18,5 @@ rm -r vendor/assets/bower_components
 bowndler install --production --config.interactive=false
 
 RAILS_ENV=development rake karma:install karma:run_once
-rake spec
+bundle exec rspec spec --format html --out tmp/spec.html --format RspecJunitFormatter --profile --format progress --deprecation-out log/rspec_deprecations.txt
 rake cucumber


### PR DESCRIPTION
Each time that you run the specs, they run with the build config and you need to overwrite. So let's move this config to the CI test script and add to .rspec only the default config that everybody uses. 