### PR TITLE
[DEV APPROVED] id: 7021, comment: Switches relative positions of header and global alert on mobile views when alert is displayed

### DIFF
--- a/app/assets/stylesheets/components/common/_global-alert.scss
+++ b/app/assets/stylesheets/components/common/_global-alert.scss
@@ -8,6 +8,14 @@
 .global-alert {
   background: $color-global-alert-message-bg;
   @include clearfix();
+
+  // position below header when viewport < breakpoint
+  position: relative;
+  top: $header-height;
+
+  @include respond-to($mq-m) {
+    top: 0;
+  }
 }
 
 .global-alert__content-container {

--- a/app/assets/stylesheets/layout/common/_header.scss
+++ b/app/assets/stylesheets/layout/common/_header.scss
@@ -1,7 +1,10 @@
+// header variables
+$header-height: $baseline-unit*9;
+
 .l-header {
   width: 100%;
   z-index: 200;
-  min-height: $baseline-unit*9;
+  min-height: $header-height;
   background-color: transparent;
 
   @include respond-to($mq-m) {
@@ -188,6 +191,7 @@
 
 .l-header__content {
   position: fixed;
+  top: 0;
   background-color: $color-green-primary;
   z-index: 150;
   max-height: 100%;


### PR DESCRIPTION
Problem is that the global alert pushes the position of the header down:
![alert_before_no-scroll](https://cloud.githubusercontent.com/assets/6080548/13045806/594a7450-d3cd-11e5-9200-1c539f69dbad.png)
====

When scrolled the header (now in fixed position) remains in this position: 
![alert_before_scroll](https://cloud.githubusercontent.com/assets/6080548/13045836/815dce10-d3cd-11e5-95dd-8df850efd25a.png)
====

The agreed solution is to switch the positions of the header and global alert in mobile view when the global alert is displayed: 
![alert_after_no-scroll](https://cloud.githubusercontent.com/assets/6080548/13045873/a5e70fbc-d3cd-11e5-9360-e040dd208684.png)
====

This displays as desired when the view is scrolled: 
![alert_after_scroll](https://cloud.githubusercontent.com/assets/6080548/13045887/b3c5cde4-d3cd-11e5-80ea-354bb86c63f4.png)