### PR TITLE
Fix for SVG icons not rendering in Safari

### DIFF
--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -175,6 +175,9 @@
 
 </head>
 <body class="<%= locale_class %> l-body">
+<!--[if ( !IE ) | ( gte IE 9 ) ]><!-->
+<%= render 'shared/svg/icon_sprite' %>
+<!--<![endif]-->
 
 <%# START Google Tag Manager embed code %>
 <% if Rails.env.production? %>
@@ -220,6 +223,5 @@
 
 <%= yield :javascripts %>
 
-<%= render 'shared/svg/icon_sprite' %>
 </body>
 </html>


### PR DESCRIPTION
Move the SVG sprites to underneath the top BODY tag but wrapped IE conditionals so it always renders unless IE < 9.
