### PR TITLE
[DEV APPROVED] #6963 - Display Web Chat offline message

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,7 @@ class ApplicationController < ActionController::Base
   include Localisation
 
   helper  StickyNewsletterVisibility
+  helper  ChatMigrationMessage
 
   COOKIE_MESSAGE_COOKIE_NAME  = '_cookie_notice'
   COOKIE_MESSAGE_COOKIE_VALUE = 'y'

--- a/app/helpers/chat_migration_message.rb
+++ b/app/helpers/chat_migration_message.rb
@@ -1,0 +1,12 @@
+module ChatMigrationMessage
+
+  MIGRATION_DATE = Date.new(2016, 2, 6)
+
+  def display_chat_migration_message?
+    Date.today == MIGRATION_DATE
+  end
+
+  def alternate_hours_active?
+    display_chat_migration_message?
+  end
+end

--- a/app/views/shared/_contact_panels.html.erb
+++ b/app/views/shared/_contact_panels.html.erb
@@ -28,9 +28,17 @@
         </div>
 
         <ul class="t-chat-opening-times contact-panel__list unstyled-list">
-          <% chat_opening_hours.open_periods.each do |period| %>
-            <li class="contact-panel__additional-info"><%= period.html_safe %></li>
+
+          <% unless alternate_hours_active? %>
+            <% chat_opening_hours.open_periods.each do |period| %>
+              <li class="contact-panel__additional-info"><%= period.html_safe %></li>
+            <% end %>
           <% end %>
+
+          <% if display_chat_migration_message? %>
+            <li class="contact-panel__additional-info"><%= t('contact_panels.chat.offline_migration_html') %></li>
+          <% end %>
+
           <li class="contact-panel__additional-info"><%= t('contact_panels.chat.bank_holiday_html') %></li>
         </ul>
 

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -145,6 +145,7 @@ cy:
       smallprint: Dim ond yn Saesneg mae gwe-sgwrsio ar gael.
       bank_holiday_html: |
         Dydd Sul a Gwyliau Banc, ar gau
+      offline_migration_html: Dydd Llun i Dydd Gwener, 8am i 8pm<br />Ar ddydd Sadwrn 06/02/2016 bydd gwaith cynnal a chadw’n golygu na fydd y We-sgwrs ar gael
     call_us:
       title: Ffoniwch ni
       description: Ffoniwch ni am gyngor ariannol am ddim a diduedd.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -144,6 +144,7 @@ en:
         description: Web chat is available from %{hours}.
       bank_holiday_html: |
         Sunday and Bank Holidays, closed
+      offline_migration_html: Monday to Friday, 8am to 8pm<br />On Saturday 06/02/2016 Web chat will be unavailable due to maintenance
     call_us:
       title: Call us
       description: Give us a call for free and impartial money advice.

--- a/features/chat_migration_message.feature
+++ b/features/chat_migration_message.feature
@@ -1,0 +1,19 @@
+Feature: show the migration chat message
+  As a user visiting the website
+  I want to see when chat is inactive outside of the usual opening hours
+  So I can decide whether to use an alternative method of contact
+
+  Background:
+    Chat will be unavailable for 1 day during migration release
+
+  Scenario: inactive chat period
+    When I visit the website on "6th February 2016"
+    Then I should see the chat offline migration message
+
+  Scenario Outline: active chat period
+    When I visit the website on an active chat "<date>"
+    Then I should not see the chat offline migration message
+    Examples:
+      | date              |
+      | 5th February 2016 |
+      | 7th February 2016 |

--- a/features/step_definitions/chat_migration_message.rb
+++ b/features/step_definitions/chat_migration_message.rb
@@ -1,0 +1,33 @@
+When(/^I visit the website on "(.*?)"$/) do |migration_date|
+
+  on_migration_date = Chronic.parse(migration_date)
+
+  Timecop.freeze(on_migration_date) do
+    step 'I visit the website'
+  end
+
+end
+
+When(/^I visit the website on an active chat "(.*?)"$/) do |date|
+
+  on_active_chat_date = Chronic.parse(date)
+
+  Timecop.freeze(on_active_chat_date) do
+    step 'I visit the website'
+  end
+
+end
+
+Then(/^I should see the chat offline migration message$/) do
+
+  expect(home_page.chat.opening_times)
+    .to have_content('On Saturday 06/02/2016 Web chat will be unavailable due to maintenance')
+
+end
+
+Then(/^I should not see the chat offline migration message$/) do
+
+  expect(home_page.chat.opening_times)
+    .to have_content('Saturday, 9am to 1pm')
+
+end

--- a/spec/helpers/chat_mirgation_message_spec.rb
+++ b/spec/helpers/chat_mirgation_message_spec.rb
@@ -1,0 +1,25 @@
+RSpec.describe ChatMigrationMessage, type: :helper do
+  describe '#display_chat_migration_message?' do
+
+    context 'before display_message date' do
+      it 'returns false' do
+      	allow(Date).to receive(:today) { Date.new(2016, 2, 5) }
+        expect(display_chat_migration_message?).to be false
+      end
+    end
+
+    context 'on display_message date' do
+      it 'returns true' do
+        allow(Date).to receive(:today) { Date.new(2016, 2, 6) }
+        expect(display_chat_migration_message?).to be true
+       end
+     end
+
+     context 'after display_message date' do
+       it 'returns false' do
+         allow(Date).to receive(:today) { Date.new(2016, 2, 7) }
+         expect(display_chat_migration_message?).to be false
+       end
+     end
+  end
+end


### PR DESCRIPTION
# Display Web Chat Offline Message for Saturday 6th February 2016

Adding a timed script to display chat unavailable message for Saturday 6th February 2016

### English

| 2nd February 2016 | 6th February 2016 | 10th February 2016 |
|---------------------------|--------------------------|----------------------------|
|<img width="304" alt="before and after" src="https://cloud.githubusercontent.com/assets/13165846/12780889/b1c63ace-ca68-11e5-8643-4298b53ca82d.png">|<img width="329" alt="screen shot 2016-02-03 at 11 25 35" src="https://cloud.githubusercontent.com/assets/13165846/12780923/e823ea9e-ca68-11e5-861a-bc84e9ea0df1.png">|<img width="304" alt="before and after" src="https://cloud.githubusercontent.com/assets/13165846/12780896/b750b564-ca68-11e5-8c61-c43efe40f96a.png">|

### Welsh

| 2nd February 2016 | 6th February 2016 | 10th February 2016 |
|---------------------------|--------------------------|----------------------------|
|<img width="316" alt="screen shot 2016-02-03 at 11 28 37" src="https://cloud.githubusercontent.com/assets/13165846/12780984/574f4080-ca69-11e5-8c54-cfe977dbd551.png">|<img width="327" alt="screen shot 2016-02-03 at 11 27 42" src="https://cloud.githubusercontent.com/assets/13165846/12780965/35c8c90e-ca69-11e5-971c-8840e0b93f05.png">|<img width="316" alt="screen shot 2016-02-03 at 11 28 37" src="https://cloud.githubusercontent.com/assets/13165846/12780984/574f4080-ca69-11e5-8c54-cfe977dbd551.png">|

### Swapping the chat opening hours

The chat migration message is wrapped in an if statement, if display_migration_message is true, display the chat offline message:

```
<% if display_migration_message? %>
  <li class="contact-panel__additional-info">
    <%= t('contact_panels.chat.offline_migration_html') %>
  </li>
<% end %>
```

Additionally, the existing chat opening hours have been wrapped in an unless conditional, if display_migration_message is true, then this block isn't rendered.

```
<% unless alternate_hours_active? %>
  <% chat_opening_hours.open_periods.each do |period| %>
    <li class="contact-panel__additional-info"><%= period.html_safe %></li>
  <% end %>
<% end %>
```

<img width="100"  alt="Time travel" src="https://cloud.githubusercontent.com/assets/13165846/12782201/68f81ce6-ca71-11e5-8280-af32154a5a86.jpg" style="text-align:center;">

### Testing - Travelling through time

There are 2 methods for testing this change:

| Method 1 - Specify alternative date |  Method 2 - Change system time |
|------------------------------------------------|---------------------------------------------|
|1) Open app/helpers/chat_migration_message.rb | 1) Open Date & Time preferences |
|2) Specify a new date by changing the values of: <br>DISPLAY_MESSAGE_YEAR<br>DISPLAY_MESSAGE_MONTH<br>DISPLAY_MESSAGE_DAY | 2) Change the date of your local machine |
| 3) Start server / Hit refresh<br>If you do change the values, please reflect the changes in spec/helpers/chat_mirgation_message_spec.rb:13<br>otherwise your local tests will fail | 3) Start server / Hit refresh |