### PR TITLE
Update content on debt management company list

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -303,8 +303,8 @@ cy:
       how_can_we_help: Sut allwn ni helpu?
     show:
       view_all: Gweld yr holl ...
-      view_more: Expand
-      view_less: Contract
+      view_more: Helaethu
+      view_less: Lleihau
 
   article_feedbacks:
     new:

--- a/config/locales/debt_management/debt_management.cy.yml
+++ b/config/locales/debt_management/debt_management.cy.yml
@@ -171,3 +171,4 @@ cy:
       - Clear View Finance Limited
       - Haydon Associates Debt Management Consultants Limited
       - Monmouthshire Financial Management Limited
+      - Repayment Management Services / Repayment Management UK Ltd (Nid yw’r cwmni hwn erioed wedi cael ei awdurdodi gan yr FCA, sy’n golygu na all cwsmeriaid gwyno amdanynt i Wasanaeth yr Ombwdsmon Ariannol)

--- a/config/locales/debt_management/debt_management.en.yml
+++ b/config/locales/debt_management/debt_management.en.yml
@@ -170,3 +170,4 @@ en:
       - Clear View Finance Limited
       - Haydon Associates Debt Management Consultants Limited
       - Monmouthshire Financial Management Limited
+      - Repayment Management Services / Repayment Management UK Ltd (This firm was never authorised by the FCA, meaning customers cannot complain about them to the Financial Ombudsman Service)


### PR DESCRIPTION
Content lives here:
https://www.moneyadviceservice.org.uk/en/campaigns/debt-management/companies

Slipped in another small Welsh translation for category pages.