### PR TITLE
Feedback Panel Feature Flag

### DIFF
--- a/app/views/shared/_feedback.html.erb
+++ b/app/views/shared/_feedback.html.erb
@@ -1,9 +1,15 @@
-<section class="panel feedback-panel">
-  <h2 class="feedback-panel__title"><%= t('feedback_panel.title') %></h2>
-  <p><%= t('feedback_panel.greeting') %></p>
-  <ul>
-    <li><%= link_to t('feedback_panel.article_feedback_link_text'), new_article_feedback_path(article.object.id), class: 't-feedback-panel__article-feedback-link' %></li>
-    <li><%= link_to t('feedback_panel.technical_feedback_link_text'), new_technical_feedback_path, class: 't-feedback-panel__technical-feedback-link' %></li>
-    <li><%= link_to t('feedback_panel.advice_link_text'), advice_path, class: 't-feedback-panel__advice-link' %></li>
-  </ul>
-</section>
+<% if Feature.active?(:feedback) %>
+  <section class="panel feedback-panel">
+    <h2 class="feedback-panel__title"><%= t('feedback_panel.title') %></h2>
+    <p><%= t('feedback_panel.greeting') %></p>
+    <ul>
+      <li><%= link_to t('feedback_panel.article_feedback_link_text'), new_article_feedback_path(article.object.id), class: 't-feedback-panel__article-feedback-link' %></li>
+      <li><%= link_to t('feedback_panel.technical_feedback_link_text'), new_technical_feedback_path, class: 't-feedback-panel__technical-feedback-link' %></li>
+      <li><%= link_to t('feedback_panel.advice_link_text'), advice_path, class: 't-feedback-panel__advice-link' %></li>
+    </ul>
+  </section>
+<% else %>
+  <section class="inline-feedback">
+    <%= link_to t('inline_feedback.technical_feedback_link'), new_technical_feedback_path, class: 'inline-feedback__link t-feedback-panel__technical-feedback-link' %>
+  </section>
+<% end %>

--- a/config/features.yml.sample
+++ b/config/features.yml.sample
@@ -1,2 +1,3 @@
 features:
-  optimizely: true
+  feedback: false
+  optimizely: false

--- a/features/feedback.feature
+++ b/features/feedback.feature
@@ -1,3 +1,4 @@
+@enable-feedback
 Feature: Giving feedback on an article
   As a visitor to the website
   When I have feedback to give about an article


### PR DESCRIPTION
This UI panel has recently resurfaced due to removing the feature flags. We’re putting it behind a feature flag to keep it hidden until we get a decision on whether it’s needed anymore or not.