### PR TITLE
Better wording for CSS styleguide

### DIFF
--- a/app/views/styleguide/css_overview.html.erb
+++ b/app/views/styleguide/css_overview.html.erb
@@ -46,7 +46,7 @@ a double dash (<code>--</code>) to indicate a modified version of a component<br
 
 <p><strong>CSS must not use <code>id</code> or <code>js-*</code> classes in selectors.</strong></p>
 
-<p>The <code>id</code> attribute and <code>js-*</code> class names are reserved for JavaScript-only use.</p>
+<p>The <code>js-*</code> class names are reserved for JavaScript-only use.</p>
 
 <p>The example below includes a dedicated JavaScript utility class to which behaviour is bound. It is independent of
   any specific UI component.</p>


### PR DESCRIPTION
We favour `js-` prefixes for Javascript selectors, whereas the styleguide was suggesting id's as well.