### PR TITLE
[DEV APPROVED] #6925 - Bump Mortgage Calculator to 1.3.8.630

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -472,7 +472,7 @@ GEM
     mini_portile (0.6.2)
     minitest (5.8.3)
     modernizr-rails (2.6.3)
-    mortgage_calculator (1.3.8.629)
+    mortgage_calculator (1.3.8.630)
       angularjs-rails (~> 1.2.18)
       dough-ruby (~> 5.0)
       jquery-rails


### PR DESCRIPTION
# Bump Mortgage Calculator to 1.3.8.630

Relates to PR: https://github.com/moneyadviceservice/mortgage_calculator/pull/240 - #6925 Mortgage calculator mobile improvements