### PR TITLE
decrease Rails cache expiry to 1 hour

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -57,7 +57,7 @@ Rails.application.configure do
   config.logger = ActiveSupport::TaggedLogging.new(Logger::Syslog.new("frontend", Syslog::LOG_LOCAL6).tap {|log| log.level = Logger::INFO})
 
   # Use a different cache store in production.
-  config.cache_store = :memory_store, { expires_in: 1.day }
+  config.cache_store = :memory_store, { expires_in: 1.hour }
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   config.action_controller.asset_host = 'https://6716c801720b2d014ddd-90dd74bb468e514261468bbc28ae4817.ssl.cf3.rackcdn.com'


### PR DESCRIPTION
This is so the caching of the categories is reduced to every hour instead of once a day. 
I'm not aware of much else that uses caching.