### PR TITLE
[DEV APPROVED] 7479 - Adding valid html to signup and account management

### DIFF
--- a/app/assets/stylesheets/layout/page_specific/_profile.scss
+++ b/app/assets/stylesheets/layout/page_specific/_profile.scss
@@ -53,6 +53,12 @@
   margin-bottom: $baseline-unit*2;
 }
 
+.l-profile__your-goal__form-legend {
+  @include body(20, 24);
+  font-weight: 700;
+  color: $color-green-dark;
+}
+
 .l-profile__your-tools__heading {
   padding-right: 25px;
   position: relative;

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -115,17 +115,13 @@
     <div class="registration__row">
       <div class="registration__field">
         <%= f.form_row :opt_in_for_research do %>
-
           <%= f.errors_for :opt_in_for_research %>
-
-          <fieldset class="form__group">
-            <div class="form__group-item">
-              <%= f.label :opt_in_for_research, class: "form__label-heading" do %>
-                <%= f.check_box :opt_in_for_research, class: "form__group-input" %>
-                <%= t("authentication.settings.opt_in_for_research.title") %>
-              <% end %>
-            </div>
-          </fieldset>
+          <div class="form__group-item">
+            <%= f.label :opt_in_for_research, class: "form__label-heading" do %>
+              <%= f.check_box :opt_in_for_research, class: "form__group-input" %>
+              <%= t("authentication.settings.opt_in_for_research.title") %>
+            <% end %>
+          </div>
         <% end %>
       </div>
     </div>

--- a/app/views/profile/edit.html.erb
+++ b/app/views/profile/edit.html.erb
@@ -86,6 +86,7 @@
     <p><%= t('.goal.introduction') %></p>
     <%= form_for current_user, html: {id: 'goal_form', class: 'form l-profile__your-goal__form'}, url: profile_path, method: :put do |f| %>
       <fieldset class="form__group">
+        <legend class="l-profile__your-goal__form-legend"><%= t('.goal.fieldset_legend') %></legend>
         <div class="form__row">
           <label class="form__label-heading" for="goal_statement" ><%= t('.goal.statement_field_label') %></label>
           <input id="goal_statement" type="text" name="goal_statement" value="<%= current_user.goal_statement %>">

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -514,6 +514,7 @@ cy:
       goal:
         heading: Traciwr nod
         introduction: Cynllunio ar gyfer rhywbeth sylweddol neu'n cynilo ar gyfer diwrnod glawog yn unig? Mae'r rhan fwyaf o bobl yn ei chael hi'n haws cyrraedd nod drwy osod terfyn amser.
+        fieldset_legend: Fy nod
         statement_field_label: Byddaf
         statement_field_placeholder: Nodwch y nod yma
         deadline_field_label: erbyn

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -511,6 +511,7 @@ en:
       goal:
         heading: Goal tracker
         introduction: Planning for something big or just saving for a rainy day? Most people find it easier to reach a goal by setting a deadline.
+        fieldset_legend: My Goal
         statement_field_label: I will
         statement_field_placeholder: Enter goal here
         deadline_field_label: By


### PR DESCRIPTION
## 7479 - Updating HTML on account management and settings pages

1) On the signup page and account settings page, remove the ``<fieldset>`` element that wraps the research opt-in tickbox - it is no longer required as there is only one field within it. This should have no visual impact.

| Please see screenshot of markup below, element is no longer in a ``<fieldset>`` element |
|--------|
|<img width="954" alt="screen shot 2016-07-25 at 09 40 47" src="https://cloud.githubusercontent.com/assets/13165846/17095354/f3d2f356-524b-11e6-9bf9-481b65b3b331.png">|

2) On the profile page, add a <legend> element as the first child of the ``<fieldset>`` element, styled like a header.

| Please see screenshot and markup below |
|--------|
|<img width="941" alt="screen shot 2016-07-25 at 09 44 05" src="https://cloud.githubusercontent.com/assets/13165846/17096285/7de8c2d8-5250-11e6-81ef-958347e77db9.png">|

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1493)
<!-- Reviewable:end -->
