### PR TITLE
catchall controller passes format to cms

### DIFF
--- a/app/controllers/catchall_controller.rb
+++ b/app/controllers/catchall_controller.rb
@@ -14,6 +14,14 @@ class CatchallController < ApplicationController
   private
 
   def interactor
-    Core::RedirectReader.new(params[:path])
+    Core::RedirectReader.new(path)
+  end
+
+  def path
+    if params[:format]
+      params[:path] + "." + params[:format]
+    else
+      params[:path]
+    end
   end
 end

--- a/spec/cassettes/en/core/cms/cms_api/find/redirected.yml
+++ b/spec/cassettes/en/core/cms/cms_api/find/redirected.yml
@@ -1,0 +1,44 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3000/api/default.aspx.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mas-Responsive/1.0 (phlee.local; plee; 2852) ruby/2.1.2 (95; x86_64-darwin14.0)
+      X-Request-Id:
+      - 3f9737cf-3e1f-4954-b475-c19baeffc697
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 301
+      message: 'Moved Permanently '
+    headers:
+      Location:
+      - http://localhost:5000/en
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 3f9737cf-3e1f-4954-b475-c19baeffc697
+      X-Runtime:
+      - '0.009176'
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.1.2/2014-05-08)
+      Date:
+      - Thu, 01 Oct 2015 10:08:23 GMT
+      Content-Length:
+      - '0'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 01 Oct 2015 10:08:23 GMT
+recorded_with: VCR 2.9.2

--- a/spec/requests/not_implemented_spec.rb
+++ b/spec/requests/not_implemented_spec.rb
@@ -5,3 +5,23 @@ RSpec.describe 'Request we have no implementation for', type: :request do
     expect(response.status).to eq(501)
   end
 end
+
+RSpec.describe 'Request that is redirected', type: :request, features: [:redirects] do
+  it 'redirects to specified location' do
+    VCR.use_cassette('/en/core/repository/categories/cms/find/redirected') do
+      get('/en/categories/redirected')
+
+      expect(response).to redirect_to('http://localhost:5000/en')
+    end
+  end
+end
+
+RSpec.describe 'Request that is redirected with extension', type: :request, features: [:redirects] do
+  it 'redirects to specified location' do
+    VCR.use_cassette('/en/core/cms/cms_api/find/redirected') do
+      get('/default.aspx')
+
+      expect(response).to redirect_to('http://localhost:5000/en')
+    end
+  end
+end


### PR DESCRIPTION
for example this will allow urls with the extension .pdf
to be redirected