### PR TITLE
Give lists in tables uniform font size

### DIFF
--- a/app/assets/stylesheets/components/common/_lists.scss
+++ b/app/assets/stylesheets/components/common/_lists.scss
@@ -95,6 +95,15 @@
   @extend .list;
 }
 
+// Dough sets th, td to 14px. We want contained lists to match within editorial content.
+.editorial {
+  th, td {
+    ul, ol {
+      @include body(14, 24);
+    }
+  }
+}
+
 // Yes/No list style for editorial content
 .editorial .yes-no {
   padding-left: 0;


### PR DESCRIPTION
Requirement is to keep font size of lists the same as the rest of the table