### PR TITLE
Rename redundancy action plan to redundancy tool

### DIFF
--- a/app/controllers/action_plans_engine_controller.rb
+++ b/app/controllers/action_plans_engine_controller.rb
@@ -26,10 +26,10 @@ class ActionPlansEngineController < MountController
   end
 
   def en_engine_id
-    EngineMountPoint::ActionPlans::EN_ID
+    ToolMountPoint::ActionPlans::EN_ID
   end
 
   def cy_engine_id
-    EngineMountPoint::ActionPlans::CY_ID
+    ToolMountPoint::ActionPlans::CY_ID
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,11 @@ Rails.application.routes.draw do
             constraints: ToolMountPoint.for(:car_cost_tool)
     end
 
+    Feature.with(:action_plans) do
+      mount ActionPlans::Engine => '/tools/:tool_id',
+            constraints: ToolMountPoint.for(:action_plans)
+    end
+
     Feature.with(:contribution_calculator) do
       mount ContributionCalculator::Engine => '/tools/:tool_id',
             constraints: ToolMountPoint.for(:contribution_calculator)
@@ -126,11 +131,6 @@ Rails.application.routes.draw do
 
     if Feature.active?(:agreements)
       mount Agreements::Engine => '/agreements'
-    end
-
-    Feature.with(:action_plans) do
-      mount ActionPlans::Engine => '/:engine_id',
-            constraints: EngineMountPoint.for(:action_plans)
     end
 
     match '/tools/:id', to: not_implemented, via: 'get', as: 'tool'

--- a/lib/engine_mount_point.rb
+++ b/lib/engine_mount_point.rb
@@ -1,6 +1,5 @@
 require_relative '../lib/engine_mount_point/base'
 require_relative '../lib/engine_mount_point/rio'
-require_relative '../lib/engine_mount_point/action_plans'
 
 module EngineMountPoint
   def self.for(tool)

--- a/lib/engine_mount_point/action_plans.rb
+++ b/lib/engine_mount_point/action_plans.rb
@@ -1,6 +1,0 @@
-module EngineMountPoint
-  class ActionPlans < Base
-    EN_ID = 'action-plans'
-    CY_ID = 'dileu-swydd'
-  end
-end

--- a/lib/tool_mount_point.rb
+++ b/lib/tool_mount_point.rb
@@ -1,4 +1,5 @@
 require_relative '../lib/tool_mount_point/base'
+require_relative '../lib/tool_mount_point/action_plans'
 require_relative '../lib/tool_mount_point/advice_plans'
 require_relative '../lib/tool_mount_point/budget_planner'
 require_relative '../lib/tool_mount_point/baby_cost_calculator'

--- a/lib/tool_mount_point/action_plans.rb
+++ b/lib/tool_mount_point/action_plans.rb
@@ -1,0 +1,6 @@
+module ToolMountPoint
+  class ActionPlans < Base
+    EN_ID = 'redundancy-pay-calculator'
+    CY_ID = 'cyfrifiannell-tal-diswyddo'
+  end
+end

--- a/spec/requests/tool_integration/action_plans_spec.rb
+++ b/spec/requests/tool_integration/action_plans_spec.rb
@@ -1,7 +1,7 @@
-RSpec.describe 'RIO', type: :request, features: [:action_plans] do
+RSpec.describe 'Redundancy pay calculator', type: :request, features: [:action_plans] do
   %W(
-    /en/#{EngineMountPoint::ActionPlans::EN_ID}/redundancy
-    /cy/#{EngineMountPoint::ActionPlans::CY_ID}/redundancy
+    /en/tools/#{ToolMountPoint::ActionPlans::EN_ID}
+    /cy/tools/#{ToolMountPoint::ActionPlans::CY_ID}
   ).each do |path|
     describe path do
       before do


### PR DESCRIPTION
* #6278 in Target process.
* Rename the existing URL https://www.moneyadviceservice.org.uk/en/action-plans/redundancy
to https://www.moneyadviceservice.org.uk/en/tools/redundancy-pay-calculator