### PR TITLE
[DEV APPROVED] 7034 - Skip to main link update

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -102,6 +102,12 @@ class ApplicationController < ActionController::Base
 
   helper_method :display_skip_to_main_navigation?
 
+  def default_main_content_location?
+    true
+  end
+
+  helper_method :default_main_content_location?
+
   def alerts?
     flash.keys.any?
   end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -57,4 +57,8 @@ class ArticlesController < ApplicationController
     @newsletter_excluded = newsletter_submitted_cookie_set? || exclusions.count > 0 || (I18n.locale == :cy ? true : false)
   end
 
+  def default_main_content_location?
+    false
+  end
+
 end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -16,4 +16,11 @@ class CategoriesController < ApplicationController
 
     assign_active_categories(@category)
   end
+
+  private
+
+  def default_main_content_location?
+    false
+  end
+
 end

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -26,7 +26,7 @@
 
 <div class="l-article-3col-main editorial">
   <div class="l-main__row">
-    <main class="l-main__cell-full" role="main" data-dough-newsletter-article="true">
+    <main class="l-main__cell-full t-article-main-content" role="main" data-dough-newsletter-article="true" id="<%= 'main' if !default_main_content_location? %>" tabindex="-1">
       <%= heading_tag article.title %>
 
       <% unless @newsletter_excluded %>

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -11,9 +11,9 @@
   <div class="l-main__row">
     <% if category.images? %>
       <%= render 'categories/category_image', small_url: category.small_image, large_url: category.large_image %>
-      <main class="l-main__cell-full l-category l-category--image" role="main" data-parent="<%= category.parent_id %>">
+      <main class="l-main__cell-full l-category l-category--image t-category-main-content" role="main" data-parent="<%= category.parent_id %>" id="<%= 'main' if !default_main_content_location? %>" tabindex="-1">
     <% else %>
-      <main class="l-main__cell-full l-category" role="main" data-parent="<%= @category.parent_id %>">
+      <main class="l-main__cell-full l-category t-category-main-content" role="main" data-parent="<%= @category.parent_id %>" id="<%= 'main' if !default_main_content_location? %>" tabindex="-1">
     <% end %>
       <div class="l-category__top">
         <div class="l-category__top__content">

--- a/app/views/layouts/_constrained.html.erb
+++ b/app/views/layouts/_constrained.html.erb
@@ -8,7 +8,7 @@
     </div>
   <% end %>
 
-  <div class="l-constrained" id="main" tabindex="-1">
+  <div class="l-constrained t-default-main-content" id="<%= 'main' if default_main_content_location? %>" tabindex="-1">
     <%= yield %>
   </div>
 <% end %>

--- a/app/views/layouts/_unconstrained.html.erb
+++ b/app/views/layouts/_unconstrained.html.erb
@@ -7,7 +7,7 @@
     </div>
   <% end %>
 
-  <div id="main" tabindex="-1">
+  <div class="t-default-main-content" id="<%= 'main' if default_main_content_location? %>" tabindex="-1">
     <% if display_banner_warning? && whitelisted? %>
       <div class="l-constrained">
         <%=  render 'shared/banner_alert' %>

--- a/features/skip_to_main_link.feature
+++ b/features/skip_to_main_link.feature
@@ -1,0 +1,16 @@
+Feature: Skip to main link
+  As a MAS user
+  I want to skip to the main content
+  So that I can easily navigate the page
+
+  Scenario: Visiting the homepage
+    When I visit the homepage
+    Then the main area is immediately after the header
+
+  Scenario: Viewing an article
+    When I view an article
+    Then the main area is at the article content
+
+  Scenario: Visiting a category page
+    When I visit a category page
+    Then the main area is at the categories list

--- a/features/step_definitions/skip_to_main_link_steps.rb
+++ b/features/step_definitions/skip_to_main_link_steps.rb
@@ -1,0 +1,29 @@
+When(/^I visit the homepage$/) do
+  home_page.load
+end
+
+When(/^I view an article$/) do
+  browse_to_article article('en')
+end
+
+When(/^I visit a category page$/) do
+  browse_to_category(category, 'en')
+end
+
+Then(/^the main area is immediately after the header$/) do
+  expected_element = page.find('.t-default-main-content')
+  main_element = page.find('div#main')
+  expect(main_element).to eq expected_element
+end
+
+Then(/^the main area is at the article content$/) do
+  expected_element = page.find('.t-article-main-content')
+  main_element = page.find('main#main')
+  expect(main_element).to eq expected_element
+end
+
+Then(/^the main area is at the categories list$/) do
+  expected_element = page.find('.t-category-main-content')
+  main_element = page.find('main#main')
+  expect(main_element).to eq expected_element
+end


### PR DESCRIPTION
## Skip to main content links update for Articles and Category pages

Skip to main link on categories and articles pages are being adjusted to that they jump to the main content.  This change will remove the main id from the entire content and place it on the actual main content of both the article and category pages.

### Tests
The tests check if the container <main> in both article and category pages contain the attribute ``id="main"`` as this is what the accessibility link contains as the anchor ``<a href="#main">``

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1421)
<!-- Reviewable:end -->
