### PR TITLE
TP-6444: Remove menu button from profile and registration pages

### DIFF
--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -1,6 +1,8 @@
 class CampaignsController < ApplicationController
   decorates_assigned :campaign, with: CampaignPage::CampaignDecorator
 
+  include SuppressMenuButton
+
   def show
     if template_exists?("/campaigns/#{params[:id].underscore}")
       render template: "/campaigns/#{params[:id].underscore}", layout: '_unconstrained'
@@ -8,9 +10,5 @@ class CampaignsController < ApplicationController
       @campaign = Template.new.build_campaign(params[:id])
       render :show
     end
-  end
-
-  def display_menu_button_in_header?
-    false
   end
 end

--- a/app/controllers/concerns/suppress_menu_button.rb
+++ b/app/controllers/concerns/suppress_menu_button.rb
@@ -1,0 +1,5 @@
+module SuppressMenuButton
+  def display_menu_button_in_header?
+    false
+  end
+end

--- a/app/controllers/debt_management_controller.rb
+++ b/app/controllers/debt_management_controller.rb
@@ -1,9 +1,7 @@
 class DebtManagementController < ApplicationController
   layout '_unconstrained'
 
-  def display_menu_button_in_header?
-    false
-  end
+  include SuppressMenuButton
 
   def hide_contact_panels?
     true

--- a/app/controllers/embedded_tools_controller.rb
+++ b/app/controllers/embedded_tools_controller.rb
@@ -1,6 +1,8 @@
 class EmbeddedToolsController < ApplicationController
   protected
 
+  include SuppressMenuButton
+
   def breadcrumbs
     BreadcrumbTrail.build(category, category_tree)
   end
@@ -65,10 +67,6 @@ class EmbeddedToolsController < ApplicationController
 
   def contact_panels_border_top?
     true
-  end
-
-  def display_menu_button_in_header?
-    false
   end
 
   def display_category_directory?

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,12 +1,9 @@
 class ErrorsController < ApplicationController
   include Gaffe::Errors
+  include SuppressMenuButton
 
   def show
     render :show, status: @status_code
-  end
-
-  def display_menu_button_in_header?
-    false
   end
 
   def display_skip_to_main_navigation?

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,9 +1,7 @@
 class HomeController < ApplicationController
-  def show
-  end
+  include SuppressMenuButton
 
-  def display_menu_button_in_header?
-    false
+  def show
   end
 
   def display_skip_to_main_navigation?

--- a/app/controllers/landing_pages_controller.rb
+++ b/app/controllers/landing_pages_controller.rb
@@ -1,10 +1,8 @@
 class LandingPagesController < ApplicationController
+  include SuppressMenuButton
+
   def show
     @breadcrumbs = BreadcrumbTrail.home
     render layout: '_unconstrained'
-  end
-
-  def display_menu_button_in_header?
-    false
   end
 end

--- a/app/controllers/mount_controller.rb
+++ b/app/controllers/mount_controller.rb
@@ -1,6 +1,8 @@
 class MountController < ApplicationController
   protected
 
+  include SuppressMenuButton
+
   def breadcrumbs
     BreadcrumbTrail.home
   end
@@ -33,10 +35,6 @@ class MountController < ApplicationController
 
   def contact_panels_border_top?
     true
-  end
-
-  def display_menu_button_in_header?
-    false
   end
 
   def display_category_directory?

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -1,6 +1,8 @@
 class ProfileController < ArticlesController
   before_action :authenticate_user!
 
+  include SuppressMenuButton
+
   def edit
   end
 

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -2,6 +2,8 @@ class RegistrationsController < Devise::RegistrationsController
   skip_before_action :store_location
   before_action :configure_permitted_parameters
 
+  include SuppressMenuButton
+
   protected
 
   def build_resource(hash = nil)

--- a/app/controllers/retirements_controller.rb
+++ b/app/controllers/retirements_controller.rb
@@ -2,11 +2,9 @@ class RetirementsController < ApplicationController
   layout 'layouts/_unconstrained'
   helper_method :locale_options
 
+  include SuppressMenuButton
+
   def locale_options
     LandingPagePaths.locale_options(params[:controller], params[:action])
-  end
-
-  def display_menu_button_in_header?
-    false
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,6 +2,8 @@ class SessionsController < Devise::SessionsController
   skip_before_action :store_location
   before_action :xhr_not_implemented, only: [:new]
 
+  include SuppressMenuButton
+
   def new
     # This method is mostly copied devise code
     # With one tweak to add the error to resource from the flash hash


### PR DESCRIPTION
![screen shot 2015-06-24 at 14 56 03](https://cloud.githubusercontent.com/assets/6049076/8331569/07ac8f58-1a81-11e5-9e63-dcfff333b50f.png)

- Added method to three controllers to remove the menu button
  as there is no menu markup output on these sections of pages
- This was causing a "t.find is not a function" JS error appearing no these pages.