### PR TITLE
[DEV APPROVED] 7444 - SVG title attributes

### DIFF
--- a/app/views/shared/_footer_primary.html.erb
+++ b/app/views/shared/_footer_primary.html.erb
@@ -6,7 +6,8 @@
         <li class="l-footer-primary__list--left">
           <div class="footer-primary__list-item">
             <a class="button facebook-link t-facebook-link" lang="en" href="https://www.facebook.com/MoneyAdviceService?ref=mas" target="_blank">
-              <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--facebook">
+              <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--facebook" role="presentation" aria-labelledby="facebook-label">
+                <title id="facebook-label">Money Advice Service Facebook page</title>
                 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--facebook"></use>
               </svg>
               <span class="icon icon--facebook"></span>
@@ -22,7 +23,8 @@
         <li class="l-footer-primary__list--centre">
           <div class="footer-primary__list-item">
             <a class="button twitter-link t-twitter-link" lang="en" href="https://twitter.com/YourMoneyAdvice" target="_blank">
-              <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--twitter">
+              <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--twitter" role="presentation" aria-labelledby="twitter-label">
+                <title id="twitter-label">Money Advice Service Twitter page</title>
                 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--twitter"></use>
               </svg>
               <span class="icon icon--twitter"></span>
@@ -38,7 +40,8 @@
         <li class="l-footer-primary__list--right">
           <div class="footer-primary__list-item">
             <a class="button youtube-link t-youtube-link" lang="en" href="https://www.youtube.com/user/MoneyAdviceService" target="_blank">
-              <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--youtube">
+              <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--youtube" role="presentation" aria-labelledby="youtube-label">
+                <title id="youtube-label">Money Advice Service Youtube channel</title>
                 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--youtube"></use>
               </svg>
               <span class="icon icon--youtube"></span>

--- a/app/views/shared/_footer_primary.html.erb
+++ b/app/views/shared/_footer_primary.html.erb
@@ -6,7 +6,7 @@
         <li class="l-footer-primary__list--left">
           <div class="footer-primary__list-item">
             <a class="button facebook-link t-facebook-link" lang="en" href="https://www.facebook.com/MoneyAdviceService?ref=mas" target="_blank">
-              <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--facebook" role="presentation" aria-labelledby="facebook-label">
+              <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--facebook" aria-labelledby="facebook-label">
                 <title id="facebook-label">Money Advice Service Facebook page</title>
                 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--facebook"></use>
               </svg>
@@ -23,7 +23,7 @@
         <li class="l-footer-primary__list--centre">
           <div class="footer-primary__list-item">
             <a class="button twitter-link t-twitter-link" lang="en" href="https://twitter.com/YourMoneyAdvice" target="_blank">
-              <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--twitter" role="presentation" aria-labelledby="twitter-label">
+              <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--twitter" aria-labelledby="twitter-label">
                 <title id="twitter-label">Money Advice Service Twitter page</title>
                 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--twitter"></use>
               </svg>
@@ -40,7 +40,7 @@
         <li class="l-footer-primary__list--right">
           <div class="footer-primary__list-item">
             <a class="button youtube-link t-youtube-link" lang="en" href="https://www.youtube.com/user/MoneyAdviceService" target="_blank">
-              <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--youtube" role="presentation" aria-labelledby="youtube-label">
+              <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--youtube" aria-labelledby="youtube-label">
                 <title id="youtube-label">Money Advice Service Youtube channel</title>
                 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--youtube"></use>
               </svg>


### PR DESCRIPTION
## Adding title attributes to SVG's

This ticket adds title attributes to the footer social SVG's.  This will also need to apply to other projects - Blog, RIO and any other that does not use the frontend footer

<img width="593" alt="screen shot 2016-07-15 at 15 04 01" src="https://cloud.githubusercontent.com/assets/13165846/16876820/6c42fcf2-4a9d-11e6-895a-be208cd73b2d.png">

Please note: There is a related ticket in dough to apply the same changes to the social sharing icons:
https://github.com/moneyadviceservice/dough/pull/272

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1486)
<!-- Reviewable:end -->
