### PR TITLE
[DEV APPROVED] - 7440 - Null image ALT attributes

### DIFF
--- a/app/views/retirements/pension_savings/_five_years_out_section.html.erb
+++ b/app/views/retirements/pension_savings/_five_years_out_section.html.erb
@@ -7,7 +7,7 @@
             <%= t('pension_savings_timeline.thinking_about_retirement_five_years_out.title') %>
         </h2>
         <div class="graphic-info-box__illustration">
-          <%= image_tag "retirement_concepts/five-years-out@2x.png", alt: t('pension_savings_timeline.thinking_about_retirement_five_years_out.image_alt') %>
+          <%= image_tag "retirement_concepts/five-years-out@2x.png", alt: '' %>
         </div>
         <p class="graphic-info-box__copy">
             <%= t('pension_savings_timeline.thinking_about_retirement_five_years_out.text') %>

--- a/app/views/retirements/pension_savings/_managing_money_in_retirement_section.html.erb
+++ b/app/views/retirements/pension_savings/_managing_money_in_retirement_section.html.erb
@@ -7,7 +7,7 @@
           <%= t('pension_savings_timeline.managing_money_in_retirement.title') %>
         </h2>
           <div class="graphic-info-box__illustration">
-          <%= image_tag "retirement_concepts/in-retirement@2x.png", alt: t('pension_savings_timeline.managing_money_in_retirement.image_alt') %>
+          <%= image_tag "retirement_concepts/in-retirement@2x.png", alt: '' %>
         </div>
         <p class="graphic-info-box__copy">
           <%= t('pension_savings_timeline.managing_money_in_retirement.text') %>

--- a/app/views/retirements/pension_savings/_moving_into_retirement_section.html.erb
+++ b/app/views/retirements/pension_savings/_moving_into_retirement_section.html.erb
@@ -7,7 +7,7 @@
           <%= t('pension_savings_timeline.moving_into_retirement.title')  %>
         </h2>
         <div class="graphic-info-box__illustration">
-          <%= image_tag "retirement_concepts/moving-into-retirement@2x.png", alt: t('pension_savings_timeline.moving_into_retirement.image_alt')  %>
+          <%= image_tag "retirement_concepts/moving-into-retirement@2x.png", alt: ''  %>
         </div>
         <p class="graphic-info-box__copy">
           <%= t('pension_savings_timeline.moving_into_retirement.text')  %>

--- a/app/views/retirements/pension_savings/_starting_out_section.html.erb
+++ b/app/views/retirements/pension_savings/_starting_out_section.html.erb
@@ -7,7 +7,7 @@
           <%= t('pension_savings_timeline.starting_out_section.title') %>
         </h2>
         <div class="graphic-info-box__illustration">
-          <%= image_tag "retirement_concepts/getting-started@2x.png", alt: t('pension_savings_timeline.starting_out_section.image_alt') %>
+          <%= image_tag "retirement_concepts/getting-started@2x.png", alt: '' %>
         </div>
         <p class="graphic-info-box__copy">
           <%= t('pension_savings_timeline.starting_out_section.intro_text') %>

--- a/app/views/retirements/pension_savings/_ten_years_out_section.html.erb
+++ b/app/views/retirements/pension_savings/_ten_years_out_section.html.erb
@@ -7,7 +7,7 @@
             <%= t('pension_savings_timeline.thinking_about_retirement_ten_years_out.title') %>
         </h2>
         <div class="graphic-info-box__illustration">
-          <%= image_tag "retirement_concepts/ten-years-out@2x.png", alt: t('pension_savings_timeline.thinking_about_retirement_ten_years_out.image_alt') %>
+          <%= image_tag "retirement_concepts/ten-years-out@2x.png", alt: '' %>
         </div>
         <p class="graphic-info-box__copy">
             <%= t('pension_savings_timeline.thinking_about_retirement_ten_years_out.intro_text') %>

--- a/app/views/retirements/pension_savings/_throughout_working_life_section.html.erb
+++ b/app/views/retirements/pension_savings/_throughout_working_life_section.html.erb
@@ -7,7 +7,7 @@
           <%= t('pension_savings_timeline.throughout_working_life.title') %>
         </h2>
         <div class="graphic-info-box__illustration">
-          <%= image_tag "retirement_concepts/in-working-life@2x.png", alt: t('pension_savings_timeline.throughout_working_life.image_alt') %>
+          <%= image_tag "retirement_concepts/in-working-life@2x.png", alt: '' %>
         </div>
         <p class="graphic-info-box__copy">
           <%= t('pension_savings_timeline.throughout_working_life.intro_text') %>

--- a/config/locales/landing_pages/pension_savings_timeline.cy.yml
+++ b/config/locales/landing_pages/pension_savings_timeline.cy.yml
@@ -5,7 +5,6 @@ cy:
       text: Pa un a ydych chi yn dechrau ar eich swydd gyntaf, hanner ffordd trwy'ch bywyd gwaith, yn agosáu at ymddeol neu wedi ymddeol, bydd y llinell amser hon yn eich helpu chi i ddeall buddion cynilo pensiwn hirdymor ac ymroi i reoli'ch arian i sicrhau bod gennych ddigon o arian i fyw arno am oes.
     starting_out_section:
       title: Dechrau Arni
-      image_alt: Darlun Eglurhaol Dechrau Arni
       intro_text: Mae pensiynau yn cynnig ffordd o gynilo yn ddi-dreth a chael treth yn ôl i'ch helpu chi i gronni pot o arian i chi fyw arno yn ddiweddarach yn eich oes. Y cynharaf y gallwch ddechrau pensiwn y mwyaf o dreth y byddwch yn ei harbed ac yn ei chael yn ôl a'r mwyaf y bydd eich pot pensiwn pan fyddwch chi'n rhoi'r gorau i weithio yn y pendraw.
       starting_a_pension:
         title: Dechrau pensiwn
@@ -19,7 +18,6 @@ cy:
         url: "/cy/articles/eich-pensiwn-cyntaf-y-dewisiadau"
     throughout_working_life:
       title: Trwy gydol bywyd gwaith
-      image_alt: Darlun Eglurhaol Trwy Gydol Bywyd Gwaith
       intro_text: Mae pensiynau yn buddsoddi mewn stociau a chyfranddaliadau felly dylech wirio yn rheolaidd sut y mae'ch pot yn perfformio a cheisio cyngor os ydych chi'n pryderu. Wrth i'ch cyflog gynyddu, fel arfer mae'n gwneud synnwyr cynilo mwy i'ch pensiwn, cyhyd â bod gennych ddigon o arian i fyw arno a bod unrhyw ddyledion dan reolaeth.
       monitoring_your_pension_investments:
         title: Monitro'ch buddsoddiadau pensiwn
@@ -50,7 +48,6 @@ cy:
         url_two: "/cy/articles/dewis-cynghorydd-ariannol"
     thinking_about_retirement_ten_years_out:
       title: Meddwl am ymddeol - 10 mlynedd i fynd
-      image_alt: Darlun Eglurhaol Meddwl am ymddeol - 10 mlynedd i fynd
       intro_text: Gallai ymddeoliad ymddangos ymhell i ffwrdd, ond yn awr yw'r amser i wirio a fydd eich potiau pensiwn yn darparu'r incwm yr ydych chi ei eisiau a deall eich opsiynau i gael mynediad atynt. Mae hefyd yn amser da i adolygu'ch dyledion, gwneud ewyllys os nad oes gennych chi un - ac i fynnu cyngor os oes angen hynny arnoch chi.
       reviewing_your_pension_investments:
         title: Adolygu'ch buddsoddiadau pensiwn
@@ -84,7 +81,6 @@ cy:
         url: "https://directory.moneyadviceservice.org.uk/cy"
     thinking_about_retirement_five_years_out:
       title: Meddwl am ymddeol - 5 mlynedd i fynd
-      image_alt: Darlun eglurhaol Meddwl am ymddeol - 5 mlynedd i fynd
       text: Dyma'r amser i gasglu'ch holl waith papur pensiwn ynghyd, adolygu'ch holl fuddsoddiadau pensiwn a gwneud addasiadau munud olaf i helpu i uchafu ar eich incwm ymddeol.
       getting_a_state_pension_forecast:
         title: Cael cyfriflen Pensiwn y Wladwriaeth
@@ -118,7 +114,6 @@ cy:
         url: "https://directory.moneyadviceservice.org.uk/cy"
     moving_into_retirement:
       title: Symud i ymddeoliad
-      image_alt: Darlun Eglurhaol Symud i Ymddeoliad
       text: Pa un a ydych chi'n ymddeol yn llawn neu'n raddol, mae angen i chi lunio cynllun incwm ymddeol yn ystod y misoedd cyn hynny i sicrhau y bydd gennych ddigon o arian i fyw. Defnyddiwch hyn i gael arweiniad neu gyngor ariannol ar ba opsiynau a allai fod yn addas i ddefnyddio'ch pot pensiwn.
       getting_retirement_income_quotes:
         title: Cael dyfynbrisiau incwm ymddeol
@@ -162,7 +157,6 @@ cy:
         url: "https://directory.moneyadviceservice.org.uk/cy"
     managing_money_in_retirement:
       title: Rheoli arian ar ôl ymddeol
-      image_alt: Darlun eglurhaol rheoli arian ar ôl ymddeol
       text: Mae'n debyg y bydd yn rhaid i chi fyw ar lai pan fyddwch chi'n ymddeol felly mae'n bwysig cadw golwg ar eich ffynonellau incwm a chanfod ffyrdd o wneud i'ch arian fynd ymhellach. Bydd angen i chi hefyd gynllunio at yr annisgwyl pe bai eich iechyd chi neu'ch partner yn newid yn ddiweddarach mewn bywyd.
       managing_your_money_day_to_day:
         title: Rheoli'ch arian o ddydd i ddydd

--- a/config/locales/landing_pages/pension_savings_timeline.en.yml
+++ b/config/locales/landing_pages/pension_savings_timeline.en.yml
@@ -5,7 +5,6 @@ en:
       text: Whether you're just starting your first job, mid-way through your working life, approaching retirement or retired, this timeline will help you understand the benefits of long-term pension saving and of actively managing your money to ensure you have enough to live on for life.
     starting_out_section:
       title: Starting Out
-      image_alt: Starting Out Illustration
       intro_text: Pensions offer a way to save tax-free and get tax back to help build up a pot of money for you to live off later in life. The sooner you start a pension the more tax you'll save and get back and the bigger your pension pot when you finally stop work.
       starting_a_pension:
         title: Starting a pension
@@ -19,7 +18,6 @@ en:
         url: "/en/tools/workplace-pension-contribution-calculator"
     throughout_working_life:
       title: Throughout working life
-      image_alt: Throughout Working Life Illustration
       intro_text: Pensions invest in stocks and shares so be sure to check regularly how your pot is performing and get advice if concerned. As your salary increases it normally makes sense to save more into your pension, provided you have sufficient money to live on and any debts are under control.
       monitoring_your_pension_investments:
         title: Monitoring your pension investments
@@ -50,7 +48,6 @@ en:
         url_two: "/en/articles/choosing-a-financial-adviser"
     thinking_about_retirement_ten_years_out:
       title: Thinking about retirement - 10 years out
-      image_alt: Thinking about retirement - 10 years out Illustration
       intro_text: Retirement may seem a long way off, but now's the time to to check whether your pension pots look set to provide the income you want  and understand your options for accessing them. It's also a good time to review your debts, make a will if you don't have one - and to get advice if you need it.
       reviewing_your_pension_investments:
         title: Reviewing your pension investments
@@ -84,7 +81,6 @@ en:
         url: "https://directory.moneyadviceservice.org.uk/en"
     thinking_about_retirement_five_years_out:
       title: Thinking about retirement - 5 years out
-      image_alt: Thinking abour retirement - 5 years out Illustration
       text: This is the time to gather all of your pension paperwork together, review all of your pension investments and make last-minute adjustments to help maximise your retirement income.
       getting_a_state_pension_forecast:
         title: Getting a State Pension statement
@@ -118,7 +114,6 @@ en:
         url: "https://directory.moneyadviceservice.org.uk/en"
     moving_into_retirement:
       title: Moving into retirement
-      image_alt: Moving Into Retirement Illustation
       text: Whether retiring fully or gradually, you need to draw up a retirement income plan in the months beforehand to ensure you'll have enough to live on. Use this to get guidance or financial advice on which options for using your pension pot may be suitable.
       getting_retirement_income_quotes:
         title: Getting retirement income quotes
@@ -162,7 +157,6 @@ en:
         url: "https://directory.moneyadviceservice.org.uk/en"
     managing_money_in_retirement:
       title: Managing money in retirement
-      image_alt: Managing money in retirement Illustration
       text: It's likely you'll have less to live on when you retire so it's important to keep your income sources under review and find ways to make your money go further. You also need to plan for the unexpected should your or your partner's health change later in life.
       managing_your_money_day_to_day:
         title: Managing your money day to day


### PR DESCRIPTION
## The issue

The DAC report highlights that images on the following page contain descriptive alt attributes:
https://www.moneyadviceservice.org.uk/en/pensions-and-retirement/pension-savings-timeline
here https://www.moneyadviceservice.org.uk/en/pensions-and-retirement

However due to accessibility requirements it is necessary to have a null alt attribute.

## The solution

The solution was to remove the alt attributes for the images from the yaml files (en|cy) and update the rails image_tag helper to use a null alt attribute like so:

```
<%= image_tag "retirement_concepts/in-retirement@2x.png", alt: '' %>
```
Which results in the output:
```
<img alt="" src="/assets/retirement_concepts/in-retirement@2x.png">
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1488)
<!-- Reviewable:end -->
