### PR TITLE
[DEV APPROVED] id: 6920, comment: Adds sticky header to mobile site with some exceptions

### DIFF
--- a/app/assets/stylesheets/components/common/_mas_logo.scss
+++ b/app/assets/stylesheets/components/common/_mas_logo.scss
@@ -2,6 +2,7 @@
   margin-left: -100%;
   max-width: none;
   width: 200%;
+  display: block;
 }
 
 .mas-logo__link {
@@ -9,8 +10,6 @@
   overflow: hidden;
   vertical-align: middle;
   width: 200px;
-  font-size: 0;
-  line-height: 1;
 
   @include respond-to($mq-m) {
     width: 285px;

--- a/app/assets/stylesheets/components/common/_mas_logo.scss
+++ b/app/assets/stylesheets/components/common/_mas_logo.scss
@@ -9,6 +9,8 @@
   overflow: hidden;
   vertical-align: middle;
   width: 200px;
+  font-size: 0;
+  line-height: 1;
 
   @include respond-to($mq-m) {
     width: 285px;

--- a/app/assets/stylesheets/components/common/_mobile_nav.scss
+++ b/app/assets/stylesheets/components/common/_mobile_nav.scss
@@ -11,15 +11,23 @@
 .mobile-nav__item {
   @extend %type-navigation;
   float: left;
-  margin: $baseline-unit*1.5 $baseline-unit $baseline-unit*1.5 0;
+  margin: $baseline-unit $baseline-unit $baseline-unit 0;
+
+  @include respond-to($mq-m) {
+    margin: $baseline-unit*1.5 $baseline-unit $baseline-unit*1.5 0;
+  }
 }
 
 .mobile-nav__link {
   @extend %link-nav-primary;
-  padding: $baseline-unit*2.5;
+  padding: $baseline-unit*2;
   display: block;
   border-radius: $baseline-unit/2;
   background-color: $color-header-buttons;
+
+  @include respond-to($mq-m) {
+    padding: $baseline-unit*2.5;
+  }
 
   &:hover,
   &:focus {
@@ -28,7 +36,14 @@
 }
 
 .mobile-nav__link--search {
-  padding: 15px 13px 11px 15px;
+  line-height: 0.8;
+  padding: $baseline-unit*2 13px $baseline-unit*2 15px;
+
+  @include respond-to($mq-m) {
+    line-height: inherit;
+    padding: 15px 13px 11px 15px;
+  }
+
   &.is-on {
     &:before {
       @include triangle(bottom, 7, 14, $color-header-buttons);

--- a/app/assets/stylesheets/layout/common/_header.scss
+++ b/app/assets/stylesheets/layout/common/_header.scss
@@ -1,7 +1,7 @@
 .l-header {
-  background: $color-green-primary;
-  min-height: $baseline-unit*11;
-  position: relative;
+  width: 100%;
+  z-index: 200;
+  min-height: 55px;
 
   .mobile-nav {
     display: none;
@@ -9,13 +9,9 @@
 
   .mas-logo {
     @include column(4);
-    margin-bottom: $baseline-unit*3;
-    margin-top: $baseline-unit*3;
+    margin-bottom: $baseline-unit*2;
+    margin-top: $baseline-unit*2;
     position: relative;
-
-    @include respond-to($mq-small-tablet) {
-      margin-bottom: $baseline-unit*3;
-    }
 
     @include respond-to($mq-m) {
       @include column(10);
@@ -135,8 +131,12 @@
   .mobile-nav {
     display: block;
     position: absolute;
-    top: 3px;
+    top: 0;
     right: 0;
+
+    @include respond-to($mq-m) {
+      top: 3px;
+    }
 
     @include respond-to($mq-l) {
       display: none;
@@ -178,6 +178,24 @@
       display: block;
     }
   }
+}
+
+.l-header__content {
+  position: fixed;
+  background: $color-green-primary;
+  z-index: 150;
+  max-height: 100%;
+  overflow-y: auto;
+
+  @include respond-to($mq-m) {
+    position: relative;
+    overflow-y: hidden;
+  }
+}
+
+.l-header__content--non-sticky {
+  position: relative;
+  overflow-y: hidden;
 }
 
 .l-menu-nav {

--- a/app/assets/stylesheets/layout/common/_header.scss
+++ b/app/assets/stylesheets/layout/common/_header.scss
@@ -233,10 +233,10 @@
     font-weight: 500;
     display: inline-block;
     margin-bottom: 0;
-    margin-top: $baseline-unit*4;
     padding-left: $baseline-unit*3;
     position: absolute;
-    bottom: 14px;
+    top: 50%;
+    margin-top: -$baseline-unit*1.5;
 
     .theme-cy & {
       padding-left: $baseline-unit;

--- a/app/assets/stylesheets/layout/common/_header.scss
+++ b/app/assets/stylesheets/layout/common/_header.scss
@@ -1,7 +1,13 @@
 .l-header {
   width: 100%;
   z-index: 200;
-  min-height: 55px;
+  min-height: $baseline-unit*9;
+  background-color: transparent;
+
+  @include respond-to($mq-m) {
+    background: $color-green-primary;
+    min-height: $baseline-unit*11;
+  }
 
   .mobile-nav {
     display: none;
@@ -182,7 +188,7 @@
 
 .l-header__content {
   position: fixed;
-  background: $color-green-primary;
+  background-color: $color-green-primary;
   z-index: 150;
   max-height: 100%;
   overflow-y: auto;
@@ -190,6 +196,7 @@
   @include respond-to($mq-m) {
     position: relative;
     overflow-y: hidden;
+    background-color: transparent;
   }
 }
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -51,6 +51,10 @@ module ApplicationHelper
     false
   end
 
+  def hide_sticky_header?
+    (request.fullpath =~ /^\/(cy|en)\/(tools|retirement-income-options)/).present?
+  end
+
   def is_environment_on_qa?
     ENV['MAS_ENVIRONMENT'] == 'qa'
   end

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,5 +1,5 @@
 <header class="l-header" role="banner">
-  <div class="l-constrained">
+  <div class="l-constrained l-header__content<%= ' l-header__content--non-sticky' if hide_sticky_header? %>">
     <div class="mas-logo">
       <%= link_to main_app.root_path, class: 'mas-logo__link' do %>
         <%= image_tag("logo-sprite-#{I18n.locale}.png", alt: t('layouts.base.title'), class: 'mas-logo__img') %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe ApplicationHelper, type: :helper do
+  describe '#hide_sticky_header?' do
+    before do
+      expect(helper).to receive(:request).and_return(request)
+    end
+
+    context 'when tools request' do
+      let(:request) { double(fullpath: '/en/tools/mortgage-calculator') }
+
+      it 'returns true' do
+        expect(helper.hide_sticky_header?).to be true
+      end
+    end
+
+    context 'when retirement income options' do
+      let(:request) { double(fullpath: '/en/retirement-income-options/income-drawdown') }
+
+      it 'returns true' do
+        expect(helper.hide_sticky_header?).to be true
+      end
+    end
+
+    context 'when non tools request' do
+      let(:request) { double(fullpath: '/en') }
+
+      it 'returns false' do
+        expect(helper.hide_sticky_header?).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
-  Adds CSS to fix position of header on smaller screen sizes
- restyles header globally to make it less deep
- updates main content position in line with changes to header depth
- Add non-sticky class when on a tool page (with the exception of payday loans tool, which has own layout)
- Adds styles to remove sticky header from selected pages

Integrates with PR239 on mortgage_calculator

