### PR TITLE
Align background image correctly for XL screen sizes (>1200px)

### DIFF
--- a/app/assets/stylesheets/components/page_specific/_home_top.scss
+++ b/app/assets/stylesheets/components/page_specific/_home_top.scss
@@ -54,14 +54,10 @@
 
 .home-top__image {
   @include respond-to($mq-xl) {
+    @include absolutely-centre-horizontally(1350px);
     background: image-url("retirement_shop_en.png") 100% 52% no-repeat;
     background-size: 46%;
     height: 345px;
-    left: 50%;
-    margin-left: -675px;
-    position: absolute;
-    top: 0;
-    width: 1350px;
 
     .theme-cy & {
       background-image: image-url("retirement_shop_cy.png");

--- a/app/assets/stylesheets/components/page_specific/_home_top.scss
+++ b/app/assets/stylesheets/components/page_specific/_home_top.scss
@@ -57,8 +57,10 @@
     background: image-url("retirement_shop_en.png") 100% 52% no-repeat;
     background-size: 46%;
     height: 345px;
-    margin: 0 auto;
+    left: 50%;
+    margin-left: -675px;
     position: absolute;
+    top: 0;
     width: 1350px;
 
     .theme-cy & {

--- a/app/assets/stylesheets/helpers/_layout.scss
+++ b/app/assets/stylesheets/helpers/_layout.scss
@@ -1,0 +1,7 @@
+@mixin absolutely-centre-horizontally($element-width) {
+  left: 50%;
+  margin-left: -1 * $element-width / 2;
+  position: absolute;
+  top: 0;
+  width: $element-width;
+}


### PR DESCRIPTION
@Tr4pSt3R spotted a bug where home page BG promo was not displaying correctly on his 27 incher.

Auto margins will not centre an absolutely positioned element.