### PR TITLE
[DEV APPROVED]id: 7009, comment: Fixes bug on Expand/Contract icons

### DIFF
--- a/app/assets/stylesheets/components/page_specific/_category_detail.scss
+++ b/app/assets/stylesheets/components/page_specific/_category_detail.scss
@@ -74,7 +74,7 @@
         display: inline;
       }
 
-      .svg-icon--plus {
+      .svg-icon--plus--blue {
         display: none;
       }
     }
@@ -182,7 +182,7 @@
       display: block;
     }
 
-    .is-active .svg-icon--plus {
+    .is-active .svg-icon--plus--yellow {
       display: none;
     }
   }


### PR DESCRIPTION
- Looks like the class-names of the icons were extended to include the colour but this wasn't reflected in the CSS.
- This PR updates the CSS to add this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1427)
<!-- Reviewable:end -->
