### PR TITLE
Accessibility updates suggested by DAC

### DIFF
--- a/app/assets/stylesheets/components/page_specific/_category_detail.scss
+++ b/app/assets/stylesheets/components/page_specific/_category_detail.scss
@@ -143,7 +143,12 @@
       &:focus,
       &:hover {
         outline: none;
-        text-decoration: underline;
+        border-bottom: 2px solid $color-green-dark;
+        margin-bottom: -2px;
+
+        svg {
+          fill: $color-green-dark;
+        }
       }
     }
 

--- a/app/assets/stylesheets/components/page_specific/_category_link_list.scss
+++ b/app/assets/stylesheets/components/page_specific/_category_link_list.scss
@@ -36,15 +36,17 @@
   border-bottom: 3px solid $color-yellow-dark;
   padding-bottom: 5px;
 
-  &:link,
   &:focus,
-  &:visited {
-    color: $color-true-black;
-  }
-
   &:hover {
     border-bottom: 3px solid $color-true-black;
     text-decoration: none;
+  }
+
+  &:focus,
+  &:link,
+  &:visited,
+  &:hover,
+  &:active {
     color: $color-true-black;
   }
 }

--- a/app/views/categories/_child_categories.html.erb
+++ b/app/views/categories/_child_categories.html.erb
@@ -22,6 +22,7 @@
         <%= render 'shared/svg/use_icon', icon: 'minus', variant: 'blue' %>
         <span class="category-detail__view-more__label-more"><%= t('categories.show.view_more') %></span>
         <span class="category-detail__view-more__label-less"><%= t('categories.show.view_less') %></span>
+        <span class="visually-hidden"> <%= child_category.title %></span>
       </span>
     <% end %>
   </section>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -303,8 +303,8 @@ cy:
       how_can_we_help: Sut allwn ni helpu?
     show:
       view_all: Gweld yr holl ...
-      view_more: View more
-      view_less: View less
+      view_more: Expand
+      view_less: Contract
 
   article_feedbacks:
     new:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -302,8 +302,8 @@ en:
       how_can_we_help: How can we help?
     show:
       view_all: View all ...
-      view_more: View more
-      view_less: View less
+      view_more: Expand
+      view_less: Contract
 
   article_feedbacks:
     new:


### PR DESCRIPTION
This PR includes some accessibility enhancements for the category pages, based upon DAC recommendation which can be seen below.

--
DAC Response - I would say that adding the function to the heading is a really good idea. However, a keyboard only user may become disorientated by the ‘+’ not receiving any visible link focus on tab. To me, the focus being only on the ‘Running a bank account’ and not on the ‘+’ sign (see screen shot) suggests that I will not be viewing more content. I would definitely underline the ‘+’ sign and possibly make it green so that they look related and one link.
Also, a ‘view more’ link usually directs users to another page/window. The ‘+’ sign is the standard icon for expandable content.