### PR TITLE
[DEV APPROVED] 6779 fix newsletter icon

### DIFF
--- a/app/assets/stylesheets/components/common/_contact_panel.scss
+++ b/app/assets/stylesheets/components/common/_contact_panel.scss
@@ -42,6 +42,12 @@
     margin-left: -25px;
   }
 
+  .no-svg-icon--icon--newsletter{
+    html.no-svg & {
+      @extend .icon--close;
+    }
+  }
+
   .icon--newsletter {
     margin-left: -35px;
     border-radius: 50%;

--- a/app/assets/stylesheets/components/common/_contact_panel.scss
+++ b/app/assets/stylesheets/components/common/_contact_panel.scss
@@ -42,22 +42,29 @@
     margin-left: -25px;
   }
 
-  .no-svg-icon--icon--newsletter{
-    html.no-svg & {
-      @extend .icon--close;
-    }
-  }
-
-  .icon--newsletter {
+  .no-svg-icon--email {
+    position: absolute;
+    top: -90px;
+    left: 50%;
     margin-left: -35px;
     border-radius: 50%;
+    background-color: $color-green-primary;
+    width: 70px;
+    height: 70px;
 
-    .svg-icon--email {
-      width: 36.396px; // 248.152px / (150 / 22);
-      height: 22px; // 150px / (150 / 22);
-      position: relative;
-      top: 24px; // (70px - (150px / (150 / 22))) / 2;
-      fill: #fff;
+    html.no-svg & {
+      @extend .icon--email;
+      margin-left: -28px;
+    }
+
+    & .svg-icon {
+      html.svg & {
+        width: 36px; // 248.152px / (150 / 22);
+        height: 22px; // 150px / (150 / 22);
+        position: relative;
+        top: 24px; // (70px - (150px / (150 / 22))) / 2;
+        fill: #fff;
+      }
     }
   }
 }

--- a/app/assets/stylesheets/components/common/_icon.scss
+++ b/app/assets/stylesheets/components/common/_icon.scss
@@ -346,6 +346,12 @@
   height: 56px;
 }
 
+.icon--email {
+  background-position: -588px -430px;
+  width: 56px;
+  height: 56px;
+}
+
 .icon--calculator {
   background-position: -1000px -217px;
   height: 51px;
@@ -372,8 +378,4 @@
   background-position: -517px -426px;
   width:68px;
   height:68px;
-}
-
-.icon-newsletter-email{
-
 }

--- a/app/assets/stylesheets/components/common/_icon.scss
+++ b/app/assets/stylesheets/components/common/_icon.scss
@@ -373,3 +373,7 @@
   width:68px;
   height:68px;
 }
+
+.icon-newsletter-email{
+
+}

--- a/app/assets/stylesheets/components/common/_icon_2x.scss
+++ b/app/assets/stylesheets/components/common/_icon_2x.scss
@@ -167,6 +167,10 @@
     height: 70px;
   }
 
+  .icon--email {
+    background-size: auto; // hack because we don't have a double-density version
+  }
+
   .icon--clear {
     background-position: 0px -209px;
   }

--- a/app/views/shared/_newsletter_signup.html.erb
+++ b/app/views/shared/_newsletter_signup.html.erb
@@ -2,16 +2,9 @@
   <%= hidden_field_tag :authenticity_token, form_authenticity_token -%>
   <%= heading_tag level: 2, class: 'contact-panel__heading' do %>
     <%= render 'shared/svg/use_icon',
-               icon: 'icon--newsletter',
-               accessibility_title: t('newsletter_subscriptions.sticky.dont_ask_me_again'),
-               accessibility_description: 'Close this popup',
+               icon: 'email',
                svg_fallback_support: true
     %>
-    <span class="icon icon--newsletter">
-      <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--email">
-        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--email"></use>
-      </svg>
-    </span>
     <%= t('newsletter_subscriptions.title') %>
   <% end %>
 

--- a/app/views/shared/_newsletter_signup.html.erb
+++ b/app/views/shared/_newsletter_signup.html.erb
@@ -1,6 +1,12 @@
 <%= form_tag(main_app.newsletter_subscription_path, class: 'newsletter-signup t-newsletter', remote: true) do %>
   <%= hidden_field_tag :authenticity_token, form_authenticity_token -%>
   <%= heading_tag level: 2, class: 'contact-panel__heading' do %>
+    <%= render 'shared/svg/use_icon',
+               icon: 'icon--newsletter',
+               accessibility_title: t('newsletter_subscriptions.sticky.dont_ask_me_again'),
+               accessibility_description: 'Close this popup',
+               svg_fallback_support: true
+    %>
     <span class="icon icon--newsletter">
       <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--email">
         <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--email"></use>


### PR DESCRIPTION
Use the partial instead to support SVG and fallback...

`<%= render 'shared/svg/use_icon',
               icon: 'email',
               svg_fallback_support: true
    %>
`

There is no double-density sprite at the moment so I had to force single sized on double density screens using background-size: auto.