### PR TITLE
Add a simple mas diff version script for everyone that bump version on the scripts repo

### DIFF
--- a/bin/mas-version-diff
+++ b/bin/mas-version-diff
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+# USAGE
+# ./bin/mas-version-diff 1869 1870
+# They should be in ascending order
+
+git log --pretty=format:"%C(yellow)%h%Cred%d\\ %Creset%s%Cblue\\ [%cn]" --decorate $1..$2


### PR DESCRIPTION
* This will be used to everybody (frontend/backend) devs when pointing the
frontend version on the scripts repo

Run like:

```
 ./bin/mas-version-diff 1865 1870
```

The result:

```
8838a16 (tag: 1870)\ Merge pull request #1137 from moneyadviceservice/fix-tool-name-routing-error\ [Jones Agyemang]
871f490\ redirects incorrect tool url to 404 page\ [Jones Agyemang]
129fac3 (tag: 1869)\ Merge pull request #1135 from moneyadviceservice/remove-registration-edit-feature\ [Jones Agyemang]
ad906fc\ remove unnecessary registration edit feature\ [Jones Agyemang]
b90b62d\ Merge pull request #1134 from moneyadviceservice/remove-404-page-feature\ [Tomas D'Stefano]
c3a84b8\ remove 404 page feature\ [Jones Agyemang]
1b86283\ Merge pull request #1128 from moneyadviceservice/error-page-routing\ [Jones Agyemang]
61930f0\ remove unnecessary feature spec file\ [Jones Agyemang]
bea132f\ fix syntax error\ [Jones Agyemang]
6bac842\ remove unnecessary 404 feature spec file\ [Jones Agyemang]
444e85e\ add tests for 404 page not found errors\ [Jones Agyemang]
```