### PR TITLE
7422 - Remove the companies intro text on debt management page

### DIFF
--- a/app/views/debt_management/show.html.erb
+++ b/app/views/debt_management/show.html.erb
@@ -62,7 +62,6 @@
     <div class="l-debtmanagement__inner l-debtmanagement__inner--with-image">
       <h2 class="l-debtmanagement__companies-heading"><%= t('companies.title') %></h2>
       <div class="l-debtmanagement__companies-list">
-        <%= t('companies.intro_html') %>
         <%= company_list.content %>
       </div>
     </div>

--- a/config/locales/debt_management/debt_management.cy.yml
+++ b/config/locales/debt_management/debt_management.cy.yml
@@ -111,9 +111,6 @@ cy:
           Botwm [Yn ôl i’r dudalen flaenorol] sy’n mynd â’r defnyddiwr yn ôl i’r dudalen lanio</p>
   companies:
     title: Pa gwmnïau yn cael eu heffeithio?
-    intro_html: |
-      <p>Yn sgil proses awdurdodi’r FCA, nid yw’r cwmnïau canlynol yn cael cynnig cynlluniau rheoli dyledion mwyach.</p>
-      <p>Efallai bod rhai cwmnïau a oedd yn arfer darparu Cynlluniau Rheoli Dyledion wedi gwerthu eu rhestr gleientiaid i gwmni arall. Os hoffech fod yn siŵr bod y cwmni yr ydych chi ynghlwm ag ef wedi ei awdurdodi gan yr FCA, gwiriwch y <a target="_blank" href="http://fca-consumer-credit-interim.force.com/CS_RegisterSearchPageNew">Gofrestr Credyd Defnyddwyr</a>.</p>
     standalone_title: Cwmnïau nad ydynt yn gweinyddu Cynlluniau Rheoli Dyledion mwyach
     standalone_intro: Mae’r FCA yn gwirio pob cwmni i sicrhau eu bod yn dilyn ei reolau ac yn trin eu cwsmeriaid yn deg. Mae’n gwneud hyn drwy ofyn iddynt wneud cais i gael eu hawdurdodi. Mae rhai cwmnïau ar y rhestr hon un ai wedi dewis peidio â gwneud cais neu heb gael eu hawdurdodi.
     back_to_faq_html: Am ragor o wybodaeth darllenwch ein <a href="/cy/campaigns/debt-management/faq">Cwestiynau Cyffredin</a>

--- a/config/locales/debt_management/debt_management.en.yml
+++ b/config/locales/debt_management/debt_management.en.yml
@@ -110,9 +110,6 @@ en:
           <p>Lines are open Monday to Friday – 8am to 8pm, Saturday – 9am to 1pm</p>
   companies:
     title: Which firms are affected?
-    intro_html: |
-      <p>In light of the FCA authorisations process, the following firms are no longer able to offer debt management plans.</p>
-      <p>Some firms that were providing Debt Management Plans may have sold their client list to another company. If you want to be sure that the firm you are working with is still authorised by the FCA check the <a target="_blank" href="http://fca-consumer-credit-interim.force.com/CS_RegisterSearchPageNew">Consumer Credit Register</a>.</p>
     standalone_title: Firms no longer offering Debt Management Plans
     standalone_intro: The FCA is checking all firms to make sure they follow its rules and treat their customers fairly. They are doing this by asking them to apply for authorisation. There are some firms that have either chosen not to apply or have not been given it. The below firms are no longer offering Debt Management Plans.
     back_to_faq_html: For more information read our <a href="/en/campaigns/debt-management/faq">Frequently Asked Questions</a>


### PR DESCRIPTION
Due to some confusion on this task, this was left out of the last PR.

This text has been moved into the CMS page so that it is also shown on the standalone page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1476)
<!-- Reviewable:end -->
