### PR TITLE
limit static pages to contact us

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,6 +1,5 @@
 class StaticPagesController < ApplicationController
   decorates_assigned :static_page, with: ContentItemDecorator
-  skip_before_action :store_location, if: :auth_related_page?
 
   def show
     @static_page = Core::StaticPageReader.new(params[:id]).call do
@@ -14,11 +13,5 @@ class StaticPagesController < ApplicationController
     else
       render :show
     end
-  end
-
-  private
-
-  def auth_related_page?
-    ['privacy', 'terms-and-conditions'].include?(params[:id])
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -209,7 +209,8 @@ Rails.application.routes.draw do
 
     resources :static_pages,
               path:        'static',
-              only:        'show'
+              only:        'show',
+              constraints: { id: %r{contact-us|cysylltu-a-ni} }
 
     resource :feedback, only: [:new, :create], controller: :technical_feedback, as: :technical_feedback
 

--- a/features/step_definitions/breadcrumbs_steps.rb
+++ b/features/step_definitions/breadcrumbs_steps.rb
@@ -11,7 +11,7 @@ Given(/^I read an action plan belonging to multiple categories$/) do
 end
 
 Given(/^I read a static page$/) do
-  static_page.load(locale: 'en', id: 'privacy')
+  static_page.load(locale: 'en', id: 'contact-us')
 end
 
 Given(/^I read a news article$/) do

--- a/features/step_definitions/static_page_steps.rb
+++ b/features/step_definitions/static_page_steps.rb
@@ -18,7 +18,7 @@ Then(/^I should see the static page in (.*)$/) do |language|
 
   expect(static_page.title).to eq("#{current_static_page.title} - #{I18n.t('layouts.base.title')}")
   expect(static_page.description[:content]).to include(current_static_page.description)
-  expect(static_page.heading).to have_content(current_static_page.title)
+  expect(static_page.heading).to have_content(%r{#{current_static_page.title}}i)
 end
 
 When(/^I view a static page with an intro$/) do

--- a/features/support/world/static_pages.rb
+++ b/features/support/world/static_pages.rb
@@ -3,9 +3,9 @@ module World
     def static_page_id_for_locale(locale)
       case locale
       when 'en'
-        'privacy'
+        'contact-us'
       when 'cy'
-        'polisipreifatrwydd'
+        'cysylltu-a-ni'
       end
     end
 

--- a/spec/controllers/static_pages_controller_spec.rb
+++ b/spec/controllers/static_pages_controller_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe StaticPagesController, type: :controller do
   describe 'GET show' do
     let(:categories) { [] }
     let(:parents) { [] }
-    let(:static_page_id) { 'test' }
+    let(:static_page_id) { 'contact-us' }
     let(:static_page) { Core::StaticPage.new(static_page_id, categories: categories) }
     let(:static_page_reader) { double(Core::StaticPageReader, call: static_page) }
     let(:category_tree) { double }
@@ -16,7 +16,7 @@ RSpec.describe StaticPagesController, type: :controller do
       end
 
       it 'is successful' do
-        get :show, id: 'foo', locale: I18n.locale
+        get :show, id: static_page_id, locale: I18n.locale
 
         expect(response).to be_ok
       end
@@ -43,14 +43,6 @@ RSpec.describe StaticPagesController, type: :controller do
           expect(subject).to render_template("static_pages/#{static_page_id.underscore}")
         end
       end
-
-      context 'if there is no custom template' do
-        subject { get :show, locale: I18n.locale, id: static_page.id }
-
-        it 'renders the default template' do
-          expect(subject).to render_template('static_pages/show')
-        end
-      end
     end
 
     context 'when an static_page does not exist' do
@@ -58,26 +50,6 @@ RSpec.describe StaticPagesController, type: :controller do
         allow_any_instance_of(Core::StaticPageReader).to receive(:call).and_yield
 
         expect { get :show, id: 'foo', locale: I18n.locale }.to raise_error(ActionController::RoutingError)
-      end
-    end
-
-    context 'when an auth related page' do
-      context 'when privacy policy' do
-        it 'does not store location' do
-          VCR.use_cassette :privacy do
-            get :show, id: 'privacy', locale: I18n.locale
-          end
-          expect(session['user_return_to']).to be_nil
-        end
-      end
-
-      context 'when terms and conditions' do
-        it 'does not store location' do
-          VCR.use_cassette :terms do
-            get :show, id: 'terms-and-conditions', locale: I18n.locale
-          end
-          expect(session['user_return_to']).to be_nil
-        end
       end
     end
   end


### PR DESCRIPTION
- this removes code that is no longer used as we only have 2 static pages. these are `contact-us` and the welsh equivalent
- this also solves the problem of static redirects handled by the cms. as these routes will no longer be routed by the application the catchall route and controller will take care of these redirects.