### PR TITLE
Change the matcher verification for annuites spec

### DIFF
--- a/spec/requests/tool_integration/annuities_spec.rb
+++ b/spec/requests/tool_integration/annuities_spec.rb
@@ -3,12 +3,8 @@ RSpec.describe 'Static page routing', type: :request  do
     context 'when the feature flag is enabled' do
       it 'routes correctly' do
         Feature.with(:annuities_landing_page) do
-          expect(get('/en/tools/annuities')).to route_to(
-            controller: 'landing_pages',
-            action:     'show',
-            locale:     'en',
-            id:         'annuities'
-          )
+          get('/en/tools/annuities')
+          expect(response).to be_success
         end
       end
     end


### PR DESCRIPTION
* The spec was renamed to requests so the route to does not exist
here. Changing the matcher will fix the spec.
* This only spec can be runned with anuites feature flag turn on