### PR TITLE
Lock rio gem to version 0.0.3 instead of master

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,7 @@ gem 'mortgage_calculator', '~> 1.3.5'
 gem 'payday_loans_intervention', '~> 1.4'
 gem 'pensions_calculator', '~> 1.0.0'
 gem 'quiz', git: 'git@github.com:moneyadviceservice/quiz.git'
-gem 'rio', git: 'git@github.com:moneyadviceservice/rio.git'
+gem 'rio', '= 0.0.3'
 gem 'savings_calculator', '~> 1.2.0'
 gem 'timelines', '>= 1.2.0', git: 'git@github.com:moneyadviceservice/timelines.git'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,16 +35,6 @@ GIT
       rails (~> 4.1)
 
 GIT
-  remote: git@github.com:moneyadviceservice/rio.git
-  revision: 81909aa3c3d6a7962c83e2c07d5456a905eeee34
-  specs:
-    rio (0.0.3)
-      bowndler
-      dough-ruby
-      pensions_calculator-calculations
-      rails (~> 4.1)
-
-GIT
   remote: git@github.com:moneyadviceservice/timelines.git
   revision: 7146855cc241276bcb6131ef28d18fa72d5df122
   specs:
@@ -573,6 +563,8 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
+    rio (0.0.3)
+      rails (~> 4.1)
     roadie (2.4.3)
       actionmailer (> 3.0.0, < 5.0.0)
       css_parser (~> 1.3.4)
@@ -789,7 +781,7 @@ DEPENDENCIES
   rack-livereload
   rails (= 4.1.8)
   redcarpet
-  rio!
+  rio (= 0.0.3)
   rouge
   rspec-html-matchers
   rspec-rails (~> 3.0)


### PR DESCRIPTION
Stop updating rio from git master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1432)
<!-- Reviewable:end -->
