### PR TITLE
Timelines update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,8 @@ gem 'pensions_calculator', '~> 0.2'
 gem 'rio', git: 'git@github.com:moneyadviceservice/rio.git'
 gem 'savings_calculator', '~> 1.1.0'
 
+gem 'timelines', '>= 1.2.0', git: 'git@github.com:moneyadviceservice/timelines.git'
+
 group :assets do
   gem 'autoprefixer-rails'
   gem 'coffee-rails', '~> 4.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,17 @@ GIT
       dough-ruby
       rails (~> 4.1)
 
+GIT
+  remote: git@github.com:moneyadviceservice/timelines.git
+  revision: 68132a4f10f5b9b110cd883f2ff4d234f76bdfe1
+  specs:
+    timelines (1.2.0)
+      bowndler
+      icalendar
+      jquery-rails (>= 3.1.2)
+      mas-feedback
+      mas-templating
+
 GEM
   remote: https://rubygems.org/
   remote: http://gems.test.mas/
@@ -347,6 +358,7 @@ GEM
     i18n (0.7.0)
     i18n-js (3.0.0.mas)
       i18n
+    icalendar (2.2.2)
     interception (0.5)
     jquery-rails (3.1.2)
       railties (>= 3.0, < 5.0)
@@ -722,6 +734,7 @@ DEPENDENCIES
   syslog-logger
   tidy-html5!
   timecop
+  timelines (>= 1.2.0)!
   uglifier (>= 1.3.0)
   unicorn-rails
   vcr

--- a/config/initializers/timelines.rb
+++ b/config/initializers/timelines.rb
@@ -1,0 +1,1 @@
+Timelines.parent_controller = '::EmbeddedToolsController'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,9 +93,8 @@ Rails.application.routes.draw do
     end
 
     Feature.with(:timelines) do
-      mount Timelines::Engine => '/tools/:tool_id/:id',
-        # constraints: ToolMountPoint.for(:timelines)
-            constraints: { tool_id: %r{timelines|llinell-amser} }
+      mount Timelines::Engine => '/tools/:tool_id',
+            constraints: ToolMountPoint.for(:timelines)
     end
 
     if Feature.active?(:agreements)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,6 +92,12 @@ Rails.application.routes.draw do
       get '/tools/:id', to: 'landing_pages#show', constraints: { id: /annuities/ }
     end
 
+    Feature.with(:timelines) do
+      mount Timelines::Engine => '/tools/:tool_id/:id',
+        # constraints: ToolMountPoint.for(:timelines)
+            constraints: { tool_id: %r{timelines|llinell-amser} }
+    end
+
     if Feature.active?(:agreements)
       mount Agreements::Engine => '/agreements'
     end

--- a/lib/tool_mount_point.rb
+++ b/lib/tool_mount_point.rb
@@ -9,6 +9,7 @@ require_relative '../lib/tool_mount_point/mortgage_calculator'
 require_relative '../lib/tool_mount_point/pensions_calculator'
 require_relative '../lib/tool_mount_point/rio'
 require_relative '../lib/tool_mount_point/savings_calculator'
+require_relative '../lib/tool_mount_point/timelines'
 
 module ToolMountPoint
   def self.for(tool)

--- a/lib/tool_mount_point/timelines.rb
+++ b/lib/tool_mount_point/timelines.rb
@@ -1,0 +1,6 @@
+module ToolMountPoint
+  class Timelines < Base
+    EN_ID = 'timelines'
+    CY_ID = 'llinellau-amser'
+  end
+end

--- a/lib/tool_mount_point/timelines.rb
+++ b/lib/tool_mount_point/timelines.rb
@@ -1,6 +1,6 @@
 module ToolMountPoint
   class Timelines < Base
-    EN_ID = 'timelines'
-    CY_ID = 'llinellau-amser'
+    EN_ID = 'baby-money-timeline'
+    CY_ID = 'llinell-amser-arian-babi'
   end
 end

--- a/spec/requests/tool_integration/timelines_spec.rb
+++ b/spec/requests/tool_integration/timelines_spec.rb
@@ -1,0 +1,16 @@
+RSpec.describe 'Timelines', type: :request, features: [:timelines] do
+  %W(
+    /en/tools/#{ToolMountPoint::Timelines::EN_ID}
+    /cy/tools/#{ToolMountPoint::Timelines::CY_ID}
+    /en/tools/#{ToolMountPoint::Timelines::EN_ID}/timeline?date[year]=2014&date[month]=8&date[day]=17
+    /cy/tools/#{ToolMountPoint::Timelines::CY_ID}/timeline?date[year]=2014&date[month]=8&date[day]=17
+  ).each do |path|
+    describe path do
+      before do
+        get path
+      end
+
+      specify { expect(response).to be_ok }
+    end
+  end
+end


### PR DESCRIPTION
Adding timelines engine (moving it from `public_website` repository).

Version specified to be at least 1.2.0.