### PR TITLE
Bumping mortgage calculator to 1.3.8.640

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -472,7 +472,7 @@ GEM
     mini_portile (0.6.2)
     minitest (5.8.3)
     modernizr-rails (2.6.3)
-    mortgage_calculator (1.3.8.635)
+    mortgage_calculator (1.3.8.640)
       angularjs-rails (~> 1.2.18)
       dough-ruby (~> 5.0)
       jquery-rails


### PR DESCRIPTION
Bumping mortgage calculator for related ticket A11Y - repayments not
read by screen reader

Related PR: https://github.com/moneyadviceservice/mortgage_calculator/pull/245