### PR TITLE
Fix issue when no child categories are present

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -108,7 +108,9 @@ class ApplicationController < ActionController::Base
   def corporate_category?(category, corporate = corporate_categories, categories = [])
     categories << corporate.map {|c| c['id']}
     return true if categories.flatten.include?(category)
-    corporate_category?(category, corporate.first['contents'], categories.flatten) if corporate.first['contents']
+    unless corporate.first['contents']
+      corporate_category?(category, corporate.first['contents'], categories.flatten)
+    end
   end
 
   helper_method :corporate_category?


### PR DESCRIPTION
Fixes recent issue of category pages blowing up and returning 500s. Incident report can be found here (if you're a MAS employee) https://moneyadviceserviceuk.atlassian.net/wiki/display/DEV/2015-04-23+-+Site+Category+Pages+Down.

