### PR TITLE
[DEV APPROVED]Make SHA refs links in version diff

### DIFF
--- a/bin/mas-version-diff
+++ b/bin/mas-version-diff
@@ -4,4 +4,11 @@
 # ./bin/mas-version-diff 1869 1870
 # They should be in ascending order
 
-git log --pretty=format:"%C(yellow)%h%Cred%d\\ %Creset%s%Cblue\\ [%cn]" --decorate $1..$2
+if [[ -z "$1" || -z "$2" ]]
+then
+    echo "Usage: $0 START_VERSION END_VERSION"
+    exit 1
+fi
+
+git --no-pager log --decorate --pretty=format:"%C(yellow)moneyadviceservice/frontend@%h%C(auto)%d %C(reset)%s %C(blue)[%cn]"  $1..$2
+echo ''


### PR DESCRIPTION
A couple tweaks here:

- Turn the SHA into a link, so they used to look like:

> 114198f\ Bumping frontend version for prod\ [slaywell]

And now:

> moneyadviceservice/scripts@114198f Bumping frontend version for prod [slaywell]

- Enable prettier colours for refs
- Remove backslashes
- Remove pager, there will be pretty short bits
- Add help text when insufficient args

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1408)
<!-- Reviewable:end -->
