### PR TITLE
[DEV APPROVED] Adding ie8 hero image

### DIFF
--- a/app/assets/stylesheets/components/page_specific/_home_top.scss
+++ b/app/assets/stylesheets/components/page_specific/_home_top.scss
@@ -58,10 +58,6 @@
     height: 345px;
   }
 
-  @if $responsive == false {
-    display: none;
-  }
-
 }
 
 .home-top-trust__heading {
@@ -99,11 +95,6 @@
       max-width: 750px;
     }
   }
-
-  @if $responsive == false {
-    max-width: 700px;
-  }
-
 }
 
 .home-top-trust-content {


### PR DESCRIPTION
IE8 hero image can be put back in now that the CMS homepage editing has
gone live, the removed CSS hid the image and increased the width of the main title