### PR TITLE
Partners embed code submission

### DIFF
--- a/app/controllers/corporate_controller.rb
+++ b/app/controllers/corporate_controller.rb
@@ -18,7 +18,8 @@ class CorporateController < ArticlesController
   end
 
   def create
-    @partner = CorporatePartner.new(partner_params)
+    @partner = CorporatePartner.find_or_initialize_by(params[:email])
+    @partner.assign_attributes(partner_params)
     @partner.tool_name = tool_friendly_name
 
     if @partner.save

--- a/app/controllers/corporate_controller.rb
+++ b/app/controllers/corporate_controller.rb
@@ -18,7 +18,7 @@ class CorporateController < ArticlesController
   end
 
   def create
-    @partner = CorporatePartner.find_or_initialize_by(params[:email])
+    @partner = CorporatePartner.find_or_initialize_by(email: params[:corporate_partner][:email])
     @partner.assign_attributes(partner_params)
     @partner.tool_name = tool_friendly_name
 

--- a/app/models/corporate_partner.rb
+++ b/app/models/corporate_partner.rb
@@ -2,7 +2,6 @@ class CorporatePartner < ActiveRecord::Base
 
   validates :name, :tool_name, :tool_language, :tool_width_unit, :tool_width, presence: true
   validates_with Validators::Email, attributes: [:email]
-  validates :email, uniqueness: true
   validates :tool_width, numericality: { only_integer: true, greater_than: 0 }
 
   def tool_id

--- a/features/corporate_tool_page.feature
+++ b/features/corporate_tool_page.feature
@@ -19,6 +19,18 @@ Feature: Corporate Tool Page
     Then I should be presented with the embed code
     And  I should see a successful confirmation of my details submitted
 
+  @enable-corporate-tool-directory
+  Scenario: Re-requesting tool embed code
+    Given I have received an embed code
+    When  I visit a corporate tool page
+    And   I fill out my organisation name
+    And   I fill out my organisation email
+    And   I specify the language I want the tool in
+    And   I specify the width of the tool
+    And   I request for the embded code
+    Then  I should be presented with the embed code
+    And   I should see a successful confirmation of my details submitted
+
   Scenario: A corporate tool page is not accessible when feature is disabled
     When I visit a corporate tool page
     Then I am told that the functionality is not implemented

--- a/features/step_definitions/corporate_tool_page_steps.rb
+++ b/features/step_definitions/corporate_tool_page_steps.rb
@@ -1,3 +1,15 @@
+Given(/^I have received an embed code$/) do
+  step 'I visit a corporate tool page'
+  step 'I fill out my organisation name'
+  step 'I fill out my organisation email'
+  step 'I specify the language I want the tool in'
+  step 'I specify the width of the tool'
+  step 'I request for the embded code'
+  step 'I should be presented with the embed code'
+  step 'I should see a successful confirmation of my details submitted'
+  step 'I should be on the corporate tool page'
+end
+
 When(/^I visit a corporate tool page$/) do
   corporate_tool_page.load(locale: 'en')
 end

--- a/spec/controllers/corporate_controller_spec.rb
+++ b/spec/controllers/corporate_controller_spec.rb
@@ -82,6 +82,21 @@ RSpec.describe CorporateController, type: :controller, features: [:corporate_too
       end
     end
 
+    context 'with valid attributes and a partner record already exists' do
+
+      before do
+        post :create, locale: I18n.locale, corporate_partner: valid_partner, id: tool.id
+      end
+
+      it 'updates existing partner record' do
+        expect do
+          post :create, locale: I18n.locale, corporate_partner: valid_partner, id: tool.id
+        end.to_not change(CorporatePartner, :count)
+        expect(CorporatePartner.count).to eq(1)
+      end
+
+    end
+
     context 'with invalid attributes' do
       it 'does not save the new partner' do
         expect do

--- a/spec/models/corporate_partner_spec.rb
+++ b/spec/models/corporate_partner_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe CorporatePartner, type: :model do
     it { is_expected.not_to allow_value('').for(:name) }
 
     it { is_expected.to allow_value('example@domain.com').for(:email) }
-    it { is_expected.to validate_uniqueness_of(:email) }
     it { is_expected.not_to allow_value('inv@lid@dress.com').for(:email) }
 
     it { is_expected.to allow_value('Sample Tool').for(:tool_name) }


### PR DESCRIPTION
Allows partners to re-request for another embed code using an existing email address. 

![mysizq4kyo](https://cloud.githubusercontent.com/assets/616080/8327604/9992888e-1a61-11e5-9754-3037d6450078.gif)
