### PR TITLE
[DEV APPROVED] bump action_plans to version 4.2.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem 'statsd-ruby'
 gem 'uglifier', '>= 1.3.0'
 gem 'postcode_anywhere-email_validation'
 
-gem 'action_plans', '~> 4.1.1'
+gem 'action_plans', '~> 4.2.8'
 gem 'advice_plans', '~> 3.1.0'
 gem 'agreements', '~> 2.0.1'
 gem 'baby_cost_calculator'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,7 +50,7 @@ GEM
   remote: https://rubygems.org/
   remote: http://gems.dev.mas.local/
   specs:
-    action_plans (4.1.1.325)
+    action_plans (4.2.8.334)
       autoprefixer-rails
       dough-ruby
       draper
@@ -119,7 +119,7 @@ GEM
     ast (2.0.0)
     astrolabe (1.3.0)
       parser (>= 2.2.0.pre.3, < 3.0)
-    autoprefixer-rails (6.3.6.2)
+    autoprefixer-rails (6.3.7)
       execjs
     baby_cost_calculator (0.2.4)
       rails (~> 4.1.8)
@@ -708,7 +708,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  action_plans (~> 4.1.1)
+  action_plans (~> 4.2.8)
   activerecord-session_store
   advice_plans (~> 3.1.0)
   aes


### PR DESCRIPTION

This has been successfully deployed and tested on _Preview_(https://www.preview.dev.mas.local/en/tools/redundancy-pay-calculator). 

History of changes can be viewed here: 
https://github.com/moneyadviceservice/action_plans/pull/137

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1499)
<!-- Reviewable:end -->
