### PR TITLE
TP-6435: update dough_ruby for frontend

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -286,7 +286,7 @@ GEM
     dotenv (0.10.0)
     dotenv-rails (0.10.0)
       dotenv (= 0.10.0)
-    dough-ruby (5.7.1.251)
+    dough-ruby (5.7.2.253)
       activesupport
       rails (>= 3.2)
       sass-rails (~> 4.0.0)


### PR DESCRIPTION
This updates dough-ruby to latest version which includes this PR:

https://github.com/moneyadviceservice/dough/pull/233