### PR TITLE
[DEV APPROVED] #7033 - Remove Skip to main nav for tools

### DIFF
--- a/app/controllers/embedded_tools_controller.rb
+++ b/app/controllers/embedded_tools_controller.rb
@@ -84,4 +84,8 @@ class EmbeddedToolsController < ApplicationController
   def base_alternate_url
     "/#{alternate_locale}/tools/#{alternate_tool_id}"
   end
+
+  def display_skip_to_main_navigation?
+    false
+  end
 end


### PR DESCRIPTION
## Hide 'Skip to main navigation' accessibility link for tools pages

This change removes the skip to navigation link from tools pages as they do not contain a main navigation