### PR TITLE
Corporate partners export

### DIFF
--- a/app/controllers/corporate_controller.rb
+++ b/app/controllers/corporate_controller.rb
@@ -40,7 +40,7 @@ class CorporateController < ArticlesController
     send_data csv,
               type: 'text/csv; charset=iso-8859-1; header=present',
               disposition: 'attachment',
-              filename: "corporate_partners-#{Date.today}.csv"
+              filename: "corporate_partners-#{Time.now.strftime('%d-%m-%y--%H-%M')}.csv"
   end
 
   private

--- a/app/controllers/corporate_controller.rb
+++ b/app/controllers/corporate_controller.rb
@@ -34,6 +34,15 @@ class CorporateController < ArticlesController
     end
   end
 
+  def export_partners
+    @corporate_partners = CorporatePartner.all
+    csv = @corporate_partners.to_csv
+    send_data csv,
+              type: 'text/csv; charset=iso-8859-1; header=present',
+              disposition: 'attachment',
+              filename: "corporate_partners-#{Date.today}.csv"
+  end
+
   private
 
   def retrieve_corporate_category

--- a/app/models/corporate_partner.rb
+++ b/app/models/corporate_partner.rb
@@ -16,4 +16,16 @@ class CorporatePartner < ActiveRecord::Base
   def total_tool_width
     tool_width.to_s + tool_width_unit
   end
+
+  def self.to_csv
+    attributes = %w(id name email tool_name tool_language tool_width_unit tool_width)
+
+    CSV.generate(headers: true) do |csv|
+      csv << attributes
+
+      all.each do |corporate_partner|
+        csv << attributes.map { |attr| corporate_partner.send(attr) }
+      end
+    end
+  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,5 +1,6 @@
 require_relative 'boot'
 
+require 'csv'
 require 'action_mailer/railtie'
 require 'action_controller/railtie'
 require 'action_view/railtie'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -167,7 +167,9 @@ Rails.application.routes.draw do
     get '/corporate/contact-us', controller: 'static_pages', action: 'show', id: 'contact-us'
     get '/corporate/cysylltu-a-ni', controller: 'static_pages', action: 'show', id: 'cysylltu-a-ni'
     resources :corporate_categories, only: [:show]
-    resources :corporate, only: [:index, :show, :create]
+    resources :corporate, only: [:index, :show, :create] do
+      get 'export-partners', on: :collection
+    end
 
     resources :campaigns,
               only: 'show',

--- a/features/corporate_partners_export.feature
+++ b/features/corporate_partners_export.feature
@@ -1,0 +1,9 @@
+Feature: Export Corporate Partners
+  As a MAS partnerships user
+  I would like to be able to see a list of all corporate partners via a spreadsheet
+  So I may send marketing materials to corporate partners
+
+  @enable-corporate-tool-directory @export-corporate-partners
+  Scenario: Requesting tool embed code
+    When I visit the export corporate partners url
+    Then I should be presented a csv file of all corporate partners

--- a/features/step_definitions/corporate_partners_export_steps.rb
+++ b/features/step_definitions/corporate_partners_export_steps.rb
@@ -1,0 +1,10 @@
+When(/^I visit the export corporate partners url$/) do
+  visit export_partners_corporate_index_path(locale: I18n.locale)
+end
+
+Then(/^I should be presented a csv file of all corporate partners$/) do
+  @corporate_partners = CorporatePartner.all
+  csv = CSV.parse(page.body)
+  corporate_partner_line = CSV.parse(@corporate_partners.to_csv).last
+  expect(csv).to include(corporate_partner_line)
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -90,5 +90,9 @@ Before do
   Core::Registry::Repository[:customer].clear
 end
 
+Before('@export-corporate-partners') do
+  create(:corporate_partner)
+end
+
 Capybara.javascript_driver = :poltergeist
 Capybara.default_wait_time = 20

--- a/spec/models/corporate_partner_spec.rb
+++ b/spec/models/corporate_partner_spec.rb
@@ -56,23 +56,38 @@ RSpec.describe CorporatePartner, type: :model do
 
     it { is_expected.to be_valid }
 
-    describe '#tool_id' do
-      it 'should return a hyphanated version of the tool name' do
-        expect(subject.tool_id).to eq('sample-tool')
-      end
+  end
+
+  describe '#tool_id' do
+    it 'should return a hyphanated version of the tool name' do
+      expect(subject.tool_id).to eq('sample-tool')
+    end
+  end
+
+  describe '#tool_slug' do
+    it 'should return a slug of the tool' do
+      expect(subject.tool_slug).to eq('sample-tool-syndication')
+    end
+  end
+
+  describe '#total_tool_width' do
+    it 'should the full width with units' do
+      expect(subject.total_tool_width).to eq('500px')
+    end
+  end
+
+  describe '.to_csv' do
+    before do
+      create(:corporate_partner)
+      @csv = CSV.parse(CorporatePartner.all.to_csv)
     end
 
-    describe '#tool_slug' do
-      it 'should return a slug of the tool' do
-        expect(subject.tool_slug).to eq('sample-tool-syndication')
-      end
+    it 'sets the correct csv headers' do
+      expect(@csv.first).to eq(['id', 'name', 'email', 'tool_name', 'tool_language', 'tool_width_unit', 'tool_width'])
     end
 
-    describe '#total_tool_width' do
-      it 'should the full width with units' do
-        expect(subject.total_tool_width).to eq('500px')
-      end
+    it 'exports all corporate partners' do
+      expect(@csv.length).to eq(2)
     end
-
   end
 end

--- a/spec/models/corporate_partner_spec.rb
+++ b/spec/models/corporate_partner_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe CorporatePartner, type: :model do
   end
 
   describe '#tool_id' do
-    it 'should return a hyphanated version of the tool name' do
+    it 'should return a hyphenated version of the tool name' do
       expect(subject.tool_id).to eq('sample-tool')
     end
   end


### PR DESCRIPTION
* Allows the partnerships team to export a list of all corporate partners who've registered for an embed code at `/en/corporate/syndication` in CSV format.
* CSV export available via url at `/en/corporate/export-partners`