### PR TITLE
Add toolTrackingId to GA dataLayer.

### DIFF
--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -55,6 +55,9 @@
       'Responsive page': 'Yes',
       'event': 'Responsive page'
     });
+    <% if content_for?(:tool_tracking_id) %>
+    dataLayer.push({'toolTrackingId': '<%= content_for(:tool_tracking_id) %>'});
+    <% end %>
 
     var require = {
       config: {


### PR DESCRIPTION
This was on the old website but never migrated over. We're changing it
to use dataLayer.push() for GTM while we're at it. The Budget Planner
and soon hopefully the Health Check, Redundancy Tool and Quiz engines
are meant to set the content for this to be a string that identifies the
tool along with a unique id for user's data. For example 'BP123456'.