### PR TITLE
Cucumber VCR cassettes for the footer from cms

### DIFF
--- a/features/cassettes/cy/core/repository/footer/cms/find/footer.yml
+++ b/features/cassettes/cy/core/repository/footer/cms/find/footer.yml
@@ -1,0 +1,113 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3000/api/cy/footer.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mas-Responsive/1.0 (kopparberg.local; paul; 56865) ruby/2.1.2 (95; x86_64-darwin13.0)
+      X-Request-Id:
+      - ae8b37f0-feff-4ad9-b692-9b8402ece98f
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - '"d8d3811915c2b5451d7de4ea36c8d9e0"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - ae8b37f0-feff-4ad9-b692-9b8402ece98f
+      X-Runtime:
+      - '0.112692'
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.1.2/2014-05-08)
+      Date:
+      - Fri, 04 Mar 2016 10:09:22 GMT
+      Content-Length:
+      - '2716'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJsYWJlbCI6IkZvb3RlciIsInNsdWciOiJmb290ZXIiLCJmdWxsX3BhdGgi
+        OiIvY3kvZm9vdGVycy9mb290ZXIiLCJtZXRhX2Rlc2NyaXB0aW9uIjpudWxs
+        LCJtZXRhX3RpdGxlIjpudWxsLCJjYXRlZ29yeV9uYW1lcyI6W10sImxheW91
+        dF9pZGVudGlmaWVyIjoiZm9vdGVyIiwicmVsYXRlZF9jb250ZW50Ijp7Imxh
+        dGVzdF9ibG9nX3Bvc3RfbGlua3MiOlt7InRpdGxlIjoiVGhlIGZhY3RvcnMg
+        c3RvcHBpbmcgdXMgYnV5aW5nIGhvbWVzIiwicGF0aCI6Imh0dHA6Ly9ibG9n
+        Lm1vbmV5YWR2aWNlc2VydmljZS5vcmcudWsvdGhlLWZhY3RvcnMtc3RvcHBp
+        bmctdXMtYnV5aW5nLWhvbWVzIn0seyJ0aXRsZSI6IlNpeCB3YXlzIHRvIHNh
+        dmUgb24geW91ciBob2xpZGF5IiwicGF0aCI6Imh0dHA6Ly9ibG9nLm1vbmV5
+        YWR2aWNlc2VydmljZS5vcmcudWsvc2l4LXdheXMtdG8tc2F2ZS1vbi15b3Vy
+        LWhvbGlkYXkifSx7InRpdGxlIjoiTmV3IGNhciBvciB1c2VkIGNhciDigJMg
+        d2hpY2ggaXMgYmV0dGVyIHZhbHVlPyIsInBhdGgiOiJodHRwOi8vYmxvZy5t
+        b25leWFkdmljZXNlcnZpY2Uub3JnLnVrL25ldy1jYXItb3ItdXNlZC1jYXIt
+        d2hpY2gtaXMtYmV0dGVyLXZhbHVlIn1dLCJwb3B1bGFyX2xpbmtzIjpbXSwi
+        cmVsYXRlZF9saW5rcyI6W10sInByZXZpb3VzX2xpbmsiOnt9LCJuZXh0X2xp
+        bmsiOnt9fSwicHVibGlzaGVkX2F0IjoiMjAxNi0wMi0yNVQxMjowNzozMS4w
+        MDBaIiwiYmxvY2tzIjpbeyJpZGVudGlmaWVyIjoicmF3X3dlYl9jaGF0X2hl
+        YWRpbmciLCJjb250ZW50IjoiIiwiY3JlYXRlZF9hdCI6IjIwMTYtMDItMjVU
+        MTI6MDc6MzEuMDAwWiIsInVwZGF0ZWRfYXQiOiIyMDE2LTAyLTI1VDEyOjA3
+        OjMxLjAwMFoifSx7ImlkZW50aWZpZXIiOiJyYXdfd2ViX2NoYXRfYWRkaXRp
+        b25hbF9vbmUiLCJjb250ZW50IjoiIiwiY3JlYXRlZF9hdCI6IjIwMTYtMDIt
+        MjVUMTI6MDc6MzEuMDAwWiIsInVwZGF0ZWRfYXQiOiIyMDE2LTAyLTI1VDEy
+        OjA3OjMxLjAwMFoifSx7ImlkZW50aWZpZXIiOiJyYXdfd2ViX2NoYXRfYWRk
+        aXRpb25hbF90d28iLCJjb250ZW50IjoiIiwiY3JlYXRlZF9hdCI6IjIwMTYt
+        MDItMjVUMTI6MDc6MzEuMDAwWiIsInVwZGF0ZWRfYXQiOiIyMDE2LTAyLTI1
+        VDEyOjA3OjMxLjAwMFoifSx7ImlkZW50aWZpZXIiOiJyYXdfd2ViX2NoYXRf
+        YWRkaXRpb25hbF90aHJlZSIsImNvbnRlbnQiOiIiLCJjcmVhdGVkX2F0Ijoi
+        MjAxNi0wMi0yNVQxMjowNzozMS4wMDBaIiwidXBkYXRlZF9hdCI6IjIwMTYt
+        MDItMjVUMTI6MDc6MzEuMDAwWiJ9LHsiaWRlbnRpZmllciI6InJhd193ZWJf
+        Y2hhdF9zbWFsbF9wcmludCIsImNvbnRlbnQiOiIiLCJjcmVhdGVkX2F0Ijoi
+        MjAxNi0wMi0yNVQxMjowNzozMS4wMDBaIiwidXBkYXRlZF9hdCI6IjIwMTYt
+        MDItMjVUMTI6MDc6MzEuMDAwWiJ9LHsiaWRlbnRpZmllciI6InJhd19jb250
+        YWN0X2hlYWRpbmciLCJjb250ZW50IjoiIiwiY3JlYXRlZF9hdCI6IjIwMTYt
+        MDItMjVUMTI6MDc6MzEuMDAwWiIsInVwZGF0ZWRfYXQiOiIyMDE2LTAyLTI1
+        VDEyOjA3OjMxLjAwMFoifSx7ImlkZW50aWZpZXIiOiJyYXdfY29udGFjdF9p
+        bnRyb2R1Y3Rpb24iLCJjb250ZW50IjoiIiwiY3JlYXRlZF9hdCI6IjIwMTYt
+        MDItMjVUMTI6MDc6MzEuMDAwWiIsInVwZGF0ZWRfYXQiOiIyMDE2LTAyLTI1
+        VDEyOjA3OjMxLjAwMFoifSx7ImlkZW50aWZpZXIiOiJyYXdfY29udGFjdF9w
+        aG9uZV9udW1iZXIiLCJjb250ZW50IjoiIiwiY3JlYXRlZF9hdCI6IjIwMTYt
+        MDItMjVUMTI6MDc6MzEuMDAwWiIsInVwZGF0ZWRfYXQiOiIyMDE2LTAyLTI1
+        VDEyOjA3OjMxLjAwMFoifSx7ImlkZW50aWZpZXIiOiJyYXdfY29udGFjdF9h
+        ZGRpdGlvbmFsX29uZSIsImNvbnRlbnQiOiIiLCJjcmVhdGVkX2F0IjoiMjAx
+        Ni0wMi0yNVQxMjowNzozMS4wMDBaIiwidXBkYXRlZF9hdCI6IjIwMTYtMDIt
+        MjVUMTI6MDc6MzEuMDAwWiJ9LHsiaWRlbnRpZmllciI6InJhd19jb250YWN0
+        X2FkZGl0aW9uYWxfdHdvIiwiY29udGVudCI6IiIsImNyZWF0ZWRfYXQiOiIy
+        MDE2LTAyLTI1VDEyOjA3OjMxLjAwMFoiLCJ1cGRhdGVkX2F0IjoiMjAxNi0w
+        Mi0yNVQxMjowNzozMS4wMDBaIn0seyJpZGVudGlmaWVyIjoicmF3X2NvbnRh
+        Y3RfYWRkaXRpb25hbF90aHJlZSIsImNvbnRlbnQiOiIiLCJjcmVhdGVkX2F0
+        IjoiMjAxNi0wMi0yNVQxMjowNzozMS4wMDBaIiwidXBkYXRlZF9hdCI6IjIw
+        MTYtMDItMjVUMTI6MDc6MzEuMDAwWiJ9LHsiaWRlbnRpZmllciI6InJhd19j
+        b250YWN0X3NtYWxsX3ByaW50IiwiY29udGVudCI6IiIsImNyZWF0ZWRfYXQi
+        OiIyMDE2LTAyLTI1VDEyOjA3OjMxLjAwMFoiLCJ1cGRhdGVkX2F0IjoiMjAx
+        Ni0wMi0yNVQxMjowNzozMS4wMDBaIn0seyJpZGVudGlmaWVyIjoicmF3X25l
+        d3NsZXR0ZXJfaGVhZGluZyIsImNvbnRlbnQiOiIiLCJjcmVhdGVkX2F0Ijoi
+        MjAxNi0wMi0yNVQxMjowNzozMS4wMDBaIiwidXBkYXRlZF9hdCI6IjIwMTYt
+        MDItMjVUMTI6MDc6MzEuMDAwWiJ9LHsiaWRlbnRpZmllciI6InJhd19uZXdz
+        bGV0dGVyX2ludHJvZHVjdGlvbiIsImNvbnRlbnQiOiIiLCJjcmVhdGVkX2F0
+        IjoiMjAxNi0wMi0yNVQxMjowNzozMS4wMDBaIiwidXBkYXRlZF9hdCI6IjIw
+        MTYtMDItMjVUMTI6MDc6MzEuMDAwWiJ9XSwidHJhbnNsYXRpb25zIjpbeyJs
+        YWJlbCI6IkZvb3RlciIsImxpbmsiOiIvZW4vZm9vdGVycy9mb290ZXIiLCJs
+        YW5ndWFnZSI6ImVuIn1dfQ==
+    http_version: 
+  recorded_at: Fri, 04 Mar 2016 10:09:22 GMT
+recorded_with: VCR 2.9.2

--- a/features/cassettes/en/core/repository/footer/cms/find/footer.yml
+++ b/features/cassettes/en/core/repository/footer/cms/find/footer.yml
@@ -1,0 +1,121 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3000/api/en/footer.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mas-Responsive/1.0 (kopparberg.local; paul; 58005) ruby/2.1.2 (95; x86_64-darwin13.0)
+      X-Request-Id:
+      - f6d3b478-10e9-4578-98f8-920c908a1a54
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - '"37ddd99373f212e8e04ca46297d397c3"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - f6d3b478-10e9-4578-98f8-920c908a1a54
+      X-Runtime:
+      - '0.042993'
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.1.2/2014-05-08)
+      Date:
+      - Fri, 04 Mar 2016 10:23:08 GMT
+      Content-Length:
+      - '3100'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJsYWJlbCI6IkZvb3RlciIsInNsdWciOiJmb290ZXIiLCJmdWxsX3BhdGgi
+        OiIvZW4vZm9vdGVycy9mb290ZXIiLCJtZXRhX2Rlc2NyaXB0aW9uIjpudWxs
+        LCJtZXRhX3RpdGxlIjpudWxsLCJjYXRlZ29yeV9uYW1lcyI6W10sImxheW91
+        dF9pZGVudGlmaWVyIjoiZm9vdGVyIiwicmVsYXRlZF9jb250ZW50Ijp7Imxh
+        dGVzdF9ibG9nX3Bvc3RfbGlua3MiOlt7InRpdGxlIjoiQ2hlYXAgTW90aGVy
+        4oCZcyBEYXkgaWRlYXMgZnJvbSBNdW1zIGluIHRoZSBrbm93IiwicGF0aCI6
+        Imh0dHA6Ly9ibG9nLm1vbmV5YWR2aWNlc2VydmljZS5vcmcudWsvY2hlYXAt
+        bW90aGVyLXMtZGF5LWlkZWFzLWZyb20tbXVtcy1pbi10aGUta25vdyJ9LHsi
+        dGl0bGUiOiJUaGUgZmFjdG9ycyBzdG9wcGluZyB1cyBidXlpbmcgaG9tZXMi
+        LCJwYXRoIjoiaHR0cDovL2Jsb2cubW9uZXlhZHZpY2VzZXJ2aWNlLm9yZy51
+        ay90aGUtZmFjdG9ycy1zdG9wcGluZy11cy1idXlpbmctaG9tZXMifSx7InRp
+        dGxlIjoiU2l4IHdheXMgdG8gc2F2ZSBvbiB5b3VyIGhvbGlkYXkiLCJwYXRo
+        IjoiaHR0cDovL2Jsb2cubW9uZXlhZHZpY2VzZXJ2aWNlLm9yZy51ay9zaXgt
+        d2F5cy10by1zYXZlLW9uLXlvdXItaG9saWRheSJ9XSwicG9wdWxhcl9saW5r
+        cyI6W10sInJlbGF0ZWRfbGlua3MiOltdLCJwcmV2aW91c19saW5rIjp7fSwi
+        bmV4dF9saW5rIjp7fX0sInB1Ymxpc2hlZF9hdCI6IjIwMTYtMDMtMDRUMTA6
+        MjI6NTIuMDAwWiIsImJsb2NrcyI6W3siaWRlbnRpZmllciI6InJhd193ZWJf
+        Y2hhdF9oZWFkaW5nIiwiY29udGVudCI6IlNhdHVyZGF5LCA5YW0gdG8gMXBt
+        IiwiY3JlYXRlZF9hdCI6IjIwMTYtMDItMjVUMTI6MDc6MzEuMDAwWiIsInVw
+        ZGF0ZWRfYXQiOiIyMDE2LTAzLTA0VDEwOjE1OjUzLjAwMFoifSx7ImlkZW50
+        aWZpZXIiOiJyYXdfd2ViX2NoYXRfYWRkaXRpb25hbF9vbmUiLCJjb250ZW50
+        IjoiU2F0dXJkYXksIDlhbSB0byAxcG0iLCJjcmVhdGVkX2F0IjoiMjAxNi0w
+        Mi0yNVQxMjowNzozMS4wMDBaIiwidXBkYXRlZF9hdCI6IjIwMTYtMDMtMDRU
+        MTA6MTU6MDMuMDAwWiJ9LHsiaWRlbnRpZmllciI6InJhd193ZWJfY2hhdF9h
+        ZGRpdGlvbmFsX3R3byIsImNvbnRlbnQiOiJTYXR1cmRheSwgOWFtIHRvIDFw
+        bSIsImNyZWF0ZWRfYXQiOiIyMDE2LTAyLTI1VDEyOjA3OjMxLjAwMFoiLCJ1
+        cGRhdGVkX2F0IjoiMjAxNi0wMy0wNFQxMDoxNTo1My4wMDBaIn0seyJpZGVu
+        dGlmaWVyIjoicmF3X3dlYl9jaGF0X2FkZGl0aW9uYWxfdGhyZWUiLCJjb250
+        ZW50IjoiU2F0dXJkYXksIDlhbSB0byAxcG0iLCJjcmVhdGVkX2F0IjoiMjAx
+        Ni0wMi0yNVQxMjowNzozMS4wMDBaIiwidXBkYXRlZF9hdCI6IjIwMTYtMDMt
+        MDRUMTA6MTU6NTMuMDAwWiJ9LHsiaWRlbnRpZmllciI6InJhd193ZWJfY2hh
+        dF9zbWFsbF9wcmludCIsImNvbnRlbnQiOiJTYXR1cmRheSwgOWFtIHRvIDFw
+        bSIsImNyZWF0ZWRfYXQiOiIyMDE2LTAyLTI1VDEyOjA3OjMxLjAwMFoiLCJ1
+        cGRhdGVkX2F0IjoiMjAxNi0wMy0wNFQxMDoxNTo1My4wMDBaIn0seyJpZGVu
+        dGlmaWVyIjoicmF3X2NvbnRhY3RfaGVhZGluZyIsImNvbnRlbnQiOiJDYWxs
+        IHVzIiwiY3JlYXRlZF9hdCI6IjIwMTYtMDItMjVUMTI6MDc6MzEuMDAwWiIs
+        InVwZGF0ZWRfYXQiOiIyMDE2LTAzLTA0VDEwOjE4OjU0LjAwMFoifSx7Imlk
+        ZW50aWZpZXIiOiJyYXdfY29udGFjdF9pbnRyb2R1Y3Rpb24iLCJjb250ZW50
+        IjoiR2l2ZSB1cyBhIGNhbGwgZm9yIGZyZWUgYW5kIGltcGFydGlhbCBtb25l
+        eSBhZHZpY2UuIiwiY3JlYXRlZF9hdCI6IjIwMTYtMDItMjVUMTI6MDc6MzEu
+        MDAwWiIsInVwZGF0ZWRfYXQiOiIyMDE2LTAzLTA0VDEwOjIyOjI0LjAwMFoi
+        fSx7ImlkZW50aWZpZXIiOiJyYXdfY29udGFjdF9waG9uZV9udW1iZXIiLCJj
+        b250ZW50IjoiMDgwMCAxMzggNzc3NyAqIiwiY3JlYXRlZF9hdCI6IjIwMTYt
+        MDItMjVUMTI6MDc6MzEuMDAwWiIsInVwZGF0ZWRfYXQiOiIyMDE2LTAzLTA0
+        VDEwOjIyOjUyLjAwMFoifSx7ImlkZW50aWZpZXIiOiJyYXdfY29udGFjdF9h
+        ZGRpdGlvbmFsX29uZSIsImNvbnRlbnQiOiJHaXZlIHVzIGEgY2FsbCBmb3Ig
+        ZnJlZSBhbmQgaW1wYXJ0aWFsIG1vbmV5IGFkdmljZS4iLCJjcmVhdGVkX2F0
+        IjoiMjAxNi0wMi0yNVQxMjowNzozMS4wMDBaIiwidXBkYXRlZF9hdCI6IjIw
+        MTYtMDMtMDRUMTA6MjI6MjQuMDAwWiJ9LHsiaWRlbnRpZmllciI6InJhd19j
+        b250YWN0X2FkZGl0aW9uYWxfdHdvIiwiY29udGVudCI6IkdpdmUgdXMgYSBj
+        YWxsIGZvciBmcmVlIGFuZCBpbXBhcnRpYWwgbW9uZXkgYWR2aWNlLiIsImNy
+        ZWF0ZWRfYXQiOiIyMDE2LTAyLTI1VDEyOjA3OjMxLjAwMFoiLCJ1cGRhdGVk
+        X2F0IjoiMjAxNi0wMy0wNFQxMDoyMjoyNC4wMDBaIn0seyJpZGVudGlmaWVy
+        IjoicmF3X2NvbnRhY3RfYWRkaXRpb25hbF90aHJlZSIsImNvbnRlbnQiOiJH
+        aXZlIHVzIGEgY2FsbCBmb3IgZnJlZSBhbmQgaW1wYXJ0aWFsIG1vbmV5IGFk
+        dmljZS4iLCJjcmVhdGVkX2F0IjoiMjAxNi0wMi0yNVQxMjowNzozMS4wMDBa
+        IiwidXBkYXRlZF9hdCI6IjIwMTYtMDMtMDRUMTA6MjI6MjQuMDAwWiJ9LHsi
+        aWRlbnRpZmllciI6InJhd19jb250YWN0X3NtYWxsX3ByaW50IiwiY29udGVu
+        dCI6IkdpdmUgdXMgYSBjYWxsIGZvciBmcmVlIGFuZCBpbXBhcnRpYWwgbW9u
+        ZXkgYWR2aWNlLiIsImNyZWF0ZWRfYXQiOiIyMDE2LTAyLTI1VDEyOjA3OjMx
+        LjAwMFoiLCJ1cGRhdGVkX2F0IjoiMjAxNi0wMy0wNFQxMDoyMjoyNC4wMDBa
+        In0seyJpZGVudGlmaWVyIjoicmF3X25ld3NsZXR0ZXJfaGVhZGluZyIsImNv
+        bnRlbnQiOiIiLCJjcmVhdGVkX2F0IjoiMjAxNi0wMi0yNVQxMjowNzozMS4w
+        MDBaIiwidXBkYXRlZF9hdCI6IjIwMTYtMDItMjVUMTI6MDc6MzEuMDAwWiJ9
+        LHsiaWRlbnRpZmllciI6InJhd19uZXdzbGV0dGVyX2ludHJvZHVjdGlvbiIs
+        ImNvbnRlbnQiOiIiLCJjcmVhdGVkX2F0IjoiMjAxNi0wMi0yNVQxMjowNzoz
+        MS4wMDBaIiwidXBkYXRlZF9hdCI6IjIwMTYtMDItMjVUMTI6MDc6MzEuMDAw
+        WiJ9XSwidHJhbnNsYXRpb25zIjpbeyJsYWJlbCI6IkZvb3RlciIsImxpbmsi
+        OiIvY3kvZm9vdGVycy9mb290ZXIiLCJsYW5ndWFnZSI6ImN5In1dfQ==
+    http_version: 
+  recorded_at: Fri, 04 Mar 2016 10:23:08 GMT
+recorded_with: VCR 2.9.2

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -29,6 +29,7 @@ news_repository                    = Core::Registry::Repository[:news]
 news_article_repository            = Core::Registry::Repository[:news_article]
 newsletter_subscription_repository = Core::Registry::Repository[:newsletter_subscription]
 home_page_repository               = Core::Registry::Repository[:home_page]
+footer_repository                  = Core::Registry::Repository[:footer]
 
 Core::Registry::Repository[:action_plan]             = Core::Repository::VCR.new(action_plan_repository)
 Core::Registry::Repository[:article]                 = Core::Repository::VCR.new(article_repository)
@@ -41,6 +42,7 @@ Core::Registry::Repository[:news]                    = Core::Repository::VCR.new
 Core::Registry::Repository[:news_article]            = Core::Repository::VCR.new(news_article_repository)
 Core::Registry::Repository[:newsletter_subscription] = Core::Repository::VCR.new(newsletter_subscription_repository)
 Core::Registry::Repository[:home_page]               = Core::Repository::VCR.new(home_page_repository)
+Core::Registry::Repository[:footer]                  = Core::Repository::VCR.new(footer_repository)
 
 Core::Registry::Repository[:customer] = Core::Repository::Customers::Fake.new
 


### PR DESCRIPTION
Cucumbers were failing as the footer is always retrieved from the CMS; previously there was a feature flag inactive for tests (apparently).

Uses VCR to fake out the requests to the CMS, as per Standard Operating Procedure for these front-end cucumbers.