### PR TITLE
[DEV APPROVED] removes sticky footer from all blog pages

### DIFF
--- a/app/helpers/sticky_newsletter_visibility.rb
+++ b/app/helpers/sticky_newsletter_visibility.rb
@@ -114,7 +114,9 @@ module StickyNewsletterVisibility
     def blacklist_filter_results
       BLACKLIST_FILTERED.map do |pattern|
         if pattern.empty?
-          '/en' == @slug || '/cy' == @slug
+          '/en'   == @slug ||
+          '/cy'   == @slug ||
+          '/blog' == @slug
         else
           /\/(en|cy)\/#{pattern}/i.match(@slug)
         end

--- a/spec/helpers/sticky_newsletter_visibility_spec.rb
+++ b/spec/helpers/sticky_newsletter_visibility_spec.rb
@@ -21,6 +21,12 @@ RSpec.describe StickyNewsletterVisibility, type: :helper do
       it_behaves_like 'shuns_sticky_newsletter'
     end
 
+    context 'cross-domain blog page' do
+      let(:url) { 'http://example.com/blog' }
+
+      it_behaves_like 'shuns_sticky_newsletter'
+    end
+
     %w(en cy).each do |locale|
       context 'home page' do
         let(:url) { "http://example.com/#{locale}" }


### PR DESCRIPTION
Background
The plan is to migrate the Blog to the MAS domain, www.moneyadviceservice.org.uk/blog in early January 2016. We do not want the MAS sticky footer to appear on any of the Blog pages

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1351)
<!-- Reviewable:end -->
