### PR TITLE
[WIP] Fixing tool newsletter button style

### DIFF
--- a/app/assets/stylesheets/components/common/_newsletter_signup.scss
+++ b/app/assets/stylesheets/components/common/_newsletter_signup.scss
@@ -34,17 +34,6 @@
   border-radius: 4px;
 }
 
-.newsletter-signup__button {
-  @extend %footer-secondary-text-size;
-  height: auto;
-  padding: 10px 12px;
-  width: 208px;
-
-  &:hover {
-    background-color: $color-newsletter-button-on-hover;
-  }
-}
-
 .newsletter-signup__button--third-party {
   margin-top: $baseline-unit*7;
 
@@ -78,8 +67,31 @@
   }
 }
 
-.newsletter-button {
+.newsletter-signup__button {
+  @include body(12,14);
+  @extend %footer-secondary-text-size;
+  background: $color-newsletter;
+  border: 0;
+  color: $color-white;
+  padding: 10px 12px;
+  font-weight: 500;
+  text-transform: uppercase;
   min-width: 268px;
+  border-radius: 4px;
+
+  &:focus,
+  &:hover,
+  &:active {
+    color: $color-true-black;
+    background: $color-newsletter-active;
+    outline: none;
+  }
+
+  &:visited,
+  &:active {
+    background: $color-newsletter;
+    color: $color-white;
+  }
 
   @include respond-to($mq-m) {
     .theme-cy & {
@@ -87,4 +99,3 @@
     }
   }
 }
-

--- a/app/assets/stylesheets/components/dough_theme/button/_button.scss
+++ b/app/assets/stylesheets/components/dough_theme/button/_button.scss
@@ -122,34 +122,3 @@
   @extend %type-button-small;
   padding: 14px 16px;
 }
-
-// Lives in newsletter signup module
-//
-// .button--newsletter
-//
-// Styleguide Newsletter signup buttons
-
-.button--newsletter {
-  @include body(12,14);
-  background: $color-newsletter;
-  border-bottom: 0;
-  color: $color-white;
-  font-weight: 500;
-  text-transform: uppercase;
-
-  &:focus,
-  &:hover,
-  &:active {
-    color: $color-true-black;
-    background: $color-newsletter-active;
-    outline: none;
-    border-top: 0;
-    padding-top: $button-padding-vertical;
-  }
-
-  &:visited,
-  &:active {
-    background: $color-newsletter;
-    color: $color-white;
-  }
-}

--- a/app/views/shared/_news_signup_sticky.html.erb
+++ b/app/views/shared/_news_signup_sticky.html.erb
@@ -23,7 +23,7 @@
         <%= hidden_field_tag 'close-box-cookie-url', main_app.cookie_dismissal_path, {:id => "close-box-cookie-url"} -%>
         <%= label_tag('subscription[email]', t('newsletter_subscriptions.label'), for: 'news-signup-email-sticky', class: 'news-signup-sticky__email-label') %>
         <%= email_field_tag('subscription[email]', nil, id: 'news-signup-email-sticky', class: 'news-signup-sticky__email-input js-news-signup-sticky-input', placeholder: t('newsletter_subscriptions.sticky.placeholder_text'), required: true) %>
-        <%= button_tag(t('newsletter_subscriptions.sticky.send_me_money_advice'), type: 'submit', class: 'button button--newsletter') %>
+        <%= button_tag(t('newsletter_subscriptions.sticky.send_me_money_advice'), type: 'submit', class: 'newsletter-signup__button') %>
         <p class="news-signup-sticky__disclaimer"><%= t('newsletter_subscriptions.sticky.privacy_policy_html') %></p>
       </div>
       <button type="submit" class="news-signup-sticky__close unstyled-button" title="<%= t('newsletter_subscriptions.sticky.dont_ask_me_again') %>">

--- a/app/views/shared/_newsletter_signup.html.erb
+++ b/app/views/shared/_newsletter_signup.html.erb
@@ -25,7 +25,7 @@
       ) %>
       <%= hidden_field_tag 'subscription[ga_categoryid]', 'Newsletter SignUp' -%>
       <%= hidden_field_tag 'subscription[category]', 'footer' -%>
-      <%= button_tag(t('newsletter_subscriptions.button'), type: 'submit', class: 'newsletter-button button button--newsletter t-newsletter-button') %>
+      <%= button_tag(t('newsletter_subscriptions.button'), type: 'submit', class: 'newsletter-signup__button t-newsletter-button') %>
     <% end %>
   </fieldset>
 


### PR DESCRIPTION
A fix for the newsletter button appearing grey in tools which use Dough:

<img width="452" alt="before" src="https://cloud.githubusercontent.com/assets/13165846/11685045/01d3dd72-9e6e-11e5-88a9-669aa91070bb.png">

This happens because frontend loads dough then applies its own css properties to the newsletter button.  Then the tool will load dough again and apply the default button style, overwriting the custom properties outlined in frontend.

My proposed fix is to remove the classname 'button' from the newsletter button tag, and then extend .button within the class (.button--newsletter):

Outcome:
<img width="435" alt="after" src="https://cloud.githubusercontent.com/assets/13165846/11685104/81872b82-9e6e-11e5-98e0-3963685ff22c.png">

This will fix all tools with this issue

Fix also applied to sticky footer:

<img width="896" alt="screen shot 2015-12-11 at 10 06 10" src="https://cloud.githubusercontent.com/assets/13165846/11741177/1ec7a3c8-9fef-11e5-84d1-e93e721abca6.png">


After: