### PR TITLE
[DEV APPROVED] #6916 - Remove sticky newsletter from some articles

### DIFF
--- a/app/helpers/sticky_newsletter_visibility.rb
+++ b/app/helpers/sticky_newsletter_visibility.rb
@@ -99,6 +99,8 @@ module StickyNewsletterVisibility
       putting-your-affairs-in-order
       preparing-for-illness-old-age-and-death
       choosing-your-executor
+      if-you-have-had-a-late-miscarriage
+      if-your-baby-has-died-shortly-after-birth
     )
 
     def initialize(slug)


### PR DESCRIPTION
Sticky newsletter will not show in following articles,
 
1.https://www.moneyadviceservice.org.uk/en/articles/if-you-have-had-a-late-miscarriage
2.https://www.moneyadviceservice.org.uk/en/articles/if-your-baby-has-died-shortly-after-birth