### PR TITLE
TP-6432: Add componentName to existing dough components in frontend

### DIFF
--- a/app/assets/javascripts/components/ClearInput.js
+++ b/app/assets/javascripts/components/ClearInput.js
@@ -24,6 +24,8 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
   */
   DoughBaseComponent.extend(ClearInput);
 
+  ClearInput.componentName = 'ClearInput';
+
   /**
   * Set up and populate the model from the form inputs
   * @param {Promise} initialised

--- a/app/assets/javascripts/components/EmbedCodeGenerator.js
+++ b/app/assets/javascripts/components/EmbedCodeGenerator.js
@@ -21,6 +21,8 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
 
   DoughBaseComponent.extend(EmbedCodeGenerator);
 
+  EmbedCodeGenerator.componentName = 'EmbedCodeGenerator';
+
   EmbedCodeGeneratorProto = EmbedCodeGenerator.prototype;
 
   EmbedCodeGeneratorProto.init = function(initialised) {

--- a/app/assets/javascripts/components/InputFilters.js
+++ b/app/assets/javascripts/components/InputFilters.js
@@ -28,6 +28,8 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
 
   DoughBaseComponent.extend(InputFilters);
 
+  InputFilters.componentName = 'InputFilters';
+
   InputFilters.prototype.init = function() {
     this.$el.on('change', this.config.trigger, $.proxy(this._onChange, this));
 

--- a/app/assets/javascripts/components/Newsletter.js
+++ b/app/assets/javascripts/components/Newsletter.js
@@ -14,6 +14,8 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
   */
   DoughBaseComponent.extend(Newsletter);
 
+  Newsletter.componentName = 'Newsletter';
+
   /**
   * @param {Promise} initialised
   */

--- a/app/assets/javascripts/components/StickyColumn.js
+++ b/app/assets/javascripts/components/StickyColumn.js
@@ -31,6 +31,8 @@ define(['jquery', 'DoughBaseComponent', 'eventsWithPromises'], function($, Dough
   */
   DoughBaseComponent.extend(StickyColumn);
 
+  StickyColumn.componentName = 'StickyColumn';
+
   /**
    * Initialize the component
    * @param {Promise} initialised


### PR DESCRIPTION

![screen shot 2015-06-18 at 10 47 08](https://cloud.githubusercontent.com/assets/6049076/8228512/48fdefc6-15a7-11e5-8a41-cd7bfe486c27.png)


ClearInput, Newsletter, StickyColumn etc etc don't have a componentName set in the JS.
 
This is causing DoughBaseComponent to spit out a console warning.
 
This task is to add names to each JS module so this warning goes away.