### PR TITLE
[DEV APPROVED] #6918 Bump debt-advice-locator version 2.0.4.96

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -240,7 +240,7 @@ GEM
       sass-rails (~> 4.0.0)
       uglifier
     database_cleaner (1.3.0)
-    debt_advice_locator (2.0.4.94)
+    debt_advice_locator (2.0.4.96)
       active_attr (~> 0.8)
       active_model_serializers (= 0.8.2)
       addressable


### PR DESCRIPTION
Bumping debt advice locator version to 2.0.4.96 from 2.0.4.94

Relates to ticket #6918 - https://github.com/moneyadviceservice/debt-advice-locator/pull/105