### PR TITLE
Bumping RIO to 1.5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,7 @@ gem 'mortgage_calculator', '~> 1.4.10'
 gem 'payday_loans_intervention', '~> 1.4'
 gem 'pensions_calculator', '~> 1.1.1'
 gem 'quiz', git: 'git@github.com:moneyadviceservice/quiz.git'
-gem 'rio', '= 1.4.0', source: 'http://gems.dev.mas.local'
+gem 'rio', '= 1.5.0', source: 'http://gems.dev.mas.local'
 gem 'savings_calculator', '~> 1.2.0'
 gem 'timelines', '~> 1.2.0', git: 'git@github.com:moneyadviceservice/timelines.git'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -563,7 +563,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
-    rio (1.4.0)
+    rio (1.5.0)
       bowndler
       dough-ruby
       pensions_calculator-calculations
@@ -784,7 +784,7 @@ DEPENDENCIES
   rack-livereload
   rails (= 4.1.8)
   redcarpet
-  rio (= 1.4.0)!
+  rio (= 1.5.0)!
   rouge
   rspec-html-matchers
   rspec-rails (~> 3.0)


### PR DESCRIPTION
## Bumping RIO to version 1.5.0

For work done in tickets 7478 and 7481

https://github.com/moneyadviceservice/rio/pull/96
https://github.com/moneyadviceservice/rio/pull/97

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1501)
<!-- Reviewable:end -->
