### PR TITLE
Registration newsletter signup opt-in should be unchecked by default

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -9,7 +9,7 @@ class RegistrationsController < Devise::RegistrationsController
   def build_resource(hash = nil)
     if hash
       hash[:accept_terms_conditions] = true
-      hash[:newsletter_subscription] = true unless request.post?
+      hash[:newsletter_subscription] = false unless request.post?
     end
     super
   end

--- a/features/registration.feature
+++ b/features/registration.feature
@@ -48,3 +48,7 @@ Feature: Registration
     Given I have a registration title set in the session
     When I visit the registration page
     Then I should not see the registration benefits
+
+  Scenario: Newsletter sign-up unchecked on user registration
+     When I visit the registration page
+     Then I should see the newsletter signup opt-in unchecked

--- a/features/step_definitions/registration_steps.rb
+++ b/features/step_definitions/registration_steps.rb
@@ -118,3 +118,7 @@ Then(/^the option to participate in marketing research should not be checked$/) 
   step 'I should have the option to opt-in or opt-out of participating in research'
   expect(sign_up_page.opt_in_for_research.checked?).to be_falsey
 end
+
+Then(/^I should see the newsletter signup opt\-in unchecked$/) do
+  expect(sign_up_page.newsletter_subscription.checked?).to be_falsey
+end


### PR DESCRIPTION
We discussed in a meeting about versioning, and this is the start point to group the gem in the right source to avoid conflict.

All rspec tests pass and cucumber ones too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1437)
<!-- Reviewable:end -->
