### PR TITLE
id: 7010, comment: Adjusts position of headings when linked from internal menu

### DIFF
--- a/app/assets/stylesheets/layout/page_specific/_article_page.scss
+++ b/app/assets/stylesheets/layout/page_specific/_article_page.scss
@@ -30,6 +30,22 @@
 
     margin-bottom: 42px;
   }
+
+  h2[id]:before,
+  h3[id]:before {
+    $sticky-offset: $baseline-unit*9;
+
+    content: '.';
+    display: block;
+    font-size: 0;
+    height: $sticky-offset;
+    margin-top: -$sticky-offset;
+    visibility: hidden;
+
+    @include respond-to($mq-m) {
+      content: none;
+    }
+  }
 }
 
 %l-3col-side {


### PR DESCRIPTION
The problem is that since the introduction of the Sticky Header on mobile devices elements that scroll to the top of the viewport when selected from internal menus are partially hidden by the header: 

![image](https://cloud.githubusercontent.com/assets/6080548/12845313/ddf84228-cbfc-11e5-912f-3e5fbd4171bd.png)

![image](https://cloud.githubusercontent.com/assets/6080548/12845396/5f8fc130-cbfd-11e5-9d4f-933eba2c89c1.png)

This fix adds ensures there is some space above the relevant headings: 

![image](https://cloud.githubusercontent.com/assets/6080548/12845417/97abc802-cbfd-11e5-9679-476042bb82de.png)
