### PR TITLE
Sticky newsletter button cucumber fix

### DIFF
--- a/features/support/ui/sections/sticky_newsletter.rb
+++ b/features/support/ui/sections/sticky_newsletter.rb
@@ -3,7 +3,7 @@ require_relative '../section'
 module UI::Sections
   class StickyNewsletter < UI::Section
     element :subscription_email, "input[name='subscription[email]']"
-    element :send_me_money_advice, ".button--newsletter"
+    element :send_me_money_advice, ".mas-button--newsletter"
     element :close_button, '.news-signup-sticky__close'
   end
 end


### PR DESCRIPTION
A fix for the currently failing cucumber test for the sticky newsletter, I changed a classname on the sticky button element but not in features/support/ui/sections/sticky_newsletter.rb