### PR TITLE
remove definition of debt-test parent template

### DIFF
--- a/app/controllers/debt_test_controller.rb
+++ b/app/controllers/debt_test_controller.rb
@@ -1,6 +1,10 @@
 class DebtTestController < EmbeddedToolsController
   def parent_template
-    'layouts/engine_unconstrained'
+    if syndicated_tool_request?
+      'layouts/engine_syndicated'
+    else
+      'layouts/engine_unconstrained'
+    end
   end
 
   protected


### PR DESCRIPTION
  * setting the parent layout in this way breaks setting the syndicated
  * layout when it is need.
  * As far as I know, setting the layout makes no difference to the layout