### PR TITLE
Fix range input display in IE10-11.

### DIFF
--- a/app/assets/stylesheets/components/dough_theme/form/_form_input_range.scss
+++ b/app/assets/stylesheets/components/dough_theme/form/_form_input_range.scss
@@ -45,7 +45,8 @@
 .form__input-range::-ms-track {
   @include range-track-colors;
   color: transparent;
-  height: 20px;
+  height: 32px;
+  border: 0;
 }
 
 .form__input-range::-ms-fill-lower,
@@ -95,6 +96,7 @@
 
 .form__input-range::-ms-thumb {
   @include range-thumb-generic;
+  @include range-thumb-large;
   height: 20px;
 }
 


### PR DESCRIPTION
`.form__input-range` was looking a little odd in IE10-11. So we've modified some styles to make it look more like the other browsers do. It does change the height of the slider element by approx 5px in IE, which isn't ideal but the usual negative margin hacks didn't seem to help. Suggestions encouraged!

__Before:__

![image](https://cloud.githubusercontent.com/assets/1007202/7137517/3e110c7e-e2b2-11e4-94fc-6f315bb137c7.png)

__After:__

![image](https://cloud.githubusercontent.com/assets/1007202/7137504/2b34f8f4-e2b2-11e4-87dc-a5aba51c542c.png)