### PR TITLE
remove pointless route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -269,8 +269,6 @@ Rails.application.routes.draw do
     end
   end
 
-  match '/tools/:id', to: not_implemented, via: 'get', as: 'tool'
-
   if Feature.active?(:redirects)
     match '*path', via: :all, to: 'catchall#not_implemented'
   else


### PR DESCRIPTION
this route is pointless because it will eventually be caught by a bigger net anyway. 
```
if Feature.active?(:redirects)
    match '*path', via: :all, to: 'catchall#not_implemented'
  else
    match '*path', via: :all, to: not_implemented
  end
```