### PR TITLE
Fix wrong feature flag in RetirementsController spec.

### DIFF
--- a/spec/controllers/retirements_controller_spec.rb
+++ b/spec/controllers/retirements_controller_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe RetirementsController, type: :controller, features: [:rio] do
+RSpec.describe RetirementsController, type: :controller, features: [:pensions_and_retirement] do
   describe '#index' do
     it 'responds with success' do
       get :index, locale: :en


### PR DESCRIPTION
This didn't show up before because the spec file didn't have `_spec.rb` on the end.

Then I renamed it in https://github.com/moneyadviceservice/frontend/pull/1035, but only tested it with the feature enabled in my local repo. Maybe in tests all features could be disabled by default, any thoughts?

@paulanthonywilson @munckymagik 