### PR TITLE
Remove public website cms fallbacks

### DIFF
--- a/lib/core/repository/cms/cms.rb
+++ b/lib/core/repository/cms/cms.rb
@@ -3,16 +3,16 @@ module Core::Repository
     class CMS < Core::Repository::Base
       def initialize(options = {})
         self.connection = Core::Registry::Connection[:cms]
-        self.fallback_repository = options[:fallback]
       end
 
       def find(id)
         resource_url = '%{locale}/%{page_type}/%{id}.json' % { locale: I18n.locale, page_type: resource_name, id: id }
         response = connection.get(resource_url)
         AttributeBuilder.build(response)
+      rescue Core::Connection::Http::ResourceNotFound
+        nil
       rescue => e
-        Rails.logger.error("Tried to fetch from Contento. Error message: #{e.message}")
-        fallback_repository.find(id)
+        raise RequestError, 'Unable to fetch Article JSON from Contento'
       end
 
       def resource_name
@@ -21,7 +21,7 @@ module Core::Repository
 
       private
 
-      attr_accessor :connection, :fallback_repository
+      attr_accessor :connection
     end
   end
 end

--- a/spec/lib/core/repository/shared_examples/cms_resource.rb
+++ b/spec/lib/core/repository/shared_examples/cms_resource.rb
@@ -2,9 +2,7 @@ RSpec.shared_examples_for 'a cms resource' do
   let(:url) { 'https://example.com' }
 
   describe '#find' do
-    subject(:repository) { described_class.new(fallback: fallback) }
-
-    let(:fallback) { double }
+    subject(:repository) { described_class.new }
 
     let(:id) { 'beginners-guide-to-managing-your-money' }
     let(:headers) { {} }
@@ -38,9 +36,8 @@ RSpec.shared_examples_for 'a cms resource' do
       let(:body) { nil }
       let(:status) { 404 }
 
-      it 'falls back to the fallback repository' do
-        expect(fallback).to receive(:find).with(id)
-        repository.find(id)
+      it 'returns nil' do
+        expect(repository.find(id)).to be_nil
       end
     end
 
@@ -48,9 +45,8 @@ RSpec.shared_examples_for 'a cms resource' do
       let(:body) { nil }
       let(:status) { 407 }
 
-      it 'falls back to the fallback repository' do
-        expect(fallback).to receive(:find).with(id)
-        repository.find(id)
+      it 'raises an RequestError' do
+        expect { repository.find(id) }.to raise_error(Core::Repository::Base::RequestError)
       end
     end
 
@@ -58,9 +54,8 @@ RSpec.shared_examples_for 'a cms resource' do
       let(:body) { nil }
       let(:status) { 500 }
 
-      it 'falls back to the fallback repository' do
-        expect(fallback).to receive(:find).with(id)
-        repository.find(id)
+      it 'raises an RequestError' do
+        expect { repository.find(id) }.to raise_error(Core::Repository::Base::RequestError)
       end
     end
   end


### PR DESCRIPTION
on a 404 it will now return nil which is what the public wesbite fallback
repository used to do