### PR TITLE
TP-6462: Override wrapping style on buttons for retirement page

### DIFF
--- a/app/assets/stylesheets/layout/page_specific/_retirements.scss
+++ b/app/assets/stylesheets/layout/page_specific/_retirements.scss
@@ -30,6 +30,10 @@
   &:last-child {
     margin-bottom: 0;
   }
+
+  .button {
+    white-space: normal;
+  }
 }
 
 .l-retirements__image {


### PR DESCRIPTION
- ensure buttons with quite long content don't cause horizontal
  scrolling issues