### PR TITLE
TP-6352: Update breakpoint on category/article page

### DIFF
--- a/app/assets/stylesheets/layout/_variables.scss
+++ b/app/assets/stylesheets/layout/_variables.scss
@@ -1,2 +1,3 @@
 $mq-small-tablet: px(600);
 $mq-small-tablet-end: px(719);
+$mq-3col-layout: px(800);

--- a/app/assets/stylesheets/layout/common/_global.scss
+++ b/app/assets/stylesheets/layout/common/_global.scss
@@ -2,7 +2,7 @@
   @include column(12);
   min-height: $baseline-unit*100;
 
-  @include respond-to($mq-m) {
+  @include respond-to($mq-3col-layout) {
     @include column(9);
 
     float: right;
@@ -66,7 +66,7 @@
   margin-top: 40px;
   margin-bottom: 42px;
 
-  @include respond-to($mq-m) {
+  @include respond-to($mq-3col-layout) {
     @include column(3);
   }
 
@@ -83,7 +83,7 @@
   }
 
   .link-to-top-block {
-    @include respond-to($mq-m) {
+    @include respond-to($mq-3col-layout) {
       display: none;
     }
   }

--- a/app/assets/stylesheets/layout/page_specific/_article_page.scss
+++ b/app/assets/stylesheets/layout/page_specific/_article_page.scss
@@ -21,6 +21,10 @@
   min-height: $baseline-unit*100;
 
   @include respond-to($mq-m) {
+    @include column(8);
+  }
+
+  @include respond-to($mq-3col-layout) {
     @include column(6);
     @include column-shift(3);
 
@@ -32,6 +36,10 @@
   @include column(12);
 
   @include respond-to($mq-m) {
+    @include column(4);
+  }
+
+  @include respond-to($mq-3col-layout) {
     @include column(3);
 
     margin-top: 40px;
@@ -46,7 +54,7 @@
 .l-article-3col-left {
   clear: both;
 
-  @include respond-to($mq-m) {
+  @include respond-to($mq-3col-layout) {
     clear: none;
     @extend %l-3col-side;
 
@@ -64,12 +72,12 @@
   }
 
   .link-to-top-block {
-    @include respond-to($mq-m) {
+    @include respond-to($mq-3col-layout) {
       display: none;
     }
   }
 
-  @include respond-to($mq-m) {
+  @include respond-to($mq-3col-layout) {
     @include column-shift(-9);
   }
 }
@@ -78,6 +86,10 @@
   @extend %l-3col-side;
 
   @include respond-to($mq-m) {
+    position: relative;
+  }
+
+  @include respond-to($mq-3col-layout) {
     @include column-shift(3);
   }
 }


### PR DESCRIPTION
- Added breakpoint of 800px where 3 cols come in
- at 720px $mq-m two columns appear on tablet for article pages

![screen shot 2015-05-12 at 13 02 29](https://cloud.githubusercontent.com/assets/6049076/7586675/3033a5fc-f8a7-11e4-9c61-6d9253389570.png)
