### PR TITLE
6877 - removing typeahead hints from search input field

### DIFF
--- a/app/assets/javascripts/modules/google_complete.js
+++ b/app/assets/javascripts/modules/google_complete.js
@@ -3,7 +3,8 @@ define(['jquery', 'typeahead', 'globals'], function($, typeahead, globals) {
 
   var GoogleComplete = function(options) {
     options.input.typeahead({
-      minLength: 2
+      minLength: 2,
+      hint: false
     }, {
       source: this.completions
     }).on('typeahead:selected', function() {

--- a/app/assets/stylesheets/components/common/_newsletter_signup.scss
+++ b/app/assets/stylesheets/components/common/_newsletter_signup.scss
@@ -77,14 +77,3 @@
     }
   }
 }
-
-.newsletter-button {
-  min-width: 268px;
-
-  @include respond-to($mq-m) {
-    .theme-cy & {
-      white-space: normal;
-    }
-  }
-}
-

--- a/app/assets/stylesheets/components/dough_theme/button/_button.scss
+++ b/app/assets/stylesheets/components/dough_theme/button/_button.scss
@@ -129,13 +129,15 @@
 //
 // Styleguide Newsletter signup buttons
 
-.button--newsletter {
+.newsletter-button {
+  @extend .button;
   @include body(12,14);
   background: $color-newsletter;
   border-bottom: 0;
   color: $color-white;
   font-weight: 500;
   text-transform: uppercase;
+  min-width: 268px;
 
   &:focus,
   &:hover,
@@ -152,4 +154,11 @@
     background: $color-newsletter;
     color: $color-white;
   }
+
+  @include respond-to($mq-m) {
+    .theme-cy & {
+      white-space: normal;
+    }
+  }
+
 }

--- a/app/views/shared/_newsletter_signup.html.erb
+++ b/app/views/shared/_newsletter_signup.html.erb
@@ -25,7 +25,7 @@
       ) %>
       <%= hidden_field_tag 'subscription[ga_categoryid]', 'Newsletter SignUp' -%>
       <%= hidden_field_tag 'subscription[category]', 'footer' -%>
-      <%= button_tag(t('newsletter_subscriptions.button'), type: 'submit', class: 'newsletter-button button button--newsletter t-newsletter-button') %>
+      <%= button_tag(t('newsletter_subscriptions.button'), type: 'submit', class: 'newsletter-button t-newsletter-button') %>
     <% end %>
   </fieldset>
 


### PR DESCRIPTION
User testing has shown that showing the search hints within the input field (typeahead) is confusing. This commit removes the hints from the field but keeps the rest of the AJAX search functionality.

**Live site:**

![old](https://cloud.githubusercontent.com/assets/14920201/11845839/a4eb0702-a40d-11e5-8918-88dc4bfd8c0f.gif)

**Proposed change:**

![new](https://cloud.githubusercontent.com/assets/14920201/11845838/a2aad71a-a40d-11e5-9341-2c03e45122a2.gif)