### PR TITLE
[DEV APPROVED] 7432/3: Add favicons and manifest

### DIFF
--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -26,6 +26,26 @@
   <meta http-equiv="cleartype" content="on"><![endif]-->
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="HandheldFriendly" content="True">
+
+  <meta name="application-name" content="Money Advice Service">
+  <meta name="msapplication-starturl" content="https://www.moneyadviceservice.org.uk">
+  <meta name="msapplication-square70x70logo" content="/favicon_ms_70x70.png">
+  <meta name="msapplication-square150x150logo" content="/favicon_ms_150x150.png">
+  <meta name="msapplication-wide310x150logo" content="/favicon_ms_310x150.png">
+  <meta name="msapplication-square310x310logo" content="/favicon_ms_310x310.png">
+  <%= tag 'link', rel: 'icon', type: 'image/png', sizes: '32x32', href: '/favicon_32x32.png' %>
+  <%= tag 'link', rel: 'icon', type: 'image/png', sizes: '48x48', href: '/favicon_48x48.png' %>
+  <%= tag 'link', rel: 'icon', type: 'image/png', sizes: '96x96', href: '/favicon_96x96.png' %>
+  <%= tag 'link', rel: 'icon', type: 'image/png', sizes: '128x128', href: '/favicon_128x128.png' %>
+  <%= tag 'link', rel: 'icon', type: 'image/png', sizes: '196x196', href: '/favicon_196x196.png' %>
+  <%= tag 'link', rel: 'apple-touch-icon-precomposed', sizes: '57x57', href: '/favicon_57x57.png' %>
+  <%= tag 'link', rel: 'apple-touch-icon-precomposed', sizes: '76x76', href: '/favicon_76x76.png' %>
+  <%= tag 'link', rel: 'apple-touch-icon-precomposed', sizes: '120x120', href: '/favicon_120x120.png' %>
+  <%= tag 'link', rel: 'apple-touch-icon-precomposed', sizes: '152x152', href: '/favicon_152x152.png' %>
+  <%= tag 'link', rel: 'apple-touch-icon-precomposed', sizes: '167x167', href: '/favicon_167x167.png' %>
+  <%= tag 'link', rel: 'apple-touch-icon-precomposed', sizes: '180x180', href: '/favicon_180x180.png' %>
+  <%= tag 'link', rel: 'manifest', href: '/manifest.json' %>
+
   <%= tag 'link', rel: 'publisher', href: Rails.application.config.google_plus_mas_url %>
   <%# Basic styles for all devices, doesn't contain anything that could cause rendering issues
       such as positional info %>


### PR DESCRIPTION
This merges two tickets, 7432 and 7433 to add references in the <head> to all the required icons and manifest file for the site. The actual assets are dealt with in PR694 in scripts (https://github.com/moneyadviceservice/scripts/pull/694)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1504)
<!-- Reviewable:end -->
