### PR TITLE
Remove newsletter opt in from signup

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -23,7 +23,6 @@ class RegistrationsController < Devise::RegistrationsController
   def configure_permitted_parameters
     devise_parameter_sanitizer.for(:sign_up) << :first_name
     devise_parameter_sanitizer.for(:sign_up) << :post_code
-    devise_parameter_sanitizer.for(:sign_up) << :newsletter_subscription
     devise_parameter_sanitizer.for(:sign_up) << :opt_in_for_research
     devise_parameter_sanitizer.for(:sign_up) << :contact_number
     devise_parameter_sanitizer.for(:account_update) << :first_name

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -114,24 +114,6 @@
 
     <div class="registration__row">
       <div class="registration__field">
-        <%= f.form_row :newsletter_subscription do %>
-        <%= f.errors_for :newsletter_subscription %>
-
-        <fieldset class="form__group">
-          <div class="form__group-item">
-            <%= f.label :newsletter_subscription, class: "form__label-heading" do %>
-              <%= f.check_box :newsletter_subscription, class: "form__group-input" %>
-              <%= t("activerecord.attributes.user.newsletter") %>
-            <% end %>
-          </div>
-        </fieldset>
-
-        <% end %>
-      </div>
-    </div>
-
-    <div class="registration__row">
-      <div class="registration__field">
         <fieldset class="form__group">
           <div class="form__group-item">
             <%= f.label :opt_in_for_research, class: "form__label-heading" do %>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -418,7 +418,6 @@ cy:
       subtitle: Yr hyn y byddwch yn ei dderbyn
       bullets:
         - "Cadwch eich Cynllunydd Cyllideb a chadwch eich crynodeb o’ch gwariant wrth law"
-        - "Cyngor ariannol am ddim yn syth i’ch mewnflwch"
         - "Cymorth gyda’ch nodau ariannol, fel prynu tŷ neu gar"
       terms_html: "Drwy glicio ar y botwm, rydych yn cytuno gyda ein <a href=\"%{url}\">Hamodau a Thelerau</a>."
       label: Ceisiwch gyngor ariannol rhad ac am ddim

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -420,7 +420,6 @@ en:
       subtitle: What you'll get
       bullets:
         - "Save your Budget Planner and keep your spending breakdown handy"
-        - "Free money advice straight to your inbox"
         - "Help with your money goals, like buying a house or car"
       description_html: default description
       terms_html: "By clicking the button you're agreeing to our <a href=\"%{url}\">Terms and Conditions</a>."

--- a/features/registration.feature
+++ b/features/registration.feature
@@ -48,7 +48,3 @@ Feature: Registration
     Given I have a registration title set in the session
     When I visit the registration page
     Then I should not see the registration benefits
-
-  Scenario: Newsletter sign-up unchecked on user registration
-     When I visit the registration page
-     Then I should see the newsletter signup opt-in unchecked

--- a/features/step_definitions/registration_steps.rb
+++ b/features/step_definitions/registration_steps.rb
@@ -8,7 +8,6 @@ When(/^I register$/) do
   sign_up_page.email.set 'phil@example.com'
   sign_up_page.password.set 'password'
   sign_up_page.post_code.set 'NE1 6EE'
-  sign_up_page.newsletter_subscription.set true
   sign_up_page.opt_in_for_research.set true
   sign_up_page.contact_number '03005005000'
   sign_up_page.submit.click
@@ -25,7 +24,7 @@ Then(/^My MAS account should (not )?be created$/) do |negated|
     expect(User.where(email: 'phil@example.com')
                 .where(first_name: 'phil')
                 .where(post_code: 'NE1 6EE')
-                .where(newsletter_subscription: true)
+                .where(newsletter_subscription: false)
                 .count).to eql(1)
   end
 end
@@ -82,7 +81,7 @@ Then(/^My MAS account should have already been created$/) do
   expect(User.where(email: 'phil@example.com')
               .where(first_name: 'phil')
               .where(post_code: 'NE1 6EE')
-              .where(newsletter_subscription: true)
+              .where(newsletter_subscription: false)
               .count).to eql(1)
 end
 
@@ -117,8 +116,4 @@ end
 Then(/^the option to participate in marketing research should not be checked$/) do
   step 'I should have the option to opt-in or opt-out of participating in research'
   expect(sign_up_page.opt_in_for_research.checked?).to be_falsey
-end
-
-Then(/^I should see the newsletter signup opt\-in unchecked$/) do
-  expect(sign_up_page.newsletter_subscription.checked?).to be_falsey
 end

--- a/features/support/ui/pages/sign_up.rb
+++ b/features/support/ui/pages/sign_up.rb
@@ -9,7 +9,6 @@ module UI::Pages
     element :password, "input[name='user[password]']"
     element :password_confirmation, "input[name='user[password_confirmation]']"
     element :post_code, "input[name='user[post_code]']"
-    element :newsletter_subscription, "input[name='user[newsletter_subscription]'][type='checkbox']"
     element :opt_in_for_research, "input[name='user[opt_in_for_research]'][type='checkbox']"
     element :contact_number, "input[name='user[contact_number]']"
     element :submit, "#new_user input[type='submit']"

--- a/spec/lib/core/repository/users/default_spec.rb
+++ b/spec/lib/core/repository/users/default_spec.rb
@@ -35,7 +35,7 @@ module Core
           customer[:gender] = 'female'
           customer[:age_range] = '0-15'
           customer[:date_of_birth] = '1988-01-01'
-          customer[:newsletter_subscription] = 'true'
+          customer[:newsletter_subscription] = 'false'
           customer[:active] = 'true'
           # topics to be implemented
 
@@ -51,7 +51,7 @@ module Core
           expect(user.gender).to eql('female')
           expect(user.age_range).to eql('0-15')
           expect(user.date_of_birth).to eql(DateTime.new(1988, 01, 01))
-          expect(user.newsletter_subscription).to eql(true)
+          expect(user.newsletter_subscription).to eql(false)
           expect(user.active).to eql(true)
         end
       end


### PR DESCRIPTION
As it says, remove the opt in on signup, also a bit of copy. 

Copy for the checkbox left in place as it's still in use on the settings page, due for removal in ticket 7331.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1465)
<!-- Reviewable:end -->
