### PR TITLE
[DEV APPROVED] 6877 - removing search hinting from input

### DIFF
--- a/app/assets/javascripts/modules/google_complete.js
+++ b/app/assets/javascripts/modules/google_complete.js
@@ -3,7 +3,8 @@ define(['jquery', 'typeahead', 'globals'], function($, typeahead, globals) {
 
   var GoogleComplete = function(options) {
     options.input.typeahead({
-      minLength: 2
+      minLength: 2,
+      hint: false
     }, {
       source: this.completions
     }).on('typeahead:selected', function() {


### PR DESCRIPTION
User testing has shown that showing the search hints within the input field (typeahead) is confusing. This commit removes the hints from the field but keeps the rest of the AJAX search functionality.

**Live site:**

![old](https://cloud.githubusercontent.com/assets/14920201/11845839/a4eb0702-a40d-11e5-8918-88dc4bfd8c0f.gif)

**Proposed change:** (ignore the error page!)

![new](https://cloud.githubusercontent.com/assets/14920201/11845838/a2aad71a-a40d-11e5-9341-2c03e45122a2.gif)