### PR TITLE
id: 6636, comment: Remove Back2credit from debt management pages

### DIFF
--- a/config/locales/debt_management/debt_management.cy.yml
+++ b/config/locales/debt_management/debt_management.cy.yml
@@ -156,7 +156,6 @@ cy:
       - Acr Finance
       - Barrington Lewis Limited
       - PJG Recovery (Scotland) Limited
-      - Back2Credit
       - Bridgewood Financial Solutions Limited
       - Debt-Simple Limited
       - Hall & Co Financial Solutions Limited

--- a/config/locales/debt_management/debt_management.en.yml
+++ b/config/locales/debt_management/debt_management.en.yml
@@ -155,7 +155,6 @@ en:
       - Acr Finance
       - Barrington Lewis Limited
       - PJG Recovery (Scotland) Limited
-      - Back2Credit
       - Bridgewood Financial Solutions Limited
       - Debt-Simple Limited
       - Hall & Co Financial Solutions Limited


### PR DESCRIPTION
- company name removed from lists in en and cy yml files, used by both pages