### PR TITLE
id:6458 comment: Suppress breadcrumb for mobiles devices

### DIFF
--- a/app/assets/stylesheets/layout/common/_context_bar.scss
+++ b/app/assets/stylesheets/layout/common/_context_bar.scss
@@ -1,15 +1,16 @@
 .l-context-bar {
-  padding-top: $baseline-unit*2;
-  padding-bottom: $baseline-unit*2;
-  background-color: $breadcrumbs-background-color;
-
-  @include respond-to($mq-m) {
-    padding-top: $baseline-unit*3;
-    padding-bottom: $baseline-unit*3;
+  @include respond-to($mq-xs, $mq-s-max) {
+    @include visually-hidden;
   }
 
-  .breadcrumbs,
-  .related-categories {
-    @include column(12);
+  @include respond-to($mq-m) {
+    background-color: $breadcrumbs-background-color;
+    padding-top: $baseline-unit*3;
+    padding-bottom: $baseline-unit*3;
+
+    .breadcrumbs,
+    .related-categories {
+      @include column(12);
+    }
   }
 }


### PR DESCRIPTION
<img width="468" alt="screen shot 2015-07-08 at 12 10 15" src="https://cloud.githubusercontent.com/assets/6049076/8568917/4ccd9390-256a-11e5-91be-41218b83ecdd.png">

viewports less than 720px view port

It was felt that the breadcrumb was taking up too much screen real-estate on mobiles, and also google had an issue in their 'mobile optimised' report that the touch targets were too small on the crumb.

- ensures it only surpresses the breadcrumb visually and is still
  accessible for screen readers