### PR TITLE
Migrate Action plans engine

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem 'rubytree'
 gem 'statsd-ruby'
 gem 'uglifier', '>= 1.3.0'
 
+gem 'action_plans', '~> 3.0.0'
 gem 'advice_plans', '~> 3.1.0'
 gem 'agreements', '~> 2.0.1'
 gem 'budget_planner', '~> 4.0.1.689'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,13 @@ GEM
   remote: https://rubygems.org/
   remote: http://gems.test.mas/
   specs:
+    action_plans (3.0.0.293)
+      autoprefixer-rails
+      dough-ruby
+      draper
+      hashie
+      jquery-rails-cdn
+      rails (~> 4.1.8)
     actionmailer (4.1.8)
       actionpack (= 4.1.8)
       actionview (= 4.1.8)
@@ -658,6 +665,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  action_plans (~> 3.0.0)
   activerecord-session_store
   advice_plans (~> 3.1.0)
   aes

--- a/app/controllers/action_plans_engine_controller.rb
+++ b/app/controllers/action_plans_engine_controller.rb
@@ -1,0 +1,35 @@
+class ActionPlansEngineController < MountController
+  def parent_template
+    'layouts/engine_unconstrained'
+  end
+
+  def category_id
+    'redundancy'
+  end
+
+  def breadcrumbs
+    categories.map(&Breadcrumb.public_method(:new))
+  end
+
+  private
+
+  def category
+    @category ||= Core::CategoryReader.new(category_id).call
+  end
+
+  def categories
+    RootToNodePath.build(category, category_tree)
+  end
+
+  def alternate_engine_id
+    send "#{alternate_locale}_engine_id"
+  end
+
+  def en_engine_id
+    EngineMountPoint::ActionPlans::EN_ID
+  end
+
+  def cy_engine_id
+    EngineMountPoint::ActionPlans::CY_ID
+  end
+end

--- a/config/initializers/action_plans.rb
+++ b/config/initializers/action_plans.rb
@@ -1,0 +1,1 @@
+ActionPlans.parent_controller = '::ActionPlansEngineController'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -115,6 +115,11 @@ Rails.application.routes.draw do
       mount Agreements::Engine => '/agreements'
     end
 
+    Feature.with(:action_plans) do
+      mount ActionPlans::Engine => '/:engine_id',
+            constraints: EngineMountPoint.for(:action_plans)
+    end
+
     match '/tools/:id', to: not_implemented, via: 'get', as: 'tool'
 
     resources :action_plans, only: 'show'

--- a/lib/engine_mount_point.rb
+++ b/lib/engine_mount_point.rb
@@ -1,5 +1,6 @@
 require_relative '../lib/engine_mount_point/base'
 require_relative '../lib/engine_mount_point/rio'
+require_relative '../lib/engine_mount_point/action_plans'
 
 module EngineMountPoint
   def self.for(tool)

--- a/lib/engine_mount_point/action_plans.rb
+++ b/lib/engine_mount_point/action_plans.rb
@@ -1,0 +1,6 @@
+module EngineMountPoint
+  class ActionPlans < Base
+    EN_ID = 'action-plans'
+    CY_ID = 'dileu-swydd'
+  end
+end

--- a/spec/requests/tool_integration/action_plans_spec.rb
+++ b/spec/requests/tool_integration/action_plans_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe 'RIO', type: :request, features: [:action_plans] do
+  %W(
+    /en/#{EngineMountPoint::ActionPlans::EN_ID}/redundancy
+    /cy/#{EngineMountPoint::ActionPlans::CY_ID}/redundancy
+  ).each do |path|
+    describe path do
+      before do
+        get path
+      end
+
+      specify { expect(response).to be_ok }
+    end
+  end
+end


### PR DESCRIPTION
- Action Plans engine has been upgraded to rails 4 and to work with frontend
- This integrates it into frontend as part of the migration