### PR TITLE
update rio to latest version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,7 @@ GIT
 
 GIT
   remote: git@github.com:moneyadviceservice/rio.git
-  revision: b9c85dcef5577bc46f493bcc0fde348f79eed3d9
+  revision: b164c8288521b1e0b826e7d7738a297306bfd9cc
   specs:
     rio (0.0.3)
       bowndler


### PR DESCRIPTION
There were a couple of small changes in RIO to update the title and canonical links for the income drawdown page. This PR bumps the engine to the latest version which includes these changes.

![screenshot 2016-02-19 10 31 41](https://cloud.githubusercontent.com/assets/32398/13173178/205e4ef8-d6f4-11e5-906c-d28ec6409e32.png)
