### PR TITLE
Removing flickering cucumber test

### DIFF
--- a/features/display_newsletter_form.feature
+++ b/features/display_newsletter_form.feature
@@ -13,9 +13,3 @@ Feature: Display sticky newsletter
   Scenario: dismiss newsletter
     When I dismiss the newsletter
     Then I should not see it again for another month
-
-  @javascript
-  Scenario: scroll beyond 50% of the page
-    Given I am on the home page
-    When I scroll to the bottom of the page
-    Then I should see a sticky newsletter sign up form

--- a/features/display_newsletter_form.feature
+++ b/features/display_newsletter_form.feature
@@ -13,3 +13,9 @@ Feature: Display sticky newsletter
   Scenario: dismiss newsletter
     When I dismiss the newsletter
     Then I should not see it again for another month
+
+  @wip @javascript
+  Scenario: scroll beyond 50% of the page
+    Given I am on the home page
+    When I scroll to the bottom of the page
+    Then I should see a sticky newsletter sign up form

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "karma-spec-reporter": "0.0.13",
     "karma-osx-reporter": "*",
     "mocha": "~1.15.1",
-    "phantomjs": "1.9.7-1",
+    "phantomjs": ">= 1.9.7-1",
     "sinon": "^1.9.0"
   },
     "scripts": {


### PR DESCRIPTION
The ‘Display sticky newsletter’ feature passes locally but is failing on the build server, reason being a JavaScript error linked to PhantomJs. After trying to specify an exact version of PhantomJs we are still not able to resolve the error.

Removing this test as per discussion with @rnalexander