### PR TITLE
[DO NOT MERGE] Update pensions_calculator and calculations gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,9 +129,8 @@ GEM
     ast (2.0.0)
     astrolabe (1.3.0)
       parser (>= 2.2.0.pre.3, < 3.0)
-    autoprefixer-rails (6.0.3)
+    autoprefixer-rails (6.3.6)
       execjs
-      json
     baby_cost_calculator (0.2.4)
       rails (~> 4.1.8)
     bcrypt (3.1.11)
@@ -445,8 +444,8 @@ GEM
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
     lumberjack (1.0.7)
-    mail (2.6.3)
-      mime-types (>= 1.16, < 3)
+    mail (2.6.4)
+      mime-types (>= 1.16, < 4)
     mailjet (1.0.0)
       activesupport (>= 3.1.0)
       rack (>= 1.4.0)
@@ -506,7 +505,7 @@ GEM
       rails (~> 4.1)
       sass-rails
       uglifier (>= 1.0.3)
-    pensions_calculator (1.0.0.538)
+    pensions_calculator (1.0.0.540)
       autoprefixer-rails
       dough-ruby (~> 5.0)
       meta-tags
@@ -515,7 +514,7 @@ GEM
       responders
       sass-rails (~> 4.0.3)
       uglifier
-    pensions_calculator-calculations (1.0.0.6)
+    pensions_calculator-calculations (1.0.0.7)
       activesupport (~> 4.1)
     poltergeist (1.9.0)
       capybara (~> 2.1)
@@ -558,7 +557,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (2.0.0)
     raindrops (0.13.0)
-    rake (11.1.1)
+    rake (11.1.2)
     ranked-model (0.4.0)
       activerecord (>= 3.1.12)
     rb-fsevent (0.9.4)
@@ -681,9 +680,8 @@ GEM
     transitions (0.1.13)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    uglifier (2.7.2)
-      execjs (>= 0.3.0)
-      json (>= 1.8.0)
+    uglifier (3.0.0)
+      execjs (>= 0.3.0, < 3)
     underscore-rails (1.8.2)
     unf (0.1.4)
       unf_ext


### PR DESCRIPTION
This will update the versions of `pensions_calculator` and `pensions_calculator-calculations` for the 06/04/2016 update, as per card 7042.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1428)
<!-- Reviewable:end -->
