### PR TITLE
[DEV APPROVED] #6793 Accessibility updates to the sticky footer

### DIFF
--- a/app/assets/javascripts/components/NewsletterSticky.js
+++ b/app/assets/javascripts/components/NewsletterSticky.js
@@ -18,7 +18,8 @@ define([
     },
     $newsletterStickForm,
     newsletterCloseBoxCookieURL,
-    $window;
+    $window,
+    TAB_KEY = 9;
 
   NewsletterSticky = function($el, config) {
     NewsletterSticky.baseConstructor.call(this, $el, config, defaultConfig);
@@ -50,14 +51,15 @@ define([
    * Sets up local variables for the sticky newsletter component
    */
   NewsletterSticky.prototype._setVars = function() {
-    this.closeButton = this.$el.find(this.config.closeClassSelector);
-    $window = $(window);
-
     var focusable = this.$el.find('a[href], area[href], input:not([disabled], [type=hidden]), ' +
       'select:not([disabled], [hidden]), textarea:not([disabled], [hidden]), ' +
       'button:not([disabled], [hidden]), iframe, object, embed, *[tabindex], *[contenteditable]');
-    this.firstFocusElement = focusable.first();
-    this.lastFocusElement = focusable.last();
+
+    this.closeButton = this.$el.find(this.config.closeClassSelector);
+    $window = $(window);
+    
+    this._firstFocusElement = focusable.first();
+    this._lastFocusElement = focusable.last();
 
     $newsletterStickForm = this.$el.find('form');
     newsletterCloseBoxCookieURL = $newsletterStickForm.find('#close-box-cookie-url').val();
@@ -72,8 +74,8 @@ define([
 
     if (isActive) {
       this.closeButton.on('click', $.proxy(this._handleCloseClick, this));
-      this.firstFocusElement.on('keydown', $.proxy(this._handleFirstElementTab, this));
-      this.lastFocusElement.on('keydown', $.proxy(this._handleLastElementTab, this));
+      this._firstFocusElement.on('keydown', $.proxy(this._handleFirstElementTab, this));
+      this._lastFocusElement.on('keydown', $.proxy(this._handleLastElementTab, this));
       this.$el.on('click', this.config.buttonDoneClass, $.proxy(this._handleCloseClick, this));
       $newsletterStickForm.on('ajax:error', $.proxy(this._formAjaxErrorHandler, this));
     } else {
@@ -120,8 +122,8 @@ define([
     if (this._hasScrolledOverPercentage(this.config.appearsAfterPercentage)) {
       this.$el.addClass(this.config.visibleClassName);
 
-      this.previousFocusElement = $(':focus');
-      this.firstFocusElement.focus();
+      this._previousFocusElement = document.activeElement;
+      this._firstFocusElement.focus();
       this._setScrollListener(false);
 
       MAS.publish('analytics:trigger', {
@@ -228,24 +230,23 @@ define([
     this.$el.removeClass(this.config.visibleClassName);
     this.closeButton.addClass(this.config.closedClassName);
     this._setListeners(false);
-    this.previousFocusElement.focus();
+    this._previousFocusElement.focus();
   };
 
   /*
   * Handle the tab event on the last and first focusable element -
   * a tab loop is created until the user dismisses the dialog (accessibility recommendation).
-  * The keycode for the tab key is 9.
    */
   NewsletterSticky.prototype._handleLastElementTab = function(e) {
-    if (e.which === 9 && !e.shiftKey) {
+    if (e.which === TAB_KEY && !e.shiftKey) {
       e.preventDefault();
-      this.firstFocusElement.focus();
+      this._firstFocusElement.focus();
     }
   }
   NewsletterSticky.prototype._handleFirstElementTab = function(e) {
-    if (e.which === 9 && e.shiftKey) {
+    if (e.which === TAB_KEY && e.shiftKey) {
       e.preventDefault();
-      this.lastFocusElement.focus();
+      this._lastFocusElement.focus();
     }
   }
 

--- a/app/assets/javascripts/components/NewsletterSticky.js
+++ b/app/assets/javascripts/components/NewsletterSticky.js
@@ -124,6 +124,7 @@ define([
 
       this._previousFocusElement = document.activeElement;
       this._firstFocusElement.focus();
+      
       this._setScrollListener(false);
 
       MAS.publish('analytics:trigger', {
@@ -230,7 +231,9 @@ define([
     this.$el.removeClass(this.config.visibleClassName);
     this.closeButton.addClass(this.config.closedClassName);
     this._setListeners(false);
-    this._previousFocusElement.focus();
+    if (this._previousFocusElement) {
+      this._previousFocusElement.focus();  
+    }
   };
 
   /*

--- a/app/assets/javascripts/components/NewsletterSticky.js
+++ b/app/assets/javascripts/components/NewsletterSticky.js
@@ -53,7 +53,9 @@ define([
     this.closeButton = this.$el.find(this.config.closeClassSelector);
     $window = $(window);
 
-    var focusable = this.$el.find('a[href], area[href], input:not([disabled], [type=hidden]), select:not([disabled], [hidden]), textarea:not([disabled], [hidden]), button:not([disabled], [hidden]), iframe, object, embed, *[tabindex], *[contenteditable]');
+    var focusable = this.$el.find('a[href], area[href], input:not([disabled], [type=hidden]), ' +
+      'select:not([disabled], [hidden]), textarea:not([disabled], [hidden]), ' +
+      'button:not([disabled], [hidden]), iframe, object, embed, *[tabindex], *[contenteditable]');
     this.firstFocusElement = focusable.first();
     this.lastFocusElement = focusable.last();
 
@@ -230,8 +232,9 @@ define([
   };
 
   /*
-  * Handle the tab event on the last and first focusable element
-  * A tab loop is created until the user dismisses the dialog (accessibility recommendation)
+  * Handle the tab event on the last and first focusable element -
+  * a tab loop is created until the user dismisses the dialog (accessibility recommendation).
+  * The keycode for the tab key is 9.
    */
   NewsletterSticky.prototype._handleLastElementTab = function(e) {
     if (e.which === 9 && !e.shiftKey) {

--- a/app/assets/javascripts/components/NewsletterSticky.js
+++ b/app/assets/javascripts/components/NewsletterSticky.js
@@ -78,12 +78,14 @@ define([
       this._lastFocusElement.on('keydown', $.proxy(this._handleLastElementTab, this));
       this.$el.on('click', this.config.buttonDoneClass, $.proxy(this._handleCloseClick, this));
       $newsletterStickForm.on('ajax:error', $.proxy(this._formAjaxErrorHandler, this));
+      $newsletterStickForm.on('ajax:success', $.proxy(this._formAjaxSuccessHandler, this));
     } else {
       this.closeButton.off('click', $.proxy(this._handleCloseClick, this));
       this._firstFocusElement.off('keydown', $.proxy(this._handleFirstElementTab, this));
       this._lastFocusElement.off('keydown', $.proxy(this._handleLastElementTab, this));
       this.$el.off('click', this.config.buttonDoneClass, $.proxy(this._handleCloseClick, this));
       $newsletterStickForm.off('ajax:error', $.proxy(this._formAjaxErrorHandler, this));
+      $newsletterStickForm.off('ajax:success', $.proxy(this._formAjaxSuccessHandler, this));
     }
   };
 
@@ -116,6 +118,15 @@ define([
       .removeClass('news-signup-sticky__text--display');
 
   };
+
+  /**
+  * Return focus to the new button after the AJAX success event
+  * Reset the variables as a new view is presented
+  */
+  NewsletterSticky.prototype._formAjaxSuccessHandler = function() {
+    this._setVars();
+    this._firstFocusElement.focus();
+  }
 
   /**
    * Make the newsletter module display if scroll is over a certain percentage

--- a/app/assets/javascripts/components/NewsletterSticky.js
+++ b/app/assets/javascripts/components/NewsletterSticky.js
@@ -80,6 +80,8 @@ define([
       $newsletterStickForm.on('ajax:error', $.proxy(this._formAjaxErrorHandler, this));
     } else {
       this.closeButton.off('click', $.proxy(this._handleCloseClick, this));
+      this._firstFocusElement.off('keydown', $.proxy(this._handleFirstElementTab, this));
+      this._lastFocusElement.off('keydown', $.proxy(this._handleLastElementTab, this));
       this.$el.off('click', this.config.buttonDoneClass, $.proxy(this._handleCloseClick, this));
       $newsletterStickForm.off('ajax:error', $.proxy(this._formAjaxErrorHandler, this));
     }

--- a/app/views/shared/_news_signup_sticky.html.erb
+++ b/app/views/shared/_news_signup_sticky.html.erb
@@ -2,7 +2,7 @@
   <% if local_assigns.has_key?(:fixed_position) %> news-signup-sticky--positioned
   <% end %> js-news-signup-sticky-form" role="dialog" aria-labelledby="news-signup__header" aria-describedby="news-signup-sticky__description1 news-signup-sticky__description2" data-dough-component="NewsletterSticky" data-done="<%= t('newsletter_subscriptions.sticky.done') %>">
   <div class="news-signup-sticky__text news-signup-sticky__text--display">
-    <h2 id="news-signup__header" class="visually-hidden"><%= t('newsletter') %></h2>
+    <h2 id="news-signup__header" class="visually-hidden"><%= t('newsletter_subscriptions.hidden_title') %></h2>
     <p class="news-signup-sticky__intro" id="news-signup-sticky__description1"><%= t('newsletter_subscriptions.sticky.intro') %></p>
 
     <p class="news-signup-sticky__intro" id="news-signup-sticky__description2">

--- a/app/views/shared/_news_signup_sticky.html.erb
+++ b/app/views/shared/_news_signup_sticky.html.erb
@@ -1,10 +1,11 @@
 <div class="news-signup-sticky
   <% if local_assigns.has_key?(:fixed_position) %> news-signup-sticky--positioned
-  <% end %> js-news-signup-sticky-form" data-dough-component="NewsletterSticky" data-done="<%= t('newsletter_subscriptions.sticky.done') %>">
+  <% end %> js-news-signup-sticky-form" role="dialog" aria-labelledby="news-signup__header" aria-describedby="news-signup-sticky__description1 news-signup-sticky__description2" data-dough-component="NewsletterSticky" data-done="<%= t('newsletter_subscriptions.sticky.done') %>">
   <div class="news-signup-sticky__text news-signup-sticky__text--display">
-    <p class="news-signup-sticky__intro"><%= t('newsletter_subscriptions.sticky.intro') %></p>
+    <h2 id="news-signup__header" class="visually-hidden"><%= t('newsletter') %></h2>
+    <p class="news-signup-sticky__intro" id="news-signup-sticky__description1"><%= t('newsletter_subscriptions.sticky.intro') %></p>
 
-    <p class="news-signup-sticky__intro">
+    <p class="news-signup-sticky__intro" id="news-signup-sticky__description2">
       <span class="news-signup-sticky__intro--emphasize"><%= t('newsletter_subscriptions.sticky.are_you') %></span> <%= t('newsletter_subscriptions.sticky.sign_up_today') %>
     </p>
   </div>

--- a/spec/javascripts/fixtures/NewsletterSticky.html
+++ b/spec/javascripts/fixtures/NewsletterSticky.html
@@ -1,11 +1,11 @@
 <div id="fixture-1">
   <div class="news-signup-sticky news-signup-sticky--positioned" data-dough-component="NewsletterSticky">
     <form onsubmit="return false;">
-      <button class="news-signup-sticky__close" id="first-focusable">
+      <button class="news-signup-sticky__close">
           &times;
       </button>
-      <input type="text" id="second-focusable">
-      <input type="text" id="third-focusable">
+      <input type="text">
+      <input type="text">
     </form>
   </div>
 </div>

--- a/spec/javascripts/fixtures/NewsletterSticky.html
+++ b/spec/javascripts/fixtures/NewsletterSticky.html
@@ -1,9 +1,11 @@
 <div id="fixture-1">
   <div class="news-signup-sticky news-signup-sticky--positioned" data-dough-component="NewsletterSticky">
     <form onsubmit="return false;">
-      <button class="news-signup-sticky__close">
+      <button class="news-signup-sticky__close" id="first-focusable">
           &times;
       </button>
+      <input type="text" id="second-focusable">
+      <input type="text" id="third-focusable">
     </form>
   </div>
 </div>

--- a/spec/javascripts/tests/NewsletterSticky_spec.js
+++ b/spec/javascripts/tests/NewsletterSticky_spec.js
@@ -138,6 +138,8 @@ describe('NewsletterSticky', function() {
       hasScrolledOverPercentageStub = sinon.stub(this.obj, '_hasScrolledOverPercentage', function() {
         return true;
       });
+      
+      this.obj._setVars();    
     });
 
     it('calls _hasScrolledOverPercentage', function() {
@@ -150,6 +152,13 @@ describe('NewsletterSticky', function() {
       this.obj._handleScroll();
 
       expect(this.obj.$el.hasClass('news-signup-sticky--visible')).to.be.equal(true);
+    });
+
+    it('sets focus to the first element in the module', function() {
+      this.obj._handleScroll();
+
+      expect(this.obj._firstFocusElement[0])
+        .to.equal(document.activeElement);
     });
 
     it('calls _setScrollListener, passing it false', function() {
@@ -200,6 +209,37 @@ describe('NewsletterSticky', function() {
   describe('_scrollThreshold', function() {
     it('returns the correct value', function() {
       expect(this.obj._scrollThreshold()).to.be.equal($(document).height() * 0.4);
+    });
+  });
+
+  describe('_handleLastElementTab', function(){
+    beforeEach(function() {
+      this.obj._setVars();
+    });
+
+    it('returns focus to the first element on sticky newsletter', function(){
+      var e = $.Event('keydown');
+      e.which = 9; // Tab Key      
+      this.obj._handleLastElementTab(e);
+      
+      expect (this.obj._firstFocusElement[0])
+        .to.equal(document.activeElement);
+    });
+  });
+
+  describe('_handleFirstElementTab', function(){
+    beforeEach(function() {
+      this.obj._setVars();
+    });
+
+    it('moves focus to the last element on sticky newsletter on shift-tab', function(){
+      var e = $.Event('keydown');
+      e.which = 9; // Tab Key
+      e.shiftKey = true;
+      this.obj._handleFirstElementTab(e);
+      
+      expect (this.obj._lastFocusElement[0])
+        .to.equal(document.activeElement);
     });
   });
 


### PR DESCRIPTION
Addressing the following accessibility recommendations (see TP ticket for details) 

* Adding aria roles for dialog and labelledby
* Setting keyboard focus when it loads
* Creating a closed tab loop for the fields within it
* Returning keyboard focus to the page when it is closed