### PR TITLE
Want to talk - Implement updated design and copy

### DIFF
--- a/app/assets/stylesheets/components/dough_theme/backgrounds/_all.scss
+++ b/app/assets/stylesheets/components/dough_theme/backgrounds/_all.scss
@@ -1,0 +1,2 @@
+@import "settings";
+@import "backgrounds";

--- a/app/assets/stylesheets/components/dough_theme/backgrounds/_backgrounds.scss
+++ b/app/assets/stylesheets/components/dough_theme/backgrounds/_backgrounds.scss
@@ -1,0 +1,3 @@
+%stripe-bg {
+  background-image: $bg-img-stripe;
+}

--- a/app/assets/stylesheets/components/dough_theme/backgrounds/_settings.scss
+++ b/app/assets/stylesheets/components/dough_theme/backgrounds/_settings.scss
@@ -1,0 +1,3 @@
+// Backgrounds
+
+$bg-img-stripe: url(data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%228%22%20height%3D%228%22%20viewBox%3D%220%200%2080%2080%22%20enable-background%3D%22new%200%200%2080%2080%22%3E%3Cpath%20stroke%3D%22%23000%22%20d%3D%22M0%2080L80%200%22%2F%3E%3C%2Fsvg%3E);

--- a/app/assets/stylesheets/components/page_specific/_stripe_banner.scss
+++ b/app/assets/stylesheets/components/page_specific/_stripe_banner.scss
@@ -3,7 +3,8 @@
 // Styleguide Stripe banner
 
 .stripe-banner {
-  background: $color-off-white url(data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%228%22%20height%3D%228%22%20viewBox%3D%220%200%2080%2080%22%20enable-background%3D%22new%200%200%2080%2080%22%3E%3Cpath%20stroke%3D%22%23000%22%20d%3D%22M0%2080L80%200%22%2F%3E%3C%2Fsvg%3E);
+  @extend %stripe-bg;
+  background-color: $color-off-white;
   background-size: 8px 8px;
   text-align: center;
   margin-top: $baseline-unit*8;

--- a/app/assets/stylesheets/components/page_specific/_want_to_talk.scss
+++ b/app/assets/stylesheets/components/page_specific/_want_to_talk.scss
@@ -4,17 +4,14 @@
 }
 
 .want-to-talk--sidebar {
+  padding-top: $baseline_unit*2;
   text-align: center;
 }
 
 .want-to-talk--inline {
-  position: relative;
   margin-top: $baseline_unit*4;
-  padding-bottom: 8px;
-}
-
-.want-to-talk--inline.want-to-talk--open {
-  padding-bottom: 0;
+  max-width: 260px;
+  padding-bottom: $baseline_unit*1.5;
 }
 
 .want-to-talk--fixed {
@@ -30,6 +27,8 @@
 
 .want-to-talk--initialised.want-to-talk--inline {
   display: block;
+  margin-left: auto;
+  margin-right: auto;
 
   @include respond-to($mq-m) {
     display: none;
@@ -48,103 +47,95 @@
   overflow: hidden;
   max-height: 0;
   transition: max-height 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
-}
-
-.want-to-talk--inline .want-to-talk__body {
-  margin-left: 70px;
+  text-align: center;
 }
 
 .want-to-talk--open .want-to-talk__body {
   max-height: 20em;
 }
 
-.want-to-talk--inline.want-to-talk--open .want-to-talk__body {
-  padding-bottom: 20px;
-}
-
 .want-to-talk__intro {
   border: none;
   background: none;
+  display: block;
+  margin: 0 auto;
   padding: 0;
-}
-
-.want-to-talk--inline .want-to-talk__intro {
-  position: relative;
-  z-index: 2;
-  margin-left: 70px;
-}
-
-.want-to-talk--inline.want-to-talk--open .want-to-talk__intro {
-  margin-bottom: 0;
+  width: 100%;
 }
 
 .want-to-talk__intro__title {
-  @include body(24, 28);
-  margin-top: $baseline_unit;
-  margin-bottom: $baseline_unit*1.5;
+  @include body(22, 28);
+  margin-top: $baseline_unit*2.5;
+  margin-bottom: $baseline_unit*2;
   color: $color-black;
+
+  @include respond-to($mq-m, $mq-l) {
+    @include body(20, 26);
+  };
+
+  @include respond-to($mq-m, $mq-l) {
+    .want-to-talk--fixed.want-to-talk--open & {
+      margin-top: 0;
+    }
+  };
 }
 
-.want-to-talk--inline .want-to-talk__intro__title {
-  text-align: left;
+.want-to-talk__icon {
+  display: block;
+  margin: 0 auto;
+
+  @include respond-to($mq-m, $mq-l) {
+    .want-to-talk--fixed.want-to-talk--open & {
+      display: none;
+    }
+  };
 }
 
 .want-to-talk__trigger {
   display: block;
-
-  &:before {
-    display: block;
-    content: " ";
-    border-bottom: 1px solid $color-white;
-    border-bottom-radius: 50%;
-    box-shadow: 0 2px 3px 0 rgba(200, 200, 200, 0.75);
-    position: absolute;
-    z-index: 2;
-    top: 25px;
-    width: 100%;
-  }
-}
-
-.want-to-talk--inline .want-to-talk__trigger {
-  width: 100%;
-  position: absolute;
-  z-index: 1;
-  bottom: 0;
-
-  &:before {
-    top: 45px;
-  }
+  margin: $baseline_unit*2 auto $baseline_unit*3;
+  text-align: center;
 }
 
 .want-to-talk__trigger__button {
-  display: block;
-  width: 58px;
-  height: 58px;
+  @extend %stripe-bg;
+  background-color: $color-off-white;
+  border: none;
+  display: inline-block;
+  margin: 0 auto;
+  padding: $baseline_unit 3px;
+  position: relative;
+  text-align: center;
+  width: 90%;
+}
+
+.want-to-talk__trigger__button__icon {
+  display: inline-block;
+  width: 32px;
+  height: 32px;
   background: #e7ba33;
   margin: 0 auto;
-  padding: 0;
   position: relative;
   z-index: 3;
-  border: none;
   border-radius: 50%;
-  border: 4px solid $color-white;
+  border: 2px solid $color-white;
+  vertical-align: middle;
 
   &:before {
+    box-shadow: 0 0 5px 1px rgba(200, 200, 200, .5);
     content: " ";
     display: block;
-    width: 58px;
-    height: 58px;
-    border: 4px solid $color-white;
+    width: 32px;
+    height: 32px;
+    border: 2px solid $color-white;
     border-radius: 50%;
-    box-shadow: 0 3px 10px 0 rgba(200, 200, 200, 0.75);
     position: absolute;
-    top: -4px;
-    left: -4px;
-    clip-path: inset(34px 0 0 0);
+    top: -2px;
+    left: -2px;
   }
 
   &:after {
-    @include body(24, 40);
+    @include body(17, 28);
     content: "+";
     color: $color-black;
     font-weight: 700;
@@ -155,7 +146,7 @@
     border-color: $color-input-focus-border-color;
 
     &:before {
-    border-color: $color-input-focus-border-color;
+      border-color: $color-input-focus-border-color;
     }
   }
 
@@ -164,17 +155,27 @@
   }
 }
 
-.want-to-talk--inline .want-to-talk__trigger__button {
-  margin: 0;
+.want-to-talk__trigger__button__text {
+  margin-right: 10px;
+  vertical-align: middle;
 
-  &:before {
-    clip-path: inset(54px 0 0 0);
-  }
+  @include respond-to($mq-m, $mq-xl) {
+    margin-right: 0;
+    margin-bottom: $baseline_unit;
+    display: block;
+  };
+
+  @include respond-to($mq-m, $mq-l) {
+    .want-to-talk--fixed.want-to-talk--open & {
+      margin-bottom: 0
+    }
+  };
 }
 
 .want-to-talk__intro__text {
   @include body(18, 24);
-  margin-top: 0;
+  margin: 0 auto $baseline_unit;
+  width: 70%;
 
   // For specificity of inline version
   .editorial & {
@@ -183,40 +184,34 @@
 }
 
 .want-to-talk__body__small-print {
-  @include body(16, 20);
+  @include body(14, 20);
+
+  @include respond-to($mq-xl) {
+    margin-left: auto;
+    margin-right: auto;
+    width: 95%;
+  };
 
   // For specificity of inline version
   .editorial & {
     @include body(14, 18);
+    margin-top: $baseline_unit*2;
   }
 }
 
-.want-to-talk--inline .want-to-talk__body__small-print {
-  margin-top: $baseline_unit;
-}
-
 .want-to-talk__body__call-us {
-  @include body(18, 24);
+  @include body(16, 20);
   margin-top: 0;
-  margin-bottom: $baseline_unit*2;
-}
-
-.want-to-talk--inline .want-to-talk__body__call-us {
-  @include body(18, 24);
-  margin-bottom: $baseline_unit;
+  margin-bottom: $baseline_unit*2.5;
 }
 
 // For specificity
 .want-to-talk__body__phone {
-  @include body(20, 24);
+  @include body(22, 26);
   font-weight: 700;
 }
 
 // For specificity
 a[href^=tel].want-to-talk__body__phone {
   color: $color-link-default;
-}
-
-.want-to-talk--inline .want-to-talk__body__phone {
-  @include body(30, 34);
 }

--- a/app/views/shared/_want_to_talk.html.erb
+++ b/app/views/shared/_want_to_talk.html.erb
@@ -1,17 +1,19 @@
 <div class="want-to-talk" data-dough-component="WantToTalk" data-open="<%= t('want_to_talk.open') %>" data-close="<%= t('want_to_talk.close') %>">
-  <div class="want-to-talk__trigger">
-    <button class="want-to-talk__trigger__button">
-      <span class="want-to-talk__trigger__button__text visually-hidden">
-        <%= t('want_to_talk.open') %>
-      </span>
-    </button>
-  </div>
+  <span class="want-to-talk__icon icon icon--call-us"></span>
   <button class="want-to-talk__intro">
     <h2 class="want-to-talk__intro__title"><%= t('want_to_talk.title') %></h2>
     <p class="want-to-talk__intro__text">
       <%= t('want_to_talk.intro') %>
     </p>
   </button>
+  <div class="want-to-talk__trigger">
+    <button class="want-to-talk__trigger__button">
+      <span class="want-to-talk__trigger__button__text">
+        <%= t('want_to_talk.open') %>
+      </span>
+      <span class="want-to-talk__trigger__button__icon"></span>
+    </button>
+  </div>
   <div class="want-to-talk__body" aria-hidden="true">
     <p class="want-to-talk__body__call-us">
       <%= t('want_to_talk.call_us') %>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -505,11 +505,11 @@ cy:
           back: Ewch yn ol i'ch tudalen cyfrif
 
   want_to_talk:
-    open: Open
-    close: Close
-    title: Want to talk?
-    intro: If you're not sure what to do next our advisors can help you. Our advice line is free and confidential.
-    small_print: Calls cost the same as a normal call, if your calls are free, it's included.
-    call_us: Call us on
-    phone_number: "tel:+44800268986"
-    phone_number_readable: 0800 268 986
+    open: Click for call details
+    close: Hide call details
+    title: Money worries?
+    intro: Talk to our advisers who can help you.
+    call_us: "Our advice line is free and confidential. Call us now on:"
+    phone_number: "tel:+443003302030"
+    phone_number_readable: 0300 330 2030
+    small_print: "*Calls cost the same as a normal call. If your calls are free, it's included."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -507,10 +507,10 @@ en:
           back: Go back to your account page
 
   want_to_talk:
-    open: Open
-    close: Close
-    title: Want to talk?
-    intro: If you have money worries, our advisers can help.
+    open: Click for call details
+    close: Hide call details
+    title: Money worries?
+    intro: Talk to our advisers who can help you.
     call_us: "Our advice line is free and confidential. Call us now on:"
     phone_number: "tel:+443003302030"
     phone_number_readable: 0300 330 2030


### PR DESCRIPTION
These changes implement the new design for the Want To Talk widget. 

## "Desktop" Closed
![screen shot 2015-03-31 at 10 16 13](https://cloud.githubusercontent.com/assets/1579511/6915852/a80f4268-d78f-11e4-89a1-752453b7ca3e.png)

## "Desktop" Open
![screen shot 2015-03-31 at 10 16 18](https://cloud.githubusercontent.com/assets/1579511/6915853/a810e636-d78f-11e4-8e28-34808d6158d7.png)

## "Mobile" Closed
![screen shot 2015-03-31 at 10 16 25](https://cloud.githubusercontent.com/assets/1579511/6915854/a811deec-d78f-11e4-814b-57e5a91b0e21.png)

## "Mobile" Open
![screen shot 2015-03-31 at 10 16 31](https://cloud.githubusercontent.com/assets/1579511/6915855/a8175912-d78f-11e4-806d-23bb33357d3b.png)

@stevoland @moneyadviceservice/frontend

id:6195 state: Being Built
