### PR TITLE
Adding optimizely embed code to empty page

### DIFF
--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -10,6 +10,12 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <%= optimizely_include_tag if Rails.env.production? && Feature.active?(:optimizely) %>
 
+  <% if hide_elements_irrelevant_for_third_parties? %>
+    <%# This is the new embed code for Optimizely training session and is temporary %>
+    <%# It will only be displayed on the /en/empty and /cy/empty/ pages %>
+    <script src="//cdn.optimizely.com/js/3564241282.js"></script>
+  <% end %>
+
   <%= display_meta_tags(site: t('.title'), reverse: true, separator: '-') %>
   <%= csrf_meta_tags %>
 


### PR DESCRIPTION
An agency for Optimizely are running a training session on Friday and need an empty page on production to demonstrate some tests with. We have decided to use the https://www.moneyadviceservice.org.uk/en/empty template for this as it is only used by third parties in a non-automated fashion.

This code simply drops in the embed code to those pages using the `hide_elements_irrelevant_for_third_parties` flag, which is only set to true on the `empty` controller.