### PR TITLE
Ignores intermittent Javascript errors in cukes

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -88,4 +88,8 @@ Before('@auth-required') do
 end
 
 Capybara.javascript_driver = :poltergeist
+options = {js_errors: false}
+Capybara.register_driver :poltergeist do |app|
+  Capybara::Poltergeist::Driver.new(app, options)
+end
 Capybara.default_wait_time = 20


### PR DESCRIPTION
There are intermittently occurring errors on the cucumber tests, caused
by javascript errors. Suggested fix is to ignore javascript warnings
and errors.

Example log below:

@javascript
  Scenario: scroll beyond 50% of the page              #
features/display_newsletter_form.feature:18
    Given I am on the home page                        #
features/step_definitions/home_page_steps.rb:1
      One or more errors were raised in the Javascript code on the
page. If you don't care about these errors, you can ignore them by
setting js_errors: false in your Poltergeist configuration (see
documentation for details).

      Error: Script error for "DoughBaseComponent"
      http://requirejs.org/docs/errors.html#scripterror
      Error: Script error for "DoughBaseComponent"
      http://requirejs.org/docs/errors.html#scripterror
          at http://127.0.0.1:56041/assets/requirejs/require.js:141 in
defaultOnError
          at http://127.0.0.1:56041/assets/requirejs/require.js:545 in
onError
          at http://127.0.0.1:56041/assets/requirejs/require.js:1736
(Capybara::Poltergeist::JavascriptError)
      ./features/step_definitions/home_page_steps.rb:2:in `/^I (?:am
on|visit) the home page$/'
      ./features/support/env.rb:57:in `call'
      ./features/support/env.rb:57:in `block in <top (required)>'
      ./features/support/cucumber_extensions.rb:14:in `block in accept'
      ./features/support/cucumber_extensions.rb:10:in `each'
      ./features/support/cucumber_extensions.rb:10:in `accept'
      features/display_newsletter_form.feature:19:in `Given I am on the
home page'
    When I scroll to the bottom of the page            #
features/step_definitions/display_newsletter_form_steps.rb:5
    Then I should see a sticky newsletter sign up form #
features/step_definitions/display_newsletter_form_steps.rb:9