### PR TITLE
Fix opt in db migration

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -133,7 +133,7 @@
         <fieldset class="form__group">
           <div class="form__group-item">
             <%= f.label :opt_in_for_research, class: "form__label-heading" do %>
-              <%= f.check_box :opt_in_for_research, class: "form__group-input" %>
+              <%= f.check_box :opt_in_for_research, { checked: true }, class: "form__group-input" %>
               <%= t("activerecord.attributes.user.opt_in_for_research") %>
             <% end %>
           </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -133,7 +133,7 @@
         <fieldset class="form__group">
           <div class="form__group-item">
             <%= f.label :opt_in_for_research, class: "form__label-heading" do %>
-              <%= f.check_box :opt_in_for_research, { checked: true }, class: "form__group-input" %>
+              <%= f.check_box :opt_in_for_research, class: "form__group-input" %>
               <%= t("activerecord.attributes.user.opt_in_for_research") %>
             <% end %>
           </div>

--- a/db/migrate/20150928135300_change_default_value_for_opt_in_for_research.rb
+++ b/db/migrate/20150928135300_change_default_value_for_opt_in_for_research.rb
@@ -1,0 +1,5 @@
+class ChangeDefaultValueForOptInForResearch < ActiveRecord::Migration
+  def change
+    change_column :users, :opt_in_for_research, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -955,7 +955,7 @@ ActiveRecord::Schema.define(version: 20150904094809) do
     t.string   "goal_statement"
     t.string   "goal_deadline"
     t.string   "contact_number"
-    t.boolean  "opt_in_for_research",                       default: true
+    t.boolean  "opt_in_for_research",                default: false
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree

--- a/features/registration.feature
+++ b/features/registration.feature
@@ -21,7 +21,7 @@ Feature: Registration
 
   Scenario: Default value for market research field
     When I visit the registration page
-    Then the option to participate in marketing research should be checked
+    Then the option to participate in marketing research should not be checked
 
   Scenario Outline: Attempt to register with bad details
     When I attempt to register with <Problem>

--- a/features/registration.feature
+++ b/features/registration.feature
@@ -19,6 +19,10 @@ Feature: Registration
     When I visit the registration page
     Then I should have the option to opt-in or opt-out of participating in research
 
+  Scenario: Default value for market research field
+    When I visit the registration page
+    Then the option to participate in marketing research should be checked
+
   Scenario Outline: Attempt to register with bad details
     When I attempt to register with <Problem>
     Then My MAS account should not be created

--- a/features/step_definitions/registration_steps.rb
+++ b/features/step_definitions/registration_steps.rb
@@ -113,3 +113,8 @@ end
 Then(/^I should not see the registration benefits$/) do
   expect(sign_up_page).to_not have_benefits
 end
+
+Then(/^the option to participate in marketing research should be checked$/) do
+  step 'I should have the option to opt-in or opt-out of participating in research'
+  expect(sign_up_page.opt_in_for_research.checked?).to be_truthy
+end

--- a/features/step_definitions/registration_steps.rb
+++ b/features/step_definitions/registration_steps.rb
@@ -114,7 +114,7 @@ Then(/^I should not see the registration benefits$/) do
   expect(sign_up_page).to_not have_benefits
 end
 
-Then(/^the option to participate in marketing research should be checked$/) do
+Then(/^the option to participate in marketing research should not be checked$/) do
   step 'I should have the option to opt-in or opt-out of participating in research'
-  expect(sign_up_page.opt_in_for_research.checked?).to be_truthy
+  expect(sign_up_page.opt_in_for_research.checked?).to be_falsey
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,6 +9,15 @@ RSpec.describe User, type: :model do
 
   subject { described_class.new(attributes) }
 
+  describe 'default values' do
+    context 'create a new user record' do
+      it 'opt_in_for_research should be false' do
+        expect(subject.opt_in_for_research).to be_falsey
+      end
+    end
+  end
+
+
   describe '#fake_send_confirmation_email' do
     it 'sends a fake confirmation email when user is saved' do
       subject.save!


### PR DESCRIPTION
    Fixes the issue we experienced and the horrors of setting defaults at the
    database level. This fix maintains the opt-in for market research field being
    set to true automatically. This assertion is on the form only. It's done neither
    through callbacks nor database defaults.