### PR TITLE
Bump rio 1.0.0 -> 1.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,7 @@ gem 'mortgage_calculator', '~> 1.3.5'
 gem 'payday_loans_intervention', '~> 1.4'
 gem 'pensions_calculator', '~> 1.0.0'
 gem 'quiz', git: 'git@github.com:moneyadviceservice/quiz.git'
-gem 'rio', '= 1.0.0', source: 'http://gems.dev.mas.local'
+gem 'rio', '= 1.2.0', source: 'http://gems.dev.mas.local'
 gem 'savings_calculator', '~> 1.2.0'
 gem 'timelines', '>= 1.2.0', git: 'git@github.com:moneyadviceservice/timelines.git'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -563,7 +563,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
-    rio (1.0.0)
+    rio (1.2.0)
       bowndler
       dough-ruby
       pensions_calculator-calculations
@@ -784,7 +784,7 @@ DEPENDENCIES
   rack-livereload
   rails (= 4.1.8)
   redcarpet
-  rio (= 1.0.0)!
+  rio (= 1.2.0)!
   rouge
   rspec-html-matchers
   rspec-rails (~> 3.0)


### PR DESCRIPTION
moneyadviceservice/rio@0612511 Bump version 1.1.0 -> 1.2.0 [Jones Agyemang]
moneyadviceservice/rio@0ffbb0f Update for 2016/2017 budget. [Jones Agyemang]
moneyadviceservice/rio@7951e86 Bump version 1.0.0 -> 1.1.0 [Jones Agyemang]
moneyadviceservice/rio@013c160 Fix indentation in Welsh income drawdown [Jones Agyemang]
moneyadviceservice/rio@c558191 Fix basic rate and other copy change in drawdown [Jones Agyemang]
moneyadviceservice/rio@80a648e Update income drawdown for 2016 [Jones Agyemang]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1441)
<!-- Reviewable:end -->
