### PR TITLE
Renaming page_specific link_list -> category_link_list

### DIFF
--- a/app/assets/stylesheets/components/page_specific/_category_link_list.scss
+++ b/app/assets/stylesheets/components/page_specific/_category_link_list.scss
@@ -2,7 +2,8 @@
   Link list component
   Currently used on category pages to list out yellow underlined links
 */
-.link-list {
+.category-link-list {
+  @extend .unstyled-list;
   @include body(22, 40);
   font-weight: bold;
 
@@ -13,25 +14,25 @@
   }
 }
 
-.link-list__item {
+.category-link-list__item {
   display: inline;
   margin-right: $baseline_unit;
 
   &:before {
     // This is to override the highly specific .editorial list styling
     content: none !important;
-  }  
+  }
 }
 
-.link-list__item:after {
+.category-link-list__item:after {
   content: ", ";
 }
- 
-.link-list__item:last-child:after {
+
+.category-link-list__item:last-child:after {
   content: none;
 }
 
-.link-list__item__link {
+.category-link-list__item__link {
   border-bottom: 3px solid $color-yellow-dark;
   padding-bottom: 5px;
 

--- a/app/views/categories/_top_links.html.erb
+++ b/app/views/categories/_top_links.html.erb
@@ -1,8 +1,8 @@
 <%= heading_tag 'How can we help?', level: 2, class: 'l-category__top__link-list-heading' %>
-<ul class="link-list">
+<ul class="category-link-list">
   <% category.links.each do |link| %>
-    <li class="link-list__item">
-      <a class="link-list__item__link" href="<%= link['url'] %>"><%= link['text'] %></a>
+    <li class="category-link-list__item">
+      <a class="category-link-list__item__link" href="<%= link['url'] %>"><%= link['text'] %></a>
     </li>
   <% end %>
 </ul>


### PR DESCRIPTION
Naming clash that was spilling to pages using link_list from common. Mainly the pensions and retirement landing page.

Also adds `@extend .unstyled-list` as this was because inherited from the 'common' component, and now we've separated them it needs to be declared here, too.