### PR TITLE
Fix pagination style for small devices

### DIFF
--- a/app/assets/stylesheets/components/dough_theme/button/_button.scss
+++ b/app/assets/stylesheets/components/dough_theme/button/_button.scss
@@ -66,8 +66,9 @@
   cursor: pointer;
   padding: 12px 8px;
   height: 52px;
-  min-width: 93px;
+  min-width: 80px;
   vertical-align: middle;
+
   > .icon {
     position: relative;
     top: 5px;

--- a/app/assets/stylesheets/components/dough_theme/pagination_counter/_pagination_counter.scss
+++ b/app/assets/stylesheets/components/dough_theme/pagination_counter/_pagination_counter.scss
@@ -5,5 +5,5 @@
 .pagination__counter {
   @include inline-block;
   vertical-align: middle;
-  margin: 0 $baseline-unit*3;
+  margin: 0 $baseline-unit;
 }

--- a/app/views/search_results/_pagination.html.erb
+++ b/app/views/search_results/_pagination.html.erb
@@ -6,7 +6,7 @@
     <% end %>
   <% end %>
 
-  <p class="t-pagination__counter <% unless search_results.first_page? %>pagination__counter<% end %>">
+  <p class="t-pagination__counter pagination__counter">
     <%= t('search_results.index_with_results.pagination_counter', page_number: search_results.page, total_pages: search_results.number_of_pages) %>
   </p>
 


### PR DESCRIPTION
The current pagination does not work well on small device sizes (awkward wrapping). So I have tightened the button dimensions to fix this.

@moneyadviceservice/frontend 