### PR TITLE
[DEV APPROVED]7568 - Adding svg-icon--arrow-left to SVG partial

### DIFF
--- a/app/views/shared/svg/_icon_sprite.html.erb
+++ b/app/views/shared/svg/_icon_sprite.html.erb
@@ -8,6 +8,9 @@
   <symbol id="svg-icon--arrow-right" viewBox="0 0 22 34">
     <polygon points="0,5 5,0 22,17 5.1,34 0,29 12,17"/>
   </symbol>
+  <symbol id="svg-icon--arrow-left" viewBox="0 0 22 34">
+    <polygon points="10,17 22,29 16.9,34 0,17 17,0 22,5 "/>
+  </symbol>
   <symbol id="svg-icon--desktop-close-box" viewBox="0 0 12.291 11.878">
     <path fill="#6B6B6B" d="M.017 2.097L2 .013l10.295 9.794-1.982 2.084z"/>
     <path fill="#6B6B6B" d="M10.296-.014l1.982 2.084-10.3 9.793L0 9.78z"/>


### PR DESCRIPTION
This icon is useful and can be reused, so we are adding it to the main SVG partial that appears on every page on the site (the arrow-right is already in there).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1515)
<!-- Reviewable:end -->
