### PR TITLE
id: 6797 homepage columns border browser zoom bug

### DIFF
--- a/app/assets/stylesheets/components/common/_contact_panel.scss
+++ b/app/assets/stylesheets/components/common/_contact_panel.scss
@@ -9,7 +9,7 @@
   margin-bottom: $baseline-unit*2;
   border-bottom: 1px solid $color-newsletter-input-border;
 
-  @include respond-to($mq-m) {
+  @include respond-to($mq-l) {
     border-bottom: 0;
   }
 
@@ -104,17 +104,6 @@
   @include respond-to($mq-l) {
     @include body(30, 48);
     margin: $baseline-unit*2 0 $baseline-unit 0;
-  }
-}
-
-.contact-panel__border {
-  border-right: 1px solid $color-newsletter-input-border;
-  height: 0;
-  float: left;
-  margin-left: -1px;
-
-  @include respond-to($mq-m) {
-    height: 400px;
   }
 }
 

--- a/app/assets/stylesheets/layout/common/_contact_panels.scss
+++ b/app/assets/stylesheets/layout/common/_contact_panels.scss
@@ -18,7 +18,6 @@
       content: "";
       position: absolute;
       border-right: 1px solid $color-newsletter-input-border;
-      height: 0;
       height: 400px;
       left: 33.3333%;
     }

--- a/app/assets/stylesheets/layout/common/_contact_panels.scss
+++ b/app/assets/stylesheets/layout/common/_contact_panels.scss
@@ -1,4 +1,5 @@
 .l-contact-panels {
+  position: relative;
   margin-top: 40px;
   border-top: $default-border-thin;
 }
@@ -11,6 +12,21 @@
 .l-contact-panels--homepage {
   border-top: 0;
   margin-top: 0;
+
+  @include respond-to($mq-l) {
+    &:before, &:after {
+      content: "";
+      position: absolute;
+      border-right: 1px solid $color-newsletter-input-border;
+      height: 0;
+      height: 400px;
+      left: 33.3333%;
+    }
+
+    &:after {
+      right: 33.3333%;
+    }
+  }
 }
 
 .l-contact-panel {

--- a/app/views/shared/_contact_panels.html.erb
+++ b/app/views/shared/_contact_panels.html.erb
@@ -40,8 +40,6 @@
       </div>
     </div>
 
-    <div class="contact-panel__border"></div>
-
     <div class="l-contact-panel">
       <div class="contact-panel">
         <%= heading_tag level: 2, class: 'contact-panel__heading t-contact-heading' do %>
@@ -60,8 +58,6 @@
         <p class="smallprint">* <%= t('contact_panels.call_us.smallprint') %></p>
       </div>
     </div>
-
-    <div class="contact-panel__border"></div>
 
     <div class="l-contact-panel">
       <div class="contact-panel contact-panel--last">


### PR DESCRIPTION
Using CSS pseudo-elements rather than <div>s to show the borders on the three-column footer on the homepage.