### PR TITLE
Conditional loading of syndicated tool iframe resizer 

### DIFF
--- a/app/assets/javascripts/syndication/tools.js.coffee
+++ b/app/assets/javascripts/syndication/tools.js.coffee
@@ -37,7 +37,7 @@
       cy:
         path: "cy/tools/prawf-dyledion"
       width: "100%"
-      height: "900px"
+      height: "1800px"
       include_ga: false
       title: "Debt test"
 

--- a/app/controllers/debt_test_controller.rb
+++ b/app/controllers/debt_test_controller.rb
@@ -7,6 +7,10 @@ class DebtTestController < EmbeddedToolsController
     end
   end
 
+  def exclude_syndicated_iframe_resizer?
+    syndicated_tool_request?
+  end
+
   protected
     def category_id
       'before-you-borrow'

--- a/app/controllers/embedded_tools_controller.rb
+++ b/app/controllers/embedded_tools_controller.rb
@@ -76,4 +76,10 @@ class EmbeddedToolsController < ApplicationController
   end
 
   helper_method :display_category_directory?
+
+  def exclude_syndicated_iframe_resizer?
+    false
+  end
+
+  helper_method :exclude_syndicated_iframe_resizer?
 end

--- a/app/views/layouts/engine_syndicated.html.erb
+++ b/app/views/layouts/engine_syndicated.html.erb
@@ -15,10 +15,12 @@
     </div>
   </div>
   <% content_for(:javascripts) do %>
-    <%= javascript_include_tag "syndication/iframeResizer" %>
-    <script>
-      window.iframeResizer('MASRESIZE-').start();
-    </script>
+    <% unless exclude_syndicated_iframe_resizer? %>
+      <%= javascript_include_tag "syndication/iframeResizer" %>
+      <script>
+        window.iframeResizer('MASRESIZE-').start();
+      </script>
+    <% end %>
   <% end %>
 <% end %>
 


### PR DESCRIPTION
Some tools do not have any benefit from having the iframe resizer when being syndicated. For the debt test tool, it was causing problems with the scrolling. This enables tools to disable the iframe resizer if they need.