### PR TITLE
Update timelines gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,7 @@ gem 'pensions_calculator', '~> 1.1.1'
 gem 'quiz', git: 'git@github.com:moneyadviceservice/quiz.git'
 gem 'rio', '= 1.5.0', source: 'http://gems.dev.mas.local'
 gem 'savings_calculator', '~> 1.2.0'
-gem 'timelines', '~> 1.2.0', git: 'git@github.com:moneyadviceservice/timelines.git'
+gem 'timelines', '~> 1.3.0', git: 'git@github.com:moneyadviceservice/timelines.git'
 
 # 1.0.2 has breaking changes as it adds japanese and turkish locales
 gem 'validate_url', '1.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,15 +36,15 @@ GIT
 
 GIT
   remote: git@github.com:moneyadviceservice/timelines.git
-  revision: 81a762a756ad8135263e828b02b88741b67b9795
+  revision: 74c9bd099b25aee3c36cd08d689ce915fdfa7ac0
   specs:
-    timelines (1.2.3)
+    timelines (1.3.0)
       bowndler
       icalendar
-      jquery-rails (>= 3.1.2)
-      mas-feedback
+      jquery-rails
       mas-templating
-      rails (= 4.1.8)
+      rails (>= 4, < 5)
+      sass-rails
 
 GEM
   remote: https://rubygems.org/
@@ -401,7 +401,7 @@ GEM
     i18n (0.7.0)
     i18n-js (3.0.0.mas)
       i18n
-    icalendar (2.3.0)
+    icalendar (2.4.0)
     interception (0.5)
     jbuilder (2.3.1)
       activesupport (>= 3.0.0, < 5)
@@ -448,7 +448,7 @@ GEM
     mas-mailer (0.3.2.10)
       delayed_job_active_record
       hashie
-    mas-templating (1.0.0.11)
+    mas-templating (1.0.0.18)
     mechanize (2.5.1)
       domain_name (~> 0.5, >= 0.5.1)
       mime-types (~> 1.17, >= 1.17.2)
@@ -801,7 +801,7 @@ DEPENDENCIES
   syslog-logger
   tidy-html5!
   timecop
-  timelines (~> 1.2.0)!
+  timelines (~> 1.3.0)!
   uglifier (>= 1.3.0)
   unicorn-rails
   validate_url (= 1.0.0)


### PR DESCRIPTION
Bring in new version that supports Rails 4.2.x

https://github.com/moneyadviceservice/timelines/pull/66

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1507)
<!-- Reviewable:end -->
