### PR TITLE
[DEV APPROVED] Ie8 Hero image fix

### DIFF
--- a/app/assets/stylesheets/components/page_specific/_home_top.scss
+++ b/app/assets/stylesheets/components/page_specific/_home_top.scss
@@ -58,6 +58,10 @@
     height: 345px;
   }
 
+  @if $responsive == false {
+    display: none;
+  }
+
 }
 
 .home-top-trust__heading {
@@ -95,6 +99,11 @@
       max-width: 750px;
     }
   }
+
+  @if $responsive == false {
+    max-width: 700px;
+  }
+
 }
 
 .home-top-trust-content {


### PR DESCRIPTION
Hiding hero image fir IE8 users, until the homepage / CMS editing work
goes live

Current:
<img width="1045" alt="screen shot 2015-12-10 at 10 37 30" src="https://cloud.githubusercontent.com/assets/13165846/11713675/c1f26182-9f2c-11e5-8935-3703719b2952.png">

Fix:
<img width="1005" alt="screen shot 2015-12-10 at 10 37 36" src="https://cloud.githubusercontent.com/assets/13165846/11713681/c6bab58e-9f2c-11e5-999b-0aa1dc79f43c.png">
