### PR TITLE
id:6499 comment:fix for button on small viewport

### DIFF
--- a/app/assets/stylesheets/layout/page_specific/_registration.scss
+++ b/app/assets/stylesheets/layout/page_specific/_registration.scss
@@ -18,7 +18,7 @@
       @include column(4, 12);
     }
 
-    .theme-cy & .button--primary {
+    .theme-cy & .button {
       white-space: normal;
     }
   }


### PR DESCRIPTION
- welsh language version of button too wide so allowed text to wrap only in this instance.
- updates previous fix for this issue which applied to button--primary, which is now replaced by button--newsletter