### PR TITLE
Redirect to root after feedback if no referrer url

### DIFF
--- a/app/controllers/technical_feedback_controller.rb
+++ b/app/controllers/technical_feedback_controller.rb
@@ -8,7 +8,7 @@ class TechnicalFeedbackController < ApplicationController
       render :new and return
     end
 
-    redirect_to session.delete(:return_to), success: t('.flash_notice')
+    redirect_to session.delete(:return_to) || root_path, success: t('.flash_notice')
   end
 
   private

--- a/spec/controllers/technical_feedback_controller_spec.rb
+++ b/spec/controllers/technical_feedback_controller_spec.rb
@@ -63,6 +63,18 @@ RSpec.describe TechnicalFeedbackController, type: :controller do
       end
     end
 
+    context 'with no return_path' do
+      before do
+        session[:return_to] = nil
+      end
+
+      it 'redirects to root' do
+        post :create, locale: I18n.locale
+
+        expect(response).to redirect_to(root_path(locale: I18n.locale))
+      end
+    end
+
     context 'when the writer call is not successful' do
       before { allow(feedback_writer).to receive(:call).and_yield }
 


### PR DESCRIPTION
After technical feedback is received the user is returned back to the
referring page. This could cause 500 errors if the url was entered
directly.

This fix redirects the user to the root page if there is no referrer.