### PR TITLE
separating 'More In' and 'Related Links' into two different components

### DIFF
--- a/app/assets/stylesheets/components/page_specific/_more_in.scss
+++ b/app/assets/stylesheets/components/page_specific/_more_in.scss
@@ -1,0 +1,17 @@
+// Content box that appears on article pages displaying links to other content in the current category
+//
+// Styleguide more in
+
+.more-in__heading {
+  @include body(18, 24);
+  letter-spacing: 0;
+  color: $related-links-heading;
+  padding: $baseline-unit*2 0;
+  margin-top: 0;
+  margin-bottom: $baseline-unit*3;
+  border-bottom: $related-links-border;
+}
+
+.more-in__link {
+  @include body(16, 24);
+}

--- a/app/controllers/styleguide_controller.rb
+++ b/app/controllers/styleguide_controller.rb
@@ -166,6 +166,20 @@ class StyleguideController < ApplicationController
 
   helper_method :categories
 
+  def categories_related_links
+    [
+      {
+        contents: [
+          { title: 'Budgeting tips when you’re on a low income' },
+          { title: 'How much can you afford to borrow for a mortgage?' },
+          { title: 'Beginner’s guide to managing your money' }
+        ]
+      }
+    ].map(&:to_ostruct)
+  end
+
+  helper_method :categories_related_links
+
   def categories_for_directory_en
     [
       {

--- a/app/decorators/category_decorator.rb
+++ b/app/decorators/category_decorator.rb
@@ -30,8 +30,8 @@ class CategoryDecorator < Draper::Decorator
   def related_links_title
     return if object.contents.blank?
 
-    h.heading_tag(level: 2, class: 'related-links__heading') do
-      I18n.t('articles.show.related_links.title_prefix', category: object.title)
+    h.heading_tag(level: 2, class: 'more-in__heading') do
+      I18n.t('articles.show.more_in.title_prefix', category: object.title)
     end
   end
 end

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -34,7 +34,7 @@
         <%= render 'articles/related_articles' %>
       </div>
 
-      <%= render 'shared/related_links', article: @article, categories: related_content %>
+      <%= render 'shared/more_in', article: @article, categories: related_content %>
 
       <%= render 'shared/feedback', article: article %>
     </main>

--- a/app/views/shared/_more_in.html.erb
+++ b/app/views/shared/_more_in.html.erb
@@ -1,0 +1,20 @@
+<% categories.each do |category| %>
+  <div class="more-in">
+    <%= category.related_links_title %>
+    <ul class="unstyled-list">
+      <% category.contents.each do |article| %>
+        <li class="more-in__link">
+          <%= link_to article.title, article.path %>
+        </li>
+      <% end %>
+    </ul>
+    <% if category_has_more_content?(article, category.object) %>
+      <%= link_to category.path, class: 'more-in__all' do %>
+        <%= t('articles.show.more_in.link_html') %>
+        <span class="visually-hidden">
+          <%= t('articles.show.more_in.hidden_link', category: category.title) %>
+        </span>
+      <% end %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/shared/_related_links.html.erb
+++ b/app/views/shared/_related_links.html.erb
@@ -8,13 +8,5 @@
         </li>
       <% end %>
     </ul>
-    <% if category_has_more_content?(article, category.object) %>
-      <%= link_to category.path, class: 'related-links__all' do %>
-        <%= t('articles.show.related_links.link_html') %>
-        <span class="visually-hidden">
-          <%= t('articles.show.related_links.hidden_link', category: category.title) %>
-        </span>
-      <% end %>
-    <% end %>
   </div>
 <% end %>

--- a/app/views/styleguide/components_website.html.erb
+++ b/app/views/styleguide/components_website.html.erb
@@ -15,7 +15,7 @@
 <% end %>
 
 <%= styleguide_section sections['related link'] do %>
-  <%= render 'shared/related_links', article: article, categories: categories %>
+  <%= render 'shared/related_links', categories: categories_related_links %>
 <% end %>
 
 <%= styleguide_section sections['more in'] do %>

--- a/app/views/styleguide/components_website.html.erb
+++ b/app/views/styleguide/components_website.html.erb
@@ -18,6 +18,10 @@
   <%= render 'shared/related_links', article: article, categories: categories %>
 <% end %>
 
+<%= styleguide_section sections['more in'] do %>
+  <%= render 'shared/more_in', article: article, categories: categories %>
+<% end %>
+
 <%= styleguide_section sections['link-list-primary'] do %>
   <%= render 'styleguide/shared/link_list_primary' %>
 <% end %>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -277,7 +277,7 @@ cy:
 
   articles:
     show:
-      related_links:
+      more_in:
         title_prefix: Mwy yn '%{category}'
         link_html: Gweld yr holl &hellip;
         hidden_link: erthyglau yn %{category}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -276,7 +276,7 @@ en:
 
   articles:
     show:
-      related_links:
+      more_in:
         title_prefix: More in '%{category}'
         link_html: View all &hellip;
         hidden_link: articles in %{category}


### PR DESCRIPTION
so that they can eventually be styled differently.

This needs to be done, as the related links on the right hand side of an article are going to be styled differently from the 'More in' list of links, in another PR