### PR TITLE
7331 - Remove the newsletter opt-in from the user settings page

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -9,7 +9,7 @@ class RegistrationsController < Devise::RegistrationsController
   def build_resource(hash = nil)
     if hash
       hash[:accept_terms_conditions] = true
-      hash[:newsletter_subscription] = false unless request.post?
+      hash[:newsletter_subscription] = false
     end
     super
   end
@@ -27,7 +27,6 @@ class RegistrationsController < Devise::RegistrationsController
     devise_parameter_sanitizer.for(:sign_up) << :contact_number
     devise_parameter_sanitizer.for(:account_update) << :first_name
     devise_parameter_sanitizer.for(:account_update) << :post_code
-    devise_parameter_sanitizer.for(:account_update) << :newsletter_subscription
     devise_parameter_sanitizer.for(:account_update) << :opt_in_for_research
     devise_parameter_sanitizer.for(:account_update) << :contact_number
   end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -114,7 +114,7 @@
 
     <div class="registration__row">
       <div class="registration__field">
-        <%= f.form_row :opt_in_for_research, html_options: {classes: "form__row--collapse"} do %>
+        <%= f.form_row :opt_in_for_research do %>
 
           <%= f.errors_for :opt_in_for_research %>
 
@@ -126,31 +126,6 @@
               <% end %>
             </div>
           </fieldset>
-        <% end %>
-      </div>
-    </div>
-
-    <div class="registration__row">
-      <div class="registration__field">
-        <%= f.form_row :newsletter_subscription do %>
-
-          <%= f.errors_for :newsletter_subscription %>
-
-          <fieldset class="form__group">
-            <div class="form__group-item">
-              <%= f.label :newsletter_subscription, class: "form__label-heading" do %>
-                <%= f.check_box :newsletter_subscription, class: "form__group-input" %>
-                <%= t("activerecord.attributes.user.newsletter") %>
-              <% end %>
-            </div>
-          </fieldset>
-          <strong><p><%= t("authentication.settings.newsletter.intro") %></p></strong>
-          <ul class="list form__list">
-            <% t('authentication.registration.newsletter.benefits').each do |benefit| %>
-              <li><%= benefit %></li>
-            <% end %>
-          </ul>
-
         <% end %>
       </div>
     </div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -102,7 +102,6 @@ cy:
         email: "E-bost"
         password: "Cyfrinair"
         post_code: "Cod post"
-        newsletter: "Anfonwch gyngor am ddim i mi drwy e-bost"
         opt_in_for_research: Ticiwch os hoffech i ni gysylltu â chi i’n helpu gyda’n hymchwil
         contact_number: Rhif cyswllt (dewisol)
         register_button: "Cofrestru"
@@ -427,14 +426,6 @@ cy:
         password: "Rhowch gyfrinair er mwyn cadw'ch gwybodaeth yn breifat"
         contact_number: Rhowch rif ffôn dilys y Deyrnas Unedig
         postcode: "Rhowch god post dilys o'r DU"
-      newsletter:
-        title: Cyngor ariannol i chi
-        intro: "Gallwn roi cymorth gyda..."
-        benefits:
-          - Cyllidebu ar incwm isel
-          - Gosod eich nodau ariannol personol eich hun
-          - Y gwir gost o redeg car
-          - Sut i fforddio prynu cartref
     sign_in_page:
       meta:
         canonical: https://www.moneyadviceservice.org.uk/cy/users/sign_in
@@ -499,7 +490,6 @@ cy:
       password_confirmation: Cadarnhau Cyfrinair Newydd
       newsletter:
         title: Rheoli fy Newisiadau
-        intro: "Parhewch i danysgrifio er mwyn cael…"
 
   technical_feedback:
     new:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,7 +100,6 @@ en:
         email: Email
         password: Password
         post_code: Postcode
-        newsletter: Send me free advice by email
         contact_number: Contact number (optional)
         opt_in_for_research: Tick if you’d like to be contacted to help us with our research
         register_button: Register
@@ -430,14 +429,6 @@ en:
         password: Please enter a password to keep your information private
         postcode: Please enter a valid UK postcode
         contact_number: Please enter a valid UK phone number
-      newsletter:
-        title: "Money advice for you"
-        intro: "We can help with..."
-        benefits:
-          - Budgeting on a low income
-          - Setting your own personal money goals
-          - The true cost of running a car
-          - How to afford to buy a home
     sign_in_page:
       meta:
         canonical: https://www.moneyadviceservice.org.uk/en/users/sign_in
@@ -501,7 +492,6 @@ en:
       password_confirmation: New Password confirmation
       newsletter:
         title: Manage my preferences
-        intro: "Stay subscribed to get..."
 
   technical_feedback:
     new:

--- a/features/settings.feature
+++ b/features/settings.feature
@@ -26,9 +26,3 @@ Feature: Settings
     And   I am on the settings page
     And   I update post code to "NW1 8TY"
     Then  I should see a successful update notification
-
-  Scenario: Updating newsletter opt-in
-    Given I am signed in
-    And   I am on the settings page
-    And   I opt out of MAS newsletters
-    Then  I should see a successful update notification

--- a/features/step_definitions/settings_steps.rb
+++ b/features/step_definitions/settings_steps.rb
@@ -27,12 +27,6 @@ When(/^I update post code to "(.*?)"$/) do |post_code|
   settings_page.submit.click
 end
 
-When(/^I opt out of MAS newsletters$/) do
-  settings_page.newsletter_subscription.set false
-  settings_page.current_password.set @user.password
-  settings_page.submit.click
-end
-
 Then(/^I should see a successful update notification$/) do
   expect(page.html).to include(I18n.t('devise.registrations.updated', locale: 'en'))
 end

--- a/features/support/ui/pages/settings.rb
+++ b/features/support/ui/pages/settings.rb
@@ -12,7 +12,6 @@ module UI::Pages
     element :current_password, "input[name='user[current_password]']"
     element :post_code, "input[name='user[post_code]']"
     element :contact_number, "input[name='user[contact_number]']"
-    element :newsletter_subscription, "#user_newsletter_subscription"
     element :opt_in_for_research, "input[name='user[opt_in_for_research]'][type='checkbox']"
 
     element :submit, "input[value='Update']"


### PR DESCRIPTION
[Ticket 7331 - User Settings Page - Remove the newsletter opt in checkbox](https://moneyadviceservice.tpondemand.com/tp2/entity/7331)

## Before

<img width="411" alt="before" src="https://cloud.githubusercontent.com/assets/9943/15927277/6fc45e1a-2e38-11e6-9ff0-93d62f366c0b.png">

## After

<img width="399" alt="after" src="https://cloud.githubusercontent.com/assets/9943/15927279/74d2b26c-2e38-11e6-89a5-8c300aaeee3e.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1466)
<!-- Reviewable:end -->
