### PR TITLE
[DEV APPROVED] #7011 - Pensions and Retirements link update

### DIFF
--- a/config/locales/retirements.cy.yml
+++ b/config/locales/retirements.cy.yml
@@ -164,14 +164,16 @@ cy:
               url: /cy/articles/yr-opsiynau-ar-gyfer-defnyddioch-cronfa-bensiwn
             - text: Oedi cymryd eich cronfa bensiwn
               url: /cy/articles/oedi-cymryd-eich-cronfa-bensiwn
+            - text: Deall a chymharu incwm a dynnir i lawr
+              url: /cy/opsiynau-incwm-ymddeoliad/income-drawdown
             - text: Sut i ddefnyddio’ch cronfa bensiwn i brynu blwydd-dal oes
               url: /cy/articles/sut-i-ddefnyddioch-cronfa-bensiwn-i-brynu-blwydd-dal-oes
-            - text: 'Tynnu arian i lawr yn hyblyg: Defnyddio’ch cronfa bensiwn i ddarparu incwm ymddeoliad hyblyg'
-              url: /cy/articles/tynnu-arian-i-lawr-yn-hyblyg
             - text: Cymryd symiau bach o arian allan o’ch cronfa bensiwn
               url: /cy/articles/cymryd-symiau-bach-o-arian-allan-och-cronfa-bensiwn
             - text: Cymryd eich cronfa bensiwn gyfan fel arian
               url: /cy/articles/cymryd-eich-cronfa-bensiwn-gyfan-fel-arian
+            - text: 'Tynnu arian i lawr yn hyblyg: Defnyddio’ch cronfa bensiwn i ddarparu incwm ymddeoliad hyblyg'
+              url: /cy/articles/tynnu-arian-i-lawr-yn-hyblyg
             - text: Beth yw blwydd-dal?
               url: /cy/articles/beth-yw-blwydd-dal
             - text: Sut i geisio’r fargen orau am flwydd-dal

--- a/config/locales/retirements.en.yml
+++ b/config/locales/retirements.en.yml
@@ -164,14 +164,16 @@ en:
               url: /en/articles/options-for-using-your-pension-pot
             - text: Delaying taking your pension pot
               url: /en/articles/delaying-taking-your-pension-pot
+            - text: Understand and compare income drawdown
+              url: /en/retirement-income-options/income-drawdown
             - text: Using your pension pot to buy a lifetime annuity
               url: /en/articles/using-your-pension-pot-to-buy-a-lifetime-annuity
-            - text: Flexi-access drawdown using your pension pot for a flexible retirement income
-              url: /en/articles/flexi-access-drawdown
             - text: Taking small cash sums from your pension pot
               url: /en/articles/taking-small-cash-sums-from-your-pension-pot
             - text: Taking your whole pension pot as cash
               url: /en/articles/taking-your-whole-pension-pot-as-cash
+            - text: Flexi-access drawdown using your pension pot for a flexible retirement income
+              url: /en/articles/flexi-access-drawdown
             - text: What is an annuity?
               url: /en/articles/what--is-an-annuity
             - text: How to shop around for an annuity


### PR DESCRIPTION
Adding a new link at position 3 of the retirement income choices to the
income drawdown page, and moving the flexi-access link to position 7 for both English and Welsh

