### PR TITLE
[DEV APPROVED] 7495 - 2016 Audit - 'Skip to main' link on certain pages

### DIFF
--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -3,6 +3,10 @@ class CampaignsController < ApplicationController
 
   include SuppressMenuButton
 
+  def display_skip_to_main_navigation?
+    false
+  end
+
   def show
     if template_exists?("/campaigns/#{params[:id].underscore}")
       render template: "/campaigns/#{params[:id].underscore}", layout: '_unconstrained'

--- a/app/controllers/landing_pages_controller.rb
+++ b/app/controllers/landing_pages_controller.rb
@@ -1,6 +1,10 @@
 class LandingPagesController < ApplicationController
   include SuppressMenuButton
 
+  def display_skip_to_main_navigation?
+    false
+  end
+
   def show
     @breadcrumbs = BreadcrumbTrail.home
     render layout: '_unconstrained'

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -4,6 +4,10 @@ class RegistrationsController < Devise::RegistrationsController
 
   include SuppressMenuButton
 
+  def display_skip_to_main_navigation?
+    false
+  end
+
   protected
 
   def build_resource(hash = nil)

--- a/app/controllers/retirements_controller.rb
+++ b/app/controllers/retirements_controller.rb
@@ -4,6 +4,10 @@ class RetirementsController < ApplicationController
 
   include SuppressMenuButton
 
+  def display_skip_to_main_navigation?
+    false
+  end
+
   def locale_options
     LandingPagePaths.locale_options(params[:controller], params[:action])
   end

--- a/app/controllers/rio_controller.rb
+++ b/app/controllers/rio_controller.rb
@@ -11,6 +11,10 @@ class RioController < MountController
     categories.map(&Breadcrumb.public_method(:new))
   end
 
+  def display_skip_to_main_navigation?
+    false
+  end
+
   private
 
   def category

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,6 +4,10 @@ class SessionsController < Devise::SessionsController
 
   include SuppressMenuButton
 
+  def display_skip_to_main_navigation?
+    false
+  end
+
   def new
     # This method is mostly copied devise code
     # With one tweak to add the error to resource from the flash hash

--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -2,6 +2,10 @@ class SitemapController < ApplicationController
   def index
   end
 
+  def display_skip_to_main_navigation?
+    false
+  end
+
   def robots
     @base_url = request.base_url
 

--- a/app/views/corporate/show.html.erb
+++ b/app/views/corporate/show.html.erb
@@ -11,7 +11,7 @@
   <% end %>
 <% end %>
 
-<main class="l-main" role="main">
+<main class="l-main" role="main" id="main">
   <%= heading_tag article.title %>
 
   <% if category && category.third_level_navigation? %>

--- a/app/views/corporate_categories/show.html.erb
+++ b/app/views/corporate_categories/show.html.erb
@@ -9,7 +9,7 @@
 
 <div class="l-main editorial">
   <div class="l-main__row">
-    <main class="l-main__cell-double" role="main">
+    <main class="l-main__cell-double" role="main" id="main">
       <%= heading_tag category.title %>
 
       <% unless category.third_level_navigation? %>

--- a/app/views/landing_pages/show.html.erb
+++ b/app/views/landing_pages/show.html.erb
@@ -14,7 +14,7 @@
   <%= render 'shared/breadcrumbs', breadcrumbs: @breadcrumbs %>
 <% end %>
 
-<main role="main">
+<main role="main" id="main">
   <div class="l-annuities__banner">
     <div class="l-constrained">
       <h1 class="l-annuities__heading"><%= t('annuities.page_heading') %></h1>


### PR DESCRIPTION
## 7495 - 2016 Audit - 'Skip to main' link on certain pages

There are certain pages which do or dont have the correct accessible links at the top of the page, to see these go to any page and hit tab, you will see the following links appear:

| Skip to main content | Skip to main navigation |
|:----------------------:|:------------------------:|
|<img width="215" alt="screen shot 2016-08-12 at 09 04 30" src="https://cloud.githubusercontent.com/assets/13165846/17616353/14732d0a-606c-11e6-89a4-38f20de35984.png">|<img width="276" alt="screen shot 2016-08-12 at 09 04 39" src="https://cloud.githubusercontent.com/assets/13165846/17616356/18f93234-606c-11e6-9408-089ff8787562.png">|



As part of this ticket, I have done a quick review of the pages/types of pages which require the skip to main content/navigation links:

| Page | Should have skip main content link | Should have skip to main navigation Link |
|------:|:------------------:|:-----------------:|
| Homepage |![image](https://cloud.githubusercontent.com/assets/13165846/17591881/f9a11df0-5fd7-11e6-94e5-e93693176dbb.png)|![image](https://cloud.githubusercontent.com/assets/13165846/17591881/f9a11df0-5fd7-11e6-94e5-e93693176dbb.png)|
| Sign in / Sign up |  ![image](https://cloud.githubusercontent.com/assets/13165846/17591881/f9a11df0-5fd7-11e6-94e5-e93693176dbb.png)|![image](https://cloud.githubusercontent.com/assets/13165846/17591881/f9a11df0-5fd7-11e6-94e5-e93693176dbb.png)|
|Categories Pages |![image](https://cloud.githubusercontent.com/assets/13165846/17591881/f9a11df0-5fd7-11e6-94e5-e93693176dbb.png)|![image](https://cloud.githubusercontent.com/assets/13165846/17591881/f9a11df0-5fd7-11e6-94e5-e93693176dbb.png)|
|Articles|![image](https://cloud.githubusercontent.com/assets/13165846/17591881/f9a11df0-5fd7-11e6-94e5-e93693176dbb.png)|![image](https://cloud.githubusercontent.com/assets/13165846/17591881/f9a11df0-5fd7-11e6-94e5-e93693176dbb.png)|
| Corporate | ![image](https://cloud.githubusercontent.com/assets/13165846/17591881/f9a11df0-5fd7-11e6-94e5-e93693176dbb.png)|![image](https://cloud.githubusercontent.com/assets/13165846/17591881/f9a11df0-5fd7-11e6-94e5-e93693176dbb.png)|
| Corporate Categories |  ![image](https://cloud.githubusercontent.com/assets/13165846/17591881/f9a11df0-5fd7-11e6-94e5-e93693176dbb.png)|![image](https://cloud.githubusercontent.com/assets/13165846/17591881/f9a11df0-5fd7-11e6-94e5-e93693176dbb.png)|
|Campaigns | ![image](https://cloud.githubusercontent.com/assets/13165846/17591881/f9a11df0-5fd7-11e6-94e5-e93693176dbb.png)|![image](https://cloud.githubusercontent.com/assets/13165846/17591919/20c1b318-5fd8-11e6-8391-0e24b5778cb4.png)|
| Tools | ![image](https://cloud.githubusercontent.com/assets/13165846/17591881/f9a11df0-5fd7-11e6-94e5-e93693176dbb.png)|![image](https://cloud.githubusercontent.com/assets/13165846/17591919/20c1b318-5fd8-11e6-8391-0e24b5778cb4.png)|
| Pensions and Retirement |  ![image](https://cloud.githubusercontent.com/assets/13165846/17591881/f9a11df0-5fd7-11e6-94e5-e93693176dbb.png)|![image](https://cloud.githubusercontent.com/assets/13165846/17591919/20c1b318-5fd8-11e6-8391-0e24b5778cb4.png)|
| Annuities |   ![image](https://cloud.githubusercontent.com/assets/13165846/17591881/f9a11df0-5fd7-11e6-94e5-e93693176dbb.png)|![image](https://cloud.githubusercontent.com/assets/13165846/17591919/20c1b318-5fd8-11e6-8391-0e24b5778cb4.png)|
| Retirement income options |  ![image](https://cloud.githubusercontent.com/assets/13165846/17591881/f9a11df0-5fd7-11e6-94e5-e93693176dbb.png)|![image](https://cloud.githubusercontent.com/assets/13165846/17591919/20c1b318-5fd8-11e6-8391-0e24b5778cb4.png)|
| Sitemap |   ![image](https://cloud.githubusercontent.com/assets/13165846/17591881/f9a11df0-5fd7-11e6-94e5-e93693176dbb.png)|![image](https://cloud.githubusercontent.com/assets/13165846/17591919/20c1b318-5fd8-11e6-8391-0e24b5778cb4.png)|

In each of the cases above - whether the links appear is correct, and all pages now contain an element with ``id="main"``, and where the navigation link is not required it has been removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1506)
<!-- Reviewable:end -->
