### PR TITLE
[DEV APPROVED] 7474 - Home Page Image Optimisation

### DIFF
--- a/app/assets/stylesheets/components/page_specific/_home_top.scss
+++ b/app/assets/stylesheets/components/page_specific/_home_top.scss
@@ -19,6 +19,15 @@
 
 }
 
+.home-top-left,
+.home-top-right {
+  @include column(12);
+
+  @include respond-to($mq-l) {
+    @include column(6);
+  }
+}
+
 .home-top-trust {
   position: relative;
   margin-top: $baseline-unit*7;
@@ -30,7 +39,6 @@
 }
 
 .home-top__image {
-
   background-repeat: no-repeat;
   background-size: contain;
   bottom: 0;
@@ -41,21 +49,14 @@
   @include respond-to($mq-m) {
     padding-top: 33%;
     right: 0;
-    width: 60%;
+    width: 50%;
+    position: relative;
   }
 
   @include respond-to($mq-l) {
     background-position: right;
     padding-top: 28%;
-    width: 55%;
-  }
-
-  @include respond-to($mq-xl) {
-    @include absolutely-centre-horizontally(1350px);
-    background-position: 100% 0%;
-    background-repeat: no-repeat;
-    background-size: 46%;
-    height: 345px;
+    position: absolute;
   }
 
   @if $responsive == false {
@@ -115,10 +116,6 @@
   @include body(16, 24);
   margin-bottom: $baseline-unit;
 
-  @include respond-to($mq-m) {
-    max-width: 45%;
-  }
-
   @include respond-to($mq-l) {
     max-width: none;
 
@@ -135,21 +132,11 @@
 }
 
 .home-top-promo {
-  clear: both;
-
-  @include respond-to($mq-small-tablet, $mq-small-tablet-end) {
-    bottom: 0;
-    left: 0;
-    position: absolute;
-  }
-
-  @include respond-to($mq-l) {
-    bottom: 0;
-    clear: none;
-    margin: 0;
-    position: absolute;
-    right: 3%;
-  }
+  bottom: 0;
+  clear: none;
+  margin: 0;
+  position: absolute;
+  right: 0;
 }
 
 .home-top-promo__text {
@@ -157,21 +144,16 @@
   @include body(22, 30);
   background-color:$color-black;
   background: rgba(0,0,0,0.8);
-  border-radius: 6px;
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px;
   margin: 0 $baseline-unit*3;
   max-width: 400px;
-  padding: $baseline-unit*4 $baseline-unit*7 $baseline-unit*4 $baseline-unit*4;
+  padding: $baseline-unit $baseline-unit*7 $baseline-unit $baseline-unit*4;
   position: relative;
-
-  @include respond-to($mq-small-tablet) {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
-  }
 
   @include respond-to($mq-m) {
     margin: $baseline-unit*2 0 0;
     padding: $baseline-unit*2 $baseline-unit*8 $baseline-unit*2 $baseline-unit*4;
-    width: 55%;
   }
 
   @include respond-to($mq-l) {

--- a/app/assets/stylesheets/layout/page_specific/_homepage.scss
+++ b/app/assets/stylesheets/layout/page_specific/_homepage.scss
@@ -21,8 +21,8 @@
   .home-top-promo {
     @include column(12);
 
-    @include respond-to($mq-l) {
-      @include column(5);
+    @include respond-to($mq-m) {
+      @include column(6);
     }
   }
 }

--- a/app/views/shared/_home_top.html.erb
+++ b/app/views/shared/_home_top.html.erb
@@ -1,23 +1,30 @@
 <div class="l-home-top">
   <div class="home-top">
-    <div style="background-image: url(<%= item.hero_image %>);" class="home-top__image"></div>
     <div class="l-constrained">
-      <div class="home-top-trust">
-        <p class="home-top-trust__heading"><%= item.heading %></p>
-        <ul class="home-top-trust-content">
-          <li class="home-top-trust-content__item"><%= item.bullet_1 %></li>
-          <li class="home-top-trust-content__item"><%= item.bullet_2 %></li>
-          <li class="home-top-trust-content__item"><%= item.bullet_3 %></li>
-        </ul>
+      
+      <div class="home-top-left">
+        <div class="home-top-trust">
+          <p class="home-top-trust__heading"><%= item.heading %></p>
+          <ul class="home-top-trust-content">
+            <li class="home-top-trust-content__item"><%= item.bullet_1 %></li>
+            <li class="home-top-trust-content__item"><%= item.bullet_2 %></li>
+            <li class="home-top-trust-content__item"><%= item.bullet_3 %></li>
+          </ul>
+        </div>
       </div>
-      <div class="home-top-promo">
-        <p class="home-top-promo__text">
-          <a href="<%= item.cta_link %>" class="home-top-promo-link">
-            <%= item.cta_text %>
-            <%= render 'shared/svg/use_icon', icon: 'arrow-right', class_name: 'home-top-promo-link__arrow' %>
-          </a>
-        </p>
+      
+      <div class="home-top-right">
+        <div style="background-image: url(<%= item.hero_image %>);" class="home-top__image"></div>
+        <div class="home-top-promo">
+          <p class="home-top-promo__text">
+            <a href="<%= item.cta_link %>" class="home-top-promo-link">
+              <%= item.cta_text %>
+              <%= render 'shared/svg/use_icon', icon: 'arrow-right', class_name: 'home-top-promo-link__arrow' %>
+            </a>
+          </p>
+        </div>
       </div>
+      
     </div>
   </div>
 </div>


### PR DESCRIPTION
This ticket introduces changes which guarantee the hero image and text do not overlap.

**Screenshots**

Desktop:

<img width="1226" alt="screen shot 2016-07-21 at 12 34 32" src="https://cloud.githubusercontent.com/assets/13165846/17021397/b2a463d8-4f3f-11e6-8330-01940a7cda1d.png">

Tablet / mobile Landscape:

<img width="953" alt="screen shot 2016-07-21 at 12 34 51" src="https://cloud.githubusercontent.com/assets/13165846/17021406/bc97ee78-4f3f-11e6-9c1f-f0d063961d24.png">

Tablet portrait / mobile

<img width="647" alt="screen shot 2016-07-21 at 12 34 56" src="https://cloud.githubusercontent.com/assets/13165846/17021412/c7d75756-4f3f-11e6-8799-7417ee43811a.png">

Mobile / Small

<img width="366" alt="screen shot 2016-07-21 at 12 35 02" src="https://cloud.githubusercontent.com/assets/13165846/17021419/d310a514-4f3f-11e6-9327-d6772071d95c.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1491)
<!-- Reviewable:end -->
