### PR TITLE
[DEV APPROVED] Bump mortgage calculator to 1.3.8.635

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -472,7 +472,7 @@ GEM
     mini_portile (0.6.2)
     minitest (5.8.3)
     modernizr-rails (2.6.3)
-    mortgage_calculator (1.3.8.633)
+    mortgage_calculator (1.3.8.635)
       angularjs-rails (~> 1.2.18)
       dough-ruby (~> 5.0)
       jquery-rails
@@ -811,6 +811,3 @@ DEPENDENCIES
   validate_url (= 1.0.0)
   vcr
   webmock
-
-BUNDLED WITH
-   1.11.2


### PR DESCRIPTION
Updated mortgage calculator version includes:

### 7048 - Fixing path to background image for expander
https://github.com/moneyadviceservice/mortgage_calculator/pull/244

### 7046 - Updating text for additional home
https://github.com/moneyadviceservice/mortgage_calculator/pull/243