### PR TITLE
Build RPMs using the Go pipeline label.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ unset RUBYOPT
 export PATH=./bin:$PATH
 export BUNDLE_WITHOUT="test:development"
 
-version_number=${GO_PIPELINE_COUNTER-0}
+version_number=${GO_PIPELINE_LABEL-0}
 revision=`git rev-parse HEAD`
 build_date=`date +'%Y-%m-%d %H:%M %z'`
 


### PR DESCRIPTION
So that we get RPM versions with the environment name built-in.

This shouldn't change anything for our normal Go pipelines as they all just use the value of `$GO_PIPELINE_COUNT`for `$GO_PIPELINE_LABEL` by default anyway. The `dev_test` and Azure build pipelines append something to the counter for those pipelines will generate RPMs with different names. This is desireable in Azure where we want more control over what RPMs we try to install (we only want the Azure-build ones), and probably makes sense for the `dev_test` ones too.