### PR TITLE
enable link to income drawdown. update link.

### DIFF
--- a/config/locales/retirements.cy.yml
+++ b/config/locales/retirements.cy.yml
@@ -192,8 +192,8 @@ cy:
               url: /cy/articles/blwydd-daliadau-tymor-penodol
             - text: Beth yw tynnu incwm i lawr?
               url: /cy/articles/tynnu-incwm-i-lawr
-            # - text: Offeryn cymharu tynnu incwm i lawr
-            #   url: '/cy/opsiynau-incwm-ymddeoliad/retirement-options#drawdown'
+            - text: Offeryn cymharu tynnu incwm i lawr
+              url: '/cy/opsiynau-incwm-ymddeoliad/income-drawdown'
             - text: Tynnu i lawr wedi’i gapio
               url: /cy/articles/capped-drawdown
         - title: Pensiwn y Wladwriaeth a budd-daliadau

--- a/config/locales/retirements.en.yml
+++ b/config/locales/retirements.en.yml
@@ -192,8 +192,8 @@ en:
               url: /en/articles/fixed-term-annuities
             - text: What is income drawdown?
               url: /en/articles/income-drawdown
-            # - text: Income drawdown comparison tool
-            #   url: '/en/retirement-income-options/retirement-options#drawdown'
+            - text: Income drawdown comparison tool
+              url: '/en/retirement-income-options/income-drawdown'
             - text: Capped drawdown
               url: /en/articles/capped-drawdown
         - title: 'State Pension & benefits'


### PR DESCRIPTION
Enables a link to the income drawdown page that was commented out. (also updates link to correct location).