### PR TITLE
Making latest tools_<generated_asset_hash>.js available as tools.js

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ include FileUtils
 
 Rails.application.load_tasks
 
-Rake::Task["assets:precompile"].enhance do
+Rake::Task['assets:precompile'].enhance do
   Rake::Task[:copy_precompiled_tools_js].invoke
 end
 
@@ -26,13 +26,12 @@ def assets_dir_name
 end
 
 def precompiled_most_recent_tools_js(file_paths)
-  files_found = file_paths.map{|path| File.new(Rails.root.join(path))}
-  sorted_results = files_found.sort{|file1, file2| file2.stat <=> file1.stat}
+  files_found = file_paths.map { |path| File.new(Rails.root.join(path)) }
+  sorted_results = files_found.sort { |file1, file2| file2.stat <=> file1.stat }
   sorted_results.first
 end
 
 def update_tools_js?(precompiled_tools_js, tools_js_location)
-  !File.exists?(tools_js_location) ||
-  (File.exists?(tools_js_location) && !FileUtils.identical?(precompiled_tools_js, tools_js_location))
+  !File.exist?(tools_js_location) ||
+  (File.exist?(tools_js_location) && !FileUtils.identical?(precompiled_tools_js, tools_js_location))
 end
-

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,38 @@
 require_relative 'config/application'
+include FileUtils
 
 Rails.application.load_tasks
+
+Rake::Task["assets:precompile"].enhance do
+  Rake::Task[:copy_precompiled_tools_js].invoke
+end
+
+private
+
+desc 'copy tools_<hash_asset_id>.js to tools.js for embedded tools'
+task :copy_precompiled_tools_js do
+  precompiled_file_paths = Dir.glob(File.join('public', assets_dir_name, 'syndication', 'tools*js'))
+  source_path = precompiled_most_recent_tools_js(precompiled_file_paths)
+  if source_path.present?
+    tools_js_location = File.join('public', assets_dir_name, 'syndication', 'tools.js')
+    if update_tools_js?(source_path, tools_js_location)
+      FileUtils.cp(source_path, tools_js_location)
+    end
+  end
+end
+
+def assets_dir_name
+  Rails.application.config.assets.prefix
+end
+
+def precompiled_most_recent_tools_js(file_paths)
+  files_found = file_paths.map{|path| File.new(Rails.root.join(path))}
+  sorted_results = files_found.sort{|file1, file2| file2.stat <=> file1.stat}
+  sorted_results.first
+end
+
+def update_tools_js?(precompiled_tools_js, tools_js_location)
+  !File.exists?(tools_js_location) ||
+  (File.exists?(tools_js_location) && !FileUtils.identical?(precompiled_tools_js, tools_js_location))
+end
+

--- a/app/assets/javascripts/syndication/tools.js.coffee
+++ b/app/assets/javascripts/syndication/tools.js.coffee
@@ -1,11 +1,7 @@
 #= require ./tool_syndication
 #= require ./resizer
 
-###
- I am being served from frontend
-###
-
-console.log "I am being served from frontend"
+served_from_frontend = "Served from frontend"
 
 @masConfig =
   targetSelector: "mas-widget"

--- a/app/assets/javascripts/syndication/tools.js.coffee
+++ b/app/assets/javascripts/syndication/tools.js.coffee
@@ -5,6 +5,8 @@
  I am being served from frontend
 ###
 
+console.log "I am being served from frontend"
+
 @masConfig =
   targetSelector: "mas-widget"
   containerClass: "mas-widget-container"

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -36,6 +36,7 @@ Rails.application.configure do
                                    styleguide.js
                                    supports.js
                                    syndication/iframeResizer.js
+                                   syndication/tools.js
                                    translations/cy.js
                                    translations/en.js
                                    dough/assets/js/lib/*.js


### PR DESCRIPTION
We want to stop serving tools.js from public website and move this to frontend. 
All the embedded partner-tools make use of /assets/syndication/tools.js
We need to make this a seamless migration.

This PR creates "tools.js" with a kind of 'after' hook on assets:precompile.

We are unsure if we need to update the scripts repo as the tools.js from public_website is currently zipped up as 'static-content' and served by nginx. Ideally we want to be using the new version from frontend.