### PR TITLE
Fixes missing text in TabSelector - Dough issue #214

### DIFF
--- a/app/assets/stylesheets/components/dough_theme/tab_selector/_tab_selector.scss
+++ b/app/assets/stylesheets/components/dough_theme/tab_selector/_tab_selector.scss
@@ -64,6 +64,7 @@
       }
 
       .tab-selector__trigger {
+        @extend %type;
         border-width: 0;
         padding-right: 35px;
         padding-left: 12px;


### PR DESCRIPTION
See #214 for background information.

Same change has been applied on Dough: https://github.com/moneyadviceservice/dough/pull/220

@moneyadviceservice/frontend
