### PR TITLE
id: 7002, comment: Fixes typeahead bug where the suggested text is hidden

### DIFF
--- a/app/assets/stylesheets/components/common/_search.scss
+++ b/app/assets/stylesheets/components/common/_search.scss
@@ -39,7 +39,7 @@
 .search__submit {
   @extend .unstyled-button;
   position: absolute;
-  bottom: 0;
+  top: 0;
   right: 0;
   width: $baseline-unit*8;
   height: $baseline-unit*8;
@@ -109,6 +109,11 @@
   border-left: $default-border-thin;
   border-right: $default-border-thin;
   border-bottom: $default-border-thin;
+  position: static !important;
+
+  @include respond-to($mq-m) {
+    position: absolute !important;
+  }
 }
 
 .tt-suggestion {

--- a/app/assets/stylesheets/layout/common/_header.scss
+++ b/app/assets/stylesheets/layout/common/_header.scss
@@ -195,7 +195,7 @@
 
   @include respond-to($mq-m) {
     position: relative;
-    overflow-y: hidden;
+    overflow-y: visible;
     background-color: transparent;
   }
 }


### PR DESCRIPTION
The overflow-y property was changed on the .l-header__content element in #6920 (Implement Sticky header on Mobile) to fix mobile scrolling problems. This hides the .tt-dropdown-menu element because it is positioned absolutely. We can overcome this by changing its position to static on mobile (!important is reluctantly used to overwrite dynamically set properties in this instance).