### PR TITLE
fix 404 catchall when cms content not found

### DIFF
--- a/app/controllers/catchall_controller.rb
+++ b/app/controllers/catchall_controller.rb
@@ -7,6 +7,8 @@ class CatchallController < ApplicationController
     end
 
     raise ActionController::RoutingError.new('Not Found')
+  rescue Core::Repository::Base::RequestError => e
+    raise ActionController::RoutingError.new('Not Found')
   end
 
   private

--- a/spec/cassettes/core/repository/cms/cms_api/find/idonotexist_nested.yml
+++ b/spec/cassettes/core/repository/cms/cms_api/find/idonotexist_nested.yml
@@ -1,0 +1,50 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3000/api/en/idonotexist/other.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mas-Responsive/1.0 (phlee.local; plee; 4123) ruby/2.1.2 (95; x86_64-darwin14.0)
+      X-Request-Id:
+      - da4d1629-65c8-4008-8fc7-3cd0ef1a8744
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: 'Bad Request '
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - da4d1629-65c8-4008-8fc7-3cd0ef1a8744
+      X-Runtime:
+      - '0.011549'
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.1.2/2014-05-08)
+      Date:
+      - Fri, 04 Sep 2015 10:59:44 GMT
+      Content-Length:
+      - '53'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"message":"Page type \"idonotexist\" not supported"}'
+    http_version: 
+  recorded_at: Fri, 04 Sep 2015 10:59:44 GMT
+recorded_with: VCR 2.9.2

--- a/spec/requests/404_spec.rb
+++ b/spec/requests/404_spec.rb
@@ -16,6 +16,14 @@ RSpec.describe '404 catachall', type: :request, features: [:redirects] do
     end
   end
 
+  context 'when nested page does not exist' do
+    it 'renders the 404 page' do
+      VCR.use_cassette('core/repository/cms/cms_api/find/idonotexist_nested') do
+        expect { get '/en/idonotexist/other' }.to raise_error(ActionController::RoutingError, 'Not Found')
+      end
+    end
+  end
+
   context 'when redirect in cms exists' do
     it 'redirects' do
       VCR.use_cassette('core/repository/cms/cms_api/find/iamredirect') do


### PR DESCRIPTION
the cms api throws an error when it doesn't recognize certain urls
for now we handle this to return a 404

the better fix is to make the cms not have this constraint
and return a 404 when the resoure cannot be located
however this needs further looking into in case there are compatability
issues