### PR TITLE
[DEV APPROVED] #6875 Revert Xmas opening times

### DIFF
--- a/app/views/shared/_contact_panels.html.erb
+++ b/app/views/shared/_contact_panels.html.erb
@@ -27,7 +27,12 @@
           </div>
         </div>
 
-        <%= t('contact_panels.chat.opening_times_html') %>
+        <ul class="t-chat-opening-times contact-panel__list unstyled-list">
+          <% chat_opening_hours.open_periods.each do |period| %>
+            <li class="contact-panel__additional-info"><%= period.html_safe %></li>
+          <% end %>
+          <li class="contact-panel__additional-info"><%= t('contact_panels.chat.bank_holiday_html') %></li>
+        </ul>
 
         <% if translation?('contact_panels.chat.smallprint') %>
           <p class="smallprint t-welsh-smallprint">* <%= t('contact_panels.chat.smallprint') %></p>

--- a/app/views/static_pages/contact_us.html.erb
+++ b/app/views/static_pages/contact_us.html.erb
@@ -173,19 +173,6 @@
         <li class="unstyled-list__item">Sunday and Bank Holidays, closed</li>
       </ul>
 
-      <%= heading_tag 'The Money Advice Service will be running a reduced service over the Christmas period:', level: 2, class: 'heading-extra-small' %>
-
-      <ul class="unstyled-list">
-        <li class="unstyled-list__item">24th December, web chat and call centre available 9am to 1pm</li>
-        <li class="unstyled-list__item">25th December, web chat and call centre closed</li>
-        <li class="unstyled-list__item">26th December, web chat and call centre closed</li>
-        <li class="unstyled-list__item">28th December, web chat and call centre closed</li>
-        <li class="unstyled-list__item">31st December, web chat and call centre available 9am to 1pm</li>
-        <li class="unstyled-list__item">1st January, web chat and call centre closed</li>
-        <li class="unstyled-list__item">2nd January, web chat and call centre closed</li>
-      </ul>
-
-
       <%= heading_tag 'Call our Money Advice Line on', level: 2, class: 'heading-extra-small' %>
       <ul class="unstyled-list">
         <li class="unstyled-list__item"><a href="tel:+443005005000">0300 500 5000</a> (English)*</li>

--- a/app/views/static_pages/cysylltu_a_ni.html.erb
+++ b/app/views/static_pages/cysylltu_a_ni.html.erb
@@ -172,18 +172,6 @@
         <li class="unstyled-list__item">Dydd Sul a Gwyliau Banc, ar gau</li>
       </ul>
 
-      <%= heading_tag 'Bydd y Gwasanaeth Cynghori Ariannol yn rhedeg gwasanaeth cyfyngedig dros gyfnod y Nadolig:', level: 2, class: 'heading-extra-small' %>
-
-      <ul class="unstyled-list">
-        <li class="unstyled-list__item">24 Rhagfyr, gwe-sgwrs a’r ganolfan alwadau ar gael 9am hyd at 1pm</li>
-        <li class="unstyled-list__item">25 Rhagfyr, gwe-sgwrs a’r ganolfan alwadau wedi cau</li>
-        <li class="unstyled-list__item">26 Rhagfyr, gwe-sgwrs a’r ganolfan alwadau wedi cau</li>
-        <li class="unstyled-list__item">28 Rhagfyr, gwe-sgwrs a’r ganolfan alwadau wedi cau</li>
-        <li class="unstyled-list__item">31 Rhagfyr, gwe-sgwrs a’r ganolfan alwadau ar gael 9am hyd at 1pm</li>
-        <li class="unstyled-list__item">1 Ionawr, gwe-sgwrs a’r ganolfan alwadau wedi cau</li>
-        <li class="unstyled-list__item">2 Ionawr, gwe-sgwrs a’r ganolfan alwadau wedi cau</li>
-      </ul>
-
       <%= heading_tag 'Ffoniwch ein Llinell Cynghori Ariannol ar', level: 2, class: 'heading-extra-small' %>
       <ul class="unstyled-list">
         <li class="unstyled-list__item"><a href="tel:+443005005000">0300 500 5000</a> (Saesneg)*</li>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -145,18 +145,14 @@ cy:
       smallprint: Dim ond yn Saesneg mae gwe-sgwrsio ar gael.
       bank_holiday_html: |
         Dydd Sul a Gwyliau Banc, ar gau
-      opening_times_html: |
-        <ul class="contact-panel__list">
-          <li class="contact-panel__additional-info">Bydd y Gwasanaeth Cynghori Ariannol yn rhedeg gwasanaeth cyfyngedig dros gyfnod y Nadolig.</li>
-          <li class="contact-panel__additional-info">I weld ein horiau agor dros y Nadolig, ewch i’n tudalen <a href="/cy/corporate/cysylltu-a-ni">Cysylltu â ni</a>.</li>
-        </ul>
     call_us:
       title: Ffoniwch ni
       description: Ffoniwch ni am gyngor ariannol am ddim a diduedd.
       opening_times_html: |
         <ul class="contact-panel__list">
-          <li class="contact-panel__additional-info">Bydd y Gwasanaeth Cynghori Ariannol yn rhedeg gwasanaeth cyfyngedig dros gyfnod y Nadolig.</li>
-          <li class="contact-panel__additional-info">I weld ein horiau agor dros y Nadolig, ewch i’n tudalen <a href="/cy/corporate/cysylltu-a-ni">Cysylltu â ni</a>.</li>
+          <li class="contact-panel__additional-info">Llun i Wener, 8am i 8pm</li>
+          <li class="contact-panel__additional-info">Dydd Sadwrn, 9am i 1pm</li>
+          <li class="contact-panel__additional-info">Dydd Sul a Gwyliau Banc, ar gau</li>
         </ul>
       smallprint: "Mae galwadau yn costio’r un faint â galw rhif 01 neu 02. Os oes gennych becyn galw “munudau am ddim”, gwiriwch gyda’ch darparwr bod rhifau 03 yn cael eu cynnwys."
     sharing:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -144,18 +144,14 @@ en:
         description: Web chat is available from %{hours}.
       bank_holiday_html: |
         Sunday and Bank Holidays, closed
-      opening_times_html: |
-        <ul class="contact-panel__list">
-          <li class="contact-panel__additional-info">The Money Advice Service will be running a reduced service over the Christmas period.</li>
-          <li class="contact-panel__additional-info">For Christmas opening hours, please visit our <a href="/en/corporate/contact-us">Contact us</a> page.</li>
-        </ul>
     call_us:
       title: Call us
       description: Give us a call for free and impartial money advice.
       opening_times_html: |
         <ul class="contact-panel__list">
-          <li class="contact-panel__additional-info">The Money Advice Service will be running a reduced service over the Christmas period.</li>
-          <li class="contact-panel__additional-info">For Christmas opening hours, please visit our <a href="/en/corporate/contact-us">Contact us</a> page.</li>
+          <li class="contact-panel__additional-info">Monday to Friday, 8am to 8pm</li>
+          <li class="contact-panel__additional-info">Saturday, 9am to 1pm</li>
+          <li class="contact-panel__additional-info">Sunday and Bank Holidays, closed</li>
         </ul>
       smallprint: "Calls cost the same as calling an 01 or 02 number. If you have a “free minutes” call package, check with your provider that 03 numbers are included."
     sharing:


### PR DESCRIPTION
Reverting Christmas opening hours to originals:

English contact panel:
<img width="772" alt="footer-eng" src="https://cloud.githubusercontent.com/assets/13165846/12088034/b80bc5ee-b2cf-11e5-89ce-348c0895bab4.png">

English contact page:
<img width="377" alt="contact-eng" src="https://cloud.githubusercontent.com/assets/13165846/12088039/c0096c7e-b2cf-11e5-8528-234d5fef2fd8.png">

Welsh contact panel:
<img width="759" alt="footer-welsh" src="https://cloud.githubusercontent.com/assets/13165846/12088042/c787476e-b2cf-11e5-8385-4139fe788da8.png">

Welsh contact page:
<img width="420" alt="contact-welsh" src="https://cloud.githubusercontent.com/assets/13165846/12088044/cf03b784-b2cf-11e5-82a0-266a5f033b50.png">
