### PR TITLE
[DEV APPROVED] 7488 - Accessibility / valid markup fixes

### DIFF
--- a/app/views/layouts/_constrained.html.erb
+++ b/app/views/layouts/_constrained.html.erb
@@ -8,7 +8,7 @@
     </div>
   <% end %>
 
-  <div class="l-constrained t-default-main-content" id="<%= 'main' if default_main_content_location? %>" tabindex="-1">
+  <div class="l-constrained t-default-main-content" <%== 'id="main"' if default_main_content_location? %> tabindex="-1">
     <%= yield %>
   </div>
 <% end %>

--- a/app/views/layouts/_unconstrained.html.erb
+++ b/app/views/layouts/_unconstrained.html.erb
@@ -7,7 +7,7 @@
     </div>
   <% end %>
 
-  <div class="t-default-main-content" id="<%= 'main' if default_main_content_location? %>" tabindex="-1">
+  <div class="t-default-main-content" <%== 'id="main"' if default_main_content_location? %> tabindex="-1">
     <%= yield %>
   </div>
 <% end %>

--- a/app/views/technical_feedback/new.html.erb
+++ b/app/views/technical_feedback/new.html.erb
@@ -19,13 +19,13 @@
         <%= f.validation_summary %>
         <div class="form__row <%= 'form__row--is-errored' if f.object.errors.include?(:attempting) %>">
           <%= f.errors_for :attempting %>
-          <label for="email" class="form__label-heading"><%= t('.trying_to_do_html') %></label>
+          <label for="feedback_attempting" class="form__label-heading"><%= t('.trying_to_do_html') %></label>
           <%= f.text_area :attempting, :cols => 60, :rows => 6, 'aria-required' => true, :class => 'feedback__input t-technical-feedback__attempting', :placeholder => t('.input_one_example_text') %>
         </div>
 
         <div class="form__row <%= 'form__row--is-errored' if f.object.errors.include?(:occurred) %>">
           <%= f.errors_for :occurred %>
-          <label for="email" class="form__label-heading"><%= t('.what_went_wrong_html') %></label>
+          <label for="feedback_occurred" class="form__label-heading"><%= t('.what_went_wrong_html') %></label>
           <%= f.text_area :occurred, :cols => 60, :rows => 6, 'aria-required' => true, :class => 'feedback__input t-technical-feedback__occurred', :placeholder => t('.input_two_example_text') %>
         </div>
 


### PR DESCRIPTION
This PR addresses two small items raised in the DAC Audit:

- Correctly labelling the form elements on the Feedback page (these had been incorrectly labelled) at some point).
- Altering code that generates empty ID attribute in some cases - empty ID attributes are invalid HTML

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1492)
<!-- Reviewable:end -->
