### PR TITLE
[DEV APPROVED] #7013 - Remove Hero image for IE8 users

### DIFF
--- a/app/assets/stylesheets/components/page_specific/_home_top.scss
+++ b/app/assets/stylesheets/components/page_specific/_home_top.scss
@@ -58,6 +58,9 @@
     height: 345px;
   }
 
+  @if $responsive == false {
+    display: none;
+  }
 }
 
 .home-top-trust__heading {
@@ -94,6 +97,10 @@
     .theme-cy & {
       max-width: 750px;
     }
+  }
+
+  @if $responsive == false {
+    max-width: 700px;
   }
 }
 


### PR DESCRIPTION
Removing hero image for IE8 users, this will allow us to use double density images, improving visual appearance of the hero image.

IE8 screenshot:
<img width="984" alt="screen shot 2016-02-05 at 15 50 09" src="https://cloud.githubusercontent.com/assets/13165846/12911517/f97b5d8a-cf0a-11e5-8d96-7bba5cb9db5b.png">

This change hides the hero image container and makes the main intro text wider to fill the empty space a little more