### PR TITLE
in .env point to QA cms

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 MAS_PUBLIC_WEBSITE_URL=https://www.moneyadviceservice.org.uk/:locale/
-MAS_CMS_URL=http://localhost:3000/
+MAS_CMS_URL=http://comfy.qa.mas
 MAS_CONTENT_SERVICE_URL=http://localhost:8080/content-service/
 GOOGLE_API_KEY=AIzaSyCydfZlpTZlIUUUSbtab5t0oOE-y1GzHy0
 GOOGLE_API_CX_EN=011931388747222259444:razn90vopwc

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,1 @@
+MAS_CMS_URL = "http://localhost:3000/"

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ $ foreman s
 
 ### Change CMS URL Path
 
-The frontend locally will try to look for CMS locally. You can change the MAS_CMS_URL on [.env](https://github.com/moneyadviceservice/frontend/blob/master/.env#L2) file. Use http://comfy.moneyadviceservice.org.uk to point to LIVE content.
+In development, frontend will use the QA CMS for convenience. You can change the MAS_CMS_URL on [.env](https://github.com/moneyadviceservice/frontend/blob/master/.env#L2) file. Use http://comfy.moneyadviceservice.org.uk to point to LIVE content. Or http://localhost:PORT to point to a local running CMS.
 
 Don't forget to restart the server after the modification.
 


### PR DESCRIPTION
this is so developers who want to fire up frontend will have access to
dummy data. reducing overhead in setup. developers can choose to set
this back to their local version if needed