### PR TITLE
Render extra content on corporate articles if partials exists.

### DIFF
--- a/app/controllers/corporate_controller.rb
+++ b/app/controllers/corporate_controller.rb
@@ -1,4 +1,6 @@
 class CorporateController < ArticlesController
+  decorates_assigned :article, with: CorporateDecorator
+
   private
 
   def interactor

--- a/app/decorators/content_item_decorator.rb
+++ b/app/decorators/content_item_decorator.rb
@@ -3,7 +3,7 @@ require 'html_processor'
 class ContentItemDecorator < Draper::Decorator
   decorates_association :categories, with: CategoryDecorator
 
-  delegate :title, :description, :callback_requestable?
+  delegate :title, :type, :slug, :description, :callback_requestable?
 
   def initialize(object, options = {})
     super

--- a/app/decorators/corporate_decorator.rb
+++ b/app/decorators/corporate_decorator.rb
@@ -1,0 +1,26 @@
+class CorporateDecorator < ContentItemDecorator
+  attr_reader :extra_content_path
+  delegate :lookup_context, to: :h
+
+  def initialize(*)
+    super
+
+    @extra_content_path = 'corporate/extra'
+  end
+
+  def extra_content_partial
+    "#{extra_content_path}/#{extra_content_partial_name}"
+  end
+
+  def extra_content?
+    path = Array(extra_content_path)
+
+    lookup_context.template_exists?(extra_content_partial_name, path, true)
+  end
+
+  private
+
+  def extra_content_partial_name
+    slug.underscore
+  end
+end

--- a/app/views/corporate/show.html.erb
+++ b/app/views/corporate/show.html.erb
@@ -1,0 +1,63 @@
+<% content_for(:context_bar) do %>
+  <% if @breadcrumbs.present? %>
+    <%= render 'shared/breadcrumbs', breadcrumbs: @breadcrumbs %>
+  <% elsif article.categories.present? %>
+    <%= render 'shared/related_categories', categories: article.categories %>
+  <% end %>
+<% end %>
+
+<div class="l-article-3col-main editorial">
+  <div class="l-main__row">
+    <main class="l-main__cell-full" role="main" data-dough-newsletter-article="true">
+      <%= heading_tag article.title %>
+
+      <% unless @newsletter_excluded %>
+        <%= render 'shared/news_signup_test' %>
+      <% end %>
+
+      <%= article.content %>
+
+      <%= render article.extra_content_partial if article.extra_content? %>
+
+      <% if Feature.active?(:callback_requester) %>
+        <% if article.callback_requestable? %>
+          <%= render 'callback_requester'  %>
+        <% end %>
+      <% end %>
+
+      <%= render 'previous_and_next' %>
+
+      <div class='related-links--mobile'>
+        <%= render 'articles/related_articles' %>
+      </div>
+
+      <%= render 'shared/related_links', article: @article, categories: related_content %>
+
+      <%= render 'shared/feedback', article: article %>
+    </main>
+  </div>
+</div>
+
+<div class="l-nav l-article-3col-right">
+  <div class='related-links--desktop'>
+    <%= render 'articles/related_articles' %>
+  </div>
+
+  <%= render 'shared/want_to_talk' %>
+</div>
+
+<div class="l-article-3col-left">
+  <%= render 'shared/nav',
+             categories:        category_navigation,
+             active_categories: active_categories
+  %>
+</div>
+
+<% content_for(:alternate_link) do %>
+  <% article.footer_alternate_options.each do |locale, url| %>
+    <%= link_to(url, lang: locale, class: "t-#{locale}-link") do %>
+      <span class="icon icon--globe"></span>
+      <%= t("locales.#{locale}") %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/lib/core/entity/article.rb
+++ b/lib/core/entity/article.rb
@@ -2,7 +2,7 @@ module Core
   class Article < Entity
     Alternate = Struct.new(:title, :url, :hreflang)
 
-    attr_accessor :type, :title, :description, :body, :categories, :related_content
+    attr_accessor :type, :slug, :identifier, :title, :description, :body, :categories, :related_content
     attr_reader :alternates
 
     validates_presence_of :title, :body

--- a/spec/decorators/corporate_decorator_spec.rb
+++ b/spec/decorators/corporate_decorator_spec.rb
@@ -1,0 +1,45 @@
+RSpec.describe CorporateDecorator do
+  include Draper::ViewHelpers
+
+  subject(:decorator) { described_class.decorate(content_item) }
+
+  let(:content_item) { instance_double(Core::Article, id: 'bob', slug: 'syndicated') }
+
+  describe '#extra_content?' do
+    let(:lookup_context) { double }
+
+    before do
+      expect(decorator).to receive(:lookup_context).and_return(lookup_context)
+    end
+
+    context 'when article has partial' do
+      before do
+        expect(lookup_context).to receive(:template_exists?)
+          .with('syndicated', ['corporate/extra'], true)
+          .and_return(true)
+      end
+
+      it 'returns true' do
+        expect(decorator.extra_content?).to be true
+      end
+    end
+
+    context 'when articles does not have partial' do
+      before do
+        expect(lookup_context).to receive(:template_exists?)
+          .with('syndicated', ['corporate/extra'], true)
+          .and_return(false)
+      end
+
+      it 'returns false' do
+        expect(decorator.extra_content?).to be false
+      end
+    end
+  end
+
+  describe '#extra_content_partial' do
+    it 'returns the corporate extra content path' do
+      expect(decorator.extra_content_partial).to eq('corporate/extra/syndicated')
+    end
+  end
+end

--- a/spec/lib/core/entity/article_spec.rb
+++ b/spec/lib/core/entity/article_spec.rb
@@ -21,6 +21,7 @@ module Core
       {
         title:       double,
         description: double,
+        slug:        double,
         body:        double,
         alternates:  [{ title: double, url: double, hreflang: double }],
         categories:  categories,
@@ -250,7 +251,6 @@ module Core
       end
 
       context 'empty related links' do
-
         let(:related_content) { { 'related_links' => [] } }
 
         it 'results in empty list' do


### PR DESCRIPTION
* This is the basic structure of the Partners/Terms and Conditions and other
corporate pages.
* Today CMS doesn't support forms and some other type of dynamic context, so this extra content is needed.