### PR TITLE
id: 7216, comment: Updates copy on Debt Management page

### DIFF
--- a/app/assets/stylesheets/layout/page_specific/_debt_management.scss
+++ b/app/assets/stylesheets/layout/page_specific/_debt_management.scss
@@ -8,14 +8,6 @@
   h1, h2, h3 {
     margin-top: 0;
   }
-
-  a:not([href*="moneyadviceservice.org.uk"]):after {
-    @extend %icon; // has to be a placeholder so IE8 shows other icons based on .icon - IE8 does not support :not CSS3 selector
-    @extend .icon--external-link;
-    content: '';
-    margin-left: 6px;
-    display: inline-block;
-  }
 }
 
 .l-debtmanagement--options {
@@ -124,6 +116,14 @@
 
 .l-debtmanagement__companies-list {
   @extend %collapsable-target;
+
+  a:not([href*="moneyadviceservice.org.uk"]):after {
+    @extend %icon; // has to be a placeholder so IE8 shows other icons based on .icon - IE8 does not support :not CSS3 selector
+    @extend .icon--external-link;
+    content: '';
+    margin-left: 6px;
+    display: inline-block;
+  }
 }
 
 .js .l-debtmanagement__companies-heading {


### PR DESCRIPTION
- also makes the "Consumer Credit Register" link open in a new tab and adds the relevant icon

This is slightly amended from PR1422: the external link stuff has been made more specific by nesting it inside .l-debtmanagement__companies-list