### PR TITLE
Remove welsh retirement landing pages feature flag

### DIFF
--- a/app/controllers/retirements_controller.rb
+++ b/app/controllers/retirements_controller.rb
@@ -3,16 +3,7 @@ class RetirementsController < ApplicationController
   helper_method :locale_options
 
   def locale_options
-    if Feature.active? :welsh_retirement_landing_pages
-      LandingPagePaths.locale_options(params[:controller], params[:action])
-    else
-      []
-    end
-  end
-
-  def alternate_locales
-    return if Feature.active? :welsh_retirement_landing_pages
-    []
+    LandingPagePaths.locale_options(params[:controller], params[:action])
   end
 
   def display_menu_button_in_header?

--- a/config/features.yml.sample
+++ b/config/features.yml.sample
@@ -28,4 +28,3 @@ features:
   settings: true
   sign_in: true
   timelines: true
-  welsh_retirement_landing_pages: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -112,12 +112,9 @@ Rails.application.routes.draw do
 
     Feature.with(:pensions_and_retirement) do
       get LandingPagePaths.path(:retirements, :index, :en),     to: 'retirements#index'
+      get LandingPagePaths.path(:retirements, :index, :cy),     to: 'retirements#index'
       get LandingPagePaths.path(:retirements, :budgeting, :en), to: 'retirements#budgeting'
-
-      Feature.with(:welsh_retirement_landing_pages) do
-        get LandingPagePaths.path(:retirements, :index, :cy),     to: 'retirements#index'
-        get LandingPagePaths.path(:retirements, :budgeting, :cy), to: 'retirements#budgeting'
-      end
+      get LandingPagePaths.path(:retirements, :budgeting, :cy), to: 'retirements#budgeting'
     end
 
     Feature.with(:savings_calculator) do

--- a/spec/controllers/retirements_controller_spec.rb
+++ b/spec/controllers/retirements_controller_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe RetirementsController, type: :controller, features: [:pensions_and_retirement, :welsh_retirement_landing_pages] do
+RSpec.describe RetirementsController, type: :controller, features: [:pensions_and_retirement] do
   describe '#index' do
     it 'responds with success' do
       get :index, locale: :en


### PR DESCRIPTION
It's going live, and it shouldn't need to be conditionally enabled or disabled.