### PR TITLE
Fix annuities request spec

### DIFF
--- a/spec/requests/tool_integration/annuities_spec.rb
+++ b/spec/requests/tool_integration/annuities_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe 'Static page routing', type: :routing  do
+RSpec.describe 'Static page routing', type: :request  do
   describe '/tools/annuities' do
     context 'when the feature flag is enabled' do
       it 'routes correctly' do
@@ -16,7 +16,9 @@ RSpec.describe 'Static page routing', type: :routing  do
     context 'when the feature flag is disabled' do
       it 'does not route' do
         Feature.without(:annuities_landing_page) do
-          expect(get('/en/tools/annuities')).to_not be_routable
+          expect {
+            get('/en/tools/annuities')
+          }.to raise_error(ActionController::RoutingError, 'Not Found')
         end
       end
     end


### PR DESCRIPTION
* The spec was broken only when the feature flag was turn off.
Fixing the matcher to catch the not found exception solves the problem