### PR TITLE
id: 6558, comment: Debt advice locator tool link broken in Welsh version

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -218,7 +218,7 @@ cy:
           text: Defnyddiwch ein Cynllunydd cyllideb i gadw trefn ar eich gwariant
           content: Cymrwch bum munud i ddefnyddio ein hofferyn i weld faint sydd gennych dros ben wedi talu am y biliau pwysicaf
       stripe_banner:
-        url: /cy/tools/debt-advice-locator
+        url: /cy/tools/canfyddwr-cyngor-ar-ddyledion
         worried_about_debt: Ydych chi’n pryderu am ddyledion?
         find_out_where: Dysgwch lle i gael cymorth cyfrinachol yn rhad ac am ddim yn awr
       blog_title: Eich blog Cyngor Ariannol


### PR DESCRIPTION
- updated YAML file to Welsh language URL