### PR TITLE
[DEV APPROVED] #6786 - Newsletter button style fix for tools

### DIFF
--- a/app/assets/stylesheets/_enhanced.scss
+++ b/app/assets/stylesheets/_enhanced.scss
@@ -30,11 +30,13 @@
 @import 'layout/common/all';
 @import 'layout/page_specific/all';
 
-// Components
-@import 'components/common/all';
-@import 'components/page_specific/all';
+// Dough Theme Components
 @import 'components/dough_theme/variables';
 @import 'components/dough_theme/*/_all.scss';
+
+// Local Components
+@import 'components/common/all';
+@import 'components/page_specific/all';
 
 .editorial {
   @import 'components/cms/all';

--- a/app/assets/stylesheets/components/common/_mas_button.scss
+++ b/app/assets/stylesheets/components/common/_mas_button.scss
@@ -1,0 +1,51 @@
+.mas-button {
+  @extend .button;
+}
+
+.mas-button--newsletter {
+  @include body(12,14);
+  background: $color-newsletter;
+  border-bottom: 0;
+  color: $color-white;
+  font-weight: 500;
+  text-transform: uppercase;
+  min-width: 268px;
+  border: 0;
+  border-radius: 4px;
+  padding: $baseline-unit*2;
+
+  &:focus,
+  &:hover,
+  &:active {
+    color: $color-true-black;
+    background: $color-newsletter-active;
+    outline: none;
+    border-top: 0;
+  }
+
+  &:visited,
+  &:active {
+    background: $color-newsletter;
+    color: $color-white;
+  }
+
+  @include respond-to($mq-m) {
+    .theme-cy & {
+      white-space: normal;
+    }
+  }
+
+  &.third-party {
+    margin-top: $baseline-unit*7;
+
+    .theme-cy & {
+      white-space: normal;
+    }
+  }
+
+  &.sticky {
+    vertical-align: top;
+    min-width: 188px;
+    margin-top: 1px;
+  }
+}

--- a/app/assets/stylesheets/components/common/_mas_button.scss
+++ b/app/assets/stylesheets/components/common/_mas_button.scss
@@ -1,5 +1,6 @@
 .mas-button {
   @extend .button;
+
 }
 
 .mas-button--newsletter {
@@ -9,10 +10,10 @@
   color: $color-white;
   font-weight: 500;
   text-transform: uppercase;
-  min-width: 268px;
-  border: 0;
-  border-radius: 4px;
-  padding: $baseline-unit*2;
+
+  .theme-cy & {
+    white-space: normal;
+  }
 
   &:focus,
   &:hover,
@@ -29,23 +30,4 @@
     color: $color-white;
   }
 
-  @include respond-to($mq-m) {
-    .theme-cy & {
-      white-space: normal;
-    }
-  }
-
-  &.third-party {
-    margin-top: $baseline-unit*7;
-
-    .theme-cy & {
-      white-space: normal;
-    }
-  }
-
-  &.sticky {
-    vertical-align: top;
-    min-width: 188px;
-    margin-top: 1px;
-  }
 }

--- a/app/assets/stylesheets/components/common/_mas_button.scss
+++ b/app/assets/stylesheets/components/common/_mas_button.scss
@@ -1,6 +1,5 @@
 .mas-button {
   @extend .button;
-
 }
 
 .mas-button--newsletter {
@@ -29,5 +28,4 @@
     background: $color-newsletter;
     color: $color-white;
   }
-
 }

--- a/app/assets/stylesheets/components/common/_news_signup_sticky.scss
+++ b/app/assets/stylesheets/components/common/_news_signup_sticky.scss
@@ -23,7 +23,6 @@
       position: relative;
       left: -3px;
       top: -2px;
-
     }
 
     & .svg-icon {
@@ -34,7 +33,6 @@
         height: 12px;
       }
     }
-
   }
 
   .no-svg-icon--mobile-close-box {
@@ -58,7 +56,6 @@
         }
       }
     }
-
   }
 
   .mas-button {
@@ -66,7 +63,6 @@
     min-width: 188px;
     margin-top: 1px;
   }
-
 }
 
 .news-signup-sticky--positioned {

--- a/app/assets/stylesheets/components/common/_news_signup_sticky.scss
+++ b/app/assets/stylesheets/components/common/_news_signup_sticky.scss
@@ -10,12 +10,6 @@
   text-align: center;
   position: relative;
 
-  .button--newsletter {
-    vertical-align: top;
-    min-width: 188px;
-    margin-top: 1px;
-  }
-
   .no-svg-icon--desktop-close-box {
     html & {
       display: none;

--- a/app/assets/stylesheets/components/common/_news_signup_sticky.scss
+++ b/app/assets/stylesheets/components/common/_news_signup_sticky.scss
@@ -61,6 +61,12 @@
 
   }
 
+  .mas-button {
+    vertical-align: top;
+    min-width: 188px;
+    margin-top: 1px;
+  }
+
 }
 
 .news-signup-sticky--positioned {

--- a/app/assets/stylesheets/components/common/_newsletter_signup.scss
+++ b/app/assets/stylesheets/components/common/_newsletter_signup.scss
@@ -2,6 +2,12 @@
 //
 // Styleguide Newsletter Signup
 
+.newsletter-signup {
+  .mas-button {
+    min-width: 268px;
+  }
+}
+
 %footer-secondary-text-size {
   @include body(16, 22);
 }

--- a/app/assets/stylesheets/components/common/_newsletter_signup.scss
+++ b/app/assets/stylesheets/components/common/_newsletter_signup.scss
@@ -34,25 +34,6 @@
   border-radius: 4px;
 }
 
-.newsletter-signup__button {
-  @extend %footer-secondary-text-size;
-  height: auto;
-  padding: 10px 12px;
-  width: 208px;
-
-  &:hover {
-    background-color: $color-newsletter-button-on-hover;
-  }
-}
-
-.newsletter-signup__button--third-party {
-  margin-top: $baseline-unit*7;
-
-  .theme-cy & {
-    white-space: normal;
-  }
-}
-
 .newsletter-signup__benefits-list {
   @extend %footer-secondary-text-size;
   margin-top: $baseline-unit*4;
@@ -77,14 +58,3 @@
     }
   }
 }
-
-.newsletter-button {
-  min-width: 268px;
-
-  @include respond-to($mq-m) {
-    .theme-cy & {
-      white-space: normal;
-    }
-  }
-}
-

--- a/app/assets/stylesheets/components/dough_theme/button/_button.scss
+++ b/app/assets/stylesheets/components/dough_theme/button/_button.scss
@@ -9,10 +9,6 @@
 // .button--primary:focus      - yellow
 // .button--primary:active     - yellow
 // .button--primary.is-disabled - yellow
-// .button--newsletter          - green
-// .button--newsletter:hover    - green
-// .button--newsletter:focus    - green
-// .button--newsletter:active   - green
 //
 // Styleguide buttons
 
@@ -121,35 +117,4 @@
 .button--small {
   @extend %type-button-small;
   padding: 14px 16px;
-}
-
-// Lives in newsletter signup module
-//
-// .button--newsletter
-//
-// Styleguide Newsletter signup buttons
-
-.button--newsletter {
-  @include body(12,14);
-  background: $color-newsletter;
-  border-bottom: 0;
-  color: $color-white;
-  font-weight: 500;
-  text-transform: uppercase;
-
-  &:focus,
-  &:hover,
-  &:active {
-    color: $color-true-black;
-    background: $color-newsletter-active;
-    outline: none;
-    border-top: 0;
-    padding-top: $button-padding-vertical;
-  }
-
-  &:visited,
-  &:active {
-    background: $color-newsletter;
-    color: $color-white;
-  }
 }

--- a/app/views/shared/_news_signup_sticky.html.erb
+++ b/app/views/shared/_news_signup_sticky.html.erb
@@ -23,7 +23,7 @@
         <%= hidden_field_tag 'close-box-cookie-url', main_app.cookie_dismissal_path, {:id => "close-box-cookie-url"} -%>
         <%= label_tag('subscription[email]', t('newsletter_subscriptions.label'), for: 'news-signup-email-sticky', class: 'news-signup-sticky__email-label') %>
         <%= email_field_tag('subscription[email]', nil, id: 'news-signup-email-sticky', class: 'news-signup-sticky__email-input js-news-signup-sticky-input', placeholder: t('newsletter_subscriptions.sticky.placeholder_text'), required: true) %>
-        <%= button_tag(t('newsletter_subscriptions.sticky.send_me_money_advice'), type: 'submit', class: 'button button--newsletter') %>
+        <%= button_tag(t('newsletter_subscriptions.sticky.send_me_money_advice'), type: 'submit', class: 'mas-button--newsletter sticky') %>
         <p class="news-signup-sticky__disclaimer"><%= t('newsletter_subscriptions.sticky.privacy_policy_html') %></p>
       </div>
       <button type="submit" class="news-signup-sticky__close unstyled-button" title="<%= t('newsletter_subscriptions.sticky.dont_ask_me_again') %>">

--- a/app/views/shared/_news_signup_sticky.html.erb
+++ b/app/views/shared/_news_signup_sticky.html.erb
@@ -23,7 +23,7 @@
         <%= hidden_field_tag 'close-box-cookie-url', main_app.cookie_dismissal_path, {:id => "close-box-cookie-url"} -%>
         <%= label_tag('subscription[email]', t('newsletter_subscriptions.label'), for: 'news-signup-email-sticky', class: 'news-signup-sticky__email-label') %>
         <%= email_field_tag('subscription[email]', nil, id: 'news-signup-email-sticky', class: 'news-signup-sticky__email-input js-news-signup-sticky-input', placeholder: t('newsletter_subscriptions.sticky.placeholder_text'), required: true) %>
-        <%= button_tag(t('newsletter_subscriptions.sticky.send_me_money_advice'), type: 'submit', class: 'mas-button--newsletter sticky') %>
+        <%= button_tag(t('newsletter_subscriptions.sticky.send_me_money_advice'), type: 'submit', class: 'mas-button mas-button--newsletter') %>
         <p class="news-signup-sticky__disclaimer"><%= t('newsletter_subscriptions.sticky.privacy_policy_html') %></p>
       </div>
       <button type="submit" class="news-signup-sticky__close unstyled-button" title="<%= t('newsletter_subscriptions.sticky.dont_ask_me_again') %>">

--- a/app/views/shared/_newsletter_signup.html.erb
+++ b/app/views/shared/_newsletter_signup.html.erb
@@ -13,7 +13,7 @@
 
   <fieldset class="newsletter-signup__form js-newsletter-form" id="newsletter_signup">
     <% if hide_elements_irrelevant_for_third_parties? %>
-      <a href="https://www.moneyadviceservice.org.uk<%= t('footer.contact_us_link') %>#newsletter_signup" class="t-newsletter-button mas-button--newsletter third-party"><%= t('newsletter_subscriptions.hidden_title') %></a>
+      <a href="https://www.moneyadviceservice.org.uk<%= t('footer.contact_us_link') %>#newsletter_signup" class="mas-button mas-button--newsletter t-newsletter-button"><%= t('newsletter_subscriptions.hidden_title') %></a>
     <% else %>
       <legend class="visually-hidden"><%= t('newsletter_subscriptions.hidden_title') %></legend>
       <%= label_tag('subscription[email]', t('newsletter_subscriptions.label'), class: 'newsletter-signup__label visually-hidden') %>
@@ -25,7 +25,7 @@
       ) %>
       <%= hidden_field_tag 'subscription[ga_categoryid]', 'Newsletter SignUp' -%>
       <%= hidden_field_tag 'subscription[category]', 'footer' -%>
-      <%= button_tag(t('newsletter_subscriptions.button'), type: 'submit', class: 'mas-button--newsletter t-newsletter-button') %>
+      <%= button_tag(t('newsletter_subscriptions.button'), type: 'submit', class: 'mas-button mas-button--newsletter t-newsletter-button') %>
     <% end %>
   </fieldset>
 

--- a/app/views/shared/_newsletter_signup.html.erb
+++ b/app/views/shared/_newsletter_signup.html.erb
@@ -13,7 +13,7 @@
 
   <fieldset class="newsletter-signup__form js-newsletter-form" id="newsletter_signup">
     <% if hide_elements_irrelevant_for_third_parties? %>
-      <a href="https://www.moneyadviceservice.org.uk<%= t('footer.contact_us_link') %>#newsletter_signup" class="t-newsletter-button button newsletter-signup__button newsletter-signup__button--third-party"><%= t('newsletter_subscriptions.hidden_title') %></a>
+      <a href="https://www.moneyadviceservice.org.uk<%= t('footer.contact_us_link') %>#newsletter_signup" class="t-newsletter-button mas-button--newsletter third-party"><%= t('newsletter_subscriptions.hidden_title') %></a>
     <% else %>
       <legend class="visually-hidden"><%= t('newsletter_subscriptions.hidden_title') %></legend>
       <%= label_tag('subscription[email]', t('newsletter_subscriptions.label'), class: 'newsletter-signup__label visually-hidden') %>
@@ -25,7 +25,7 @@
       ) %>
       <%= hidden_field_tag 'subscription[ga_categoryid]', 'Newsletter SignUp' -%>
       <%= hidden_field_tag 'subscription[category]', 'footer' -%>
-      <%= button_tag(t('newsletter_subscriptions.button'), type: 'submit', class: 'newsletter-button button button--newsletter t-newsletter-button') %>
+      <%= button_tag(t('newsletter_subscriptions.button'), type: 'submit', class: 'mas-button--newsletter t-newsletter-button') %>
     <% end %>
   </fieldset>
 


### PR DESCRIPTION
This ticket highlighted other issues with the newsletter buttons, all have been addressed in this PR:

Moved Dough Theme import Components above Local Components to stop overwrites.
Added mas-button and removed non-generic modifiers.
Moved the specific modifiers to parent Block SCSS files.
Removed third-party class.
Removed unused newsletter button css properties.

Before:
<img width="345" alt="screen shot 2016-01-06 at 13 32 23" src="https://cloud.githubusercontent.com/assets/13165846/12143607/fa865c12-b479-11e5-96f9-b632ffd262c4.png">

After:
<img width="364" alt="screen shot 2016-01-06 at 13 33 46" src="https://cloud.githubusercontent.com/assets/13165846/12143626/2a17f6ac-b47a-11e5-9b53-ab952db5036a.png">
