### PR TITLE
Update db/schema.rb

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150904094809) do
+ActiveRecord::Schema.define(version: 20150928135300) do
 
   create_table "action_items", force: true do |t|
     t.string   "article_id"
@@ -955,7 +955,7 @@ ActiveRecord::Schema.define(version: 20150904094809) do
     t.string   "goal_statement"
     t.string   "goal_deadline"
     t.string   "contact_number"
-    t.boolean  "opt_in_for_research",                default: false
+    t.boolean  "opt_in_for_research",                       default: false
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree


### PR DESCRIPTION
I just did rake db:schema:load && rake db:migrate. Nothing else. 

This is failing on CI here: https://go.test.moneyadviceservice.org.uk/go/pipelines/responsive_commit/2013/test_and_build/2

Because this PR: #1225 that the schema.rb (schema version) was not commited.