### PR TITLE
[DEV APPROVED] #7163 - Excluding newsletter signup from articles

### DIFF
--- a/app/helpers/sticky_newsletter_visibility.rb
+++ b/app/helpers/sticky_newsletter_visibility.rb
@@ -100,6 +100,11 @@ module StickyNewsletterVisibility
       choosing-your-executor
       if-you-have-had-a-late-miscarriage
       if-your-baby-has-died-shortly-after-birth
+      a-new-start-without-debt
+      feel-better-without-debt
+      no-more-debt-stress
+      get-debt-under-control
+      no-more-debt
     )
 
     def initialize(slug)

--- a/lib/newsletter_exclusions.rb
+++ b/lib/newsletter_exclusions.rb
@@ -90,7 +90,12 @@ module NewsletterExclusions
       'choosing-your-executor',
       'raising-standards',
       'if-you-have-had-a-late-miscarriage',
-      'if-your-baby-has-died-shortly-after-birth'
+      'if-your-baby-has-died-shortly-after-birth',
+      'a-new-start-without-debt',
+      'feel-better-without-debt',
+      'no-more-debt-stress',
+      'get-debt-under-control',
+      'no-more-debt'
     ]
   end
 end


### PR DESCRIPTION
Excluding the in article and sticky footer from the following articles:

* a-new-start-without-debt
* feel-better-without-debt
* no-more-debt-stress
* get-debt-under-control
* no-more-debt

These have not been published yet, I’ve been reassured that these
article names won’t change