### PR TITLE
TP-6352: Sticky column - back to top edge case bug

### DIFF
--- a/app/assets/javascripts/components/StickyColumn.js
+++ b/app/assets/javascripts/components/StickyColumn.js
@@ -148,12 +148,20 @@ define(['jquery', 'DoughBaseComponent', 'eventsWithPromises'], function($, Dough
       }
     }
 
-    if (this.isAtBottom && scrollTop < this.bottom) {
+    if (this.isAtBottom && scrollTop < this.bottom && scrollTop > this.top) {
       this.$el
         .addClass(this.config.classes.fixed)
         .removeClass(this.config.classes.bottom);
       this.isAtBottom = false;
       return;
+    }
+
+    if (this.isAtBottom && scrollTop < this.top) {
+      this.$el
+        .removeClass(this.config.classes.fixed)
+        .removeClass(this.config.classes.bottom);
+      this.isAtBottom = false;
+      this.isFixed = false;
     }
   };
 

--- a/app/assets/javascripts/components/StickyColumn.js
+++ b/app/assets/javascripts/components/StickyColumn.js
@@ -148,20 +148,22 @@ define(['jquery', 'DoughBaseComponent', 'eventsWithPromises'], function($, Dough
       }
     }
 
-    if (this.isAtBottom && scrollTop < this.bottom && scrollTop > this.top) {
-      this.$el
+    if (this.isAtBottom) {
+      if (scrollTop < this.bottom && scrollTop > this.top) {
+        this.$el
         .addClass(this.config.classes.fixed)
         .removeClass(this.config.classes.bottom);
-      this.isAtBottom = false;
-      return;
-    }
+        this.isAtBottom = false;
+        return;
+      }
 
-    if (this.isAtBottom && scrollTop < this.top) {
-      this.$el
+      if (scrollTop < this.top) {
+        this.$el
         .removeClass(this.config.classes.fixed)
         .removeClass(this.config.classes.bottom);
-      this.isAtBottom = false;
-      this.isFixed = false;
+        this.isAtBottom = false;
+        this.isFixed = false;
+      }
     }
   };
 

--- a/spec/javascripts/tests/StickyColumn_spec.js
+++ b/spec/javascripts/tests/StickyColumn_spec.js
@@ -260,6 +260,20 @@ describe('StickyColumn', function() {
 
       expect(this.component.attr('class')).to.be.equal('sticky fixed');
     });
+
+    it('returns the sticky module back to its static position', function() {
+      var stub = sinon.stub(this.obj, '_getWindowScroll').returns(0);
+
+      this.obj.isInSidebar = true;
+      this.obj.isFixed = false;
+      this.obj.isAtBottom = true;
+      this.obj.top = 175;
+      this.obj.bottom = 4000;
+
+      this.obj._positionComponent();
+
+      expect(this.component.attr('class')).to.be.equal('sticky');
+    });
   });
 
   describe('_handleScroll', function() {


### PR DESCRIPTION
- Sometimes when back to top is clicked, the browser gets
  confused, thinking that the sticky component is at the bottom.
- Added check to ensure that it returns to it's natural static
  position when back to top is pressed