### PR TITLE
Moving SVG sprite to bottom of page

### DIFF
--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -176,8 +176,6 @@
 </head>
 <body class="<%= locale_class %> l-body">
 
-<%= render 'shared/svg/icon_sprite' %>
-
 <%# START Google Tag Manager embed code %>
 <% if Rails.env.production? %>
   <noscript>
@@ -222,5 +220,6 @@
 
 <%= yield :javascripts %>
 
+<%= render 'shared/svg/icon_sprite' %>
 </body>
 </html>


### PR DESCRIPTION
When at the top, the whole top half of every page of the site was failing to render in IE8