### PR TITLE
[DEV APPROVED] - 7563 - Properly label the 'view all' link on the Pensions & Retirement Landing page

### DIFF
--- a/app/views/retirements/index.html.erb
+++ b/app/views/retirements/index.html.erb
@@ -90,7 +90,10 @@
             <% end %>
           </ul>
 
-          <a data-dough-view-all-trigger class="view-all__trigger view-all__trigger--hidden" href="#"><%= t('retirements.section4.view_all') %></a>
+          <a data-dough-view-all-trigger class="view-all__trigger view-all__trigger--hidden" href="#">
+            <%= panel[:view_all] %>
+          </a>
+
         </div>
       <% end %>
     </div>
@@ -104,7 +107,10 @@
             <% end %>
           </ul>
 
-          <a data-dough-view-all-trigger class="view-all__trigger view-all__trigger--hidden" href="#"><%= t('retirements.section4.view_all') %></a>
+          <a data-dough-view-all-trigger class="view-all__trigger view-all__trigger--hidden" href="#">
+            <%= panel[:view_all] %>
+          </a>
+
         </div>
       <% end %>
     </div>
@@ -118,7 +124,10 @@
             <% end %>
           </ul>
 
-          <a data-dough-view-all-trigger class="view-all__trigger view-all__trigger--hidden" href="#"><%= t('retirements.section4.view_all') %></a>
+          <a data-dough-view-all-trigger class="view-all__trigger view-all__trigger--hidden" href="#">
+            <%= panel[:view_all] %>
+          </a>
+
         </div>
       <% end %>
     </div>

--- a/config/locales/retirements.cy.yml
+++ b/config/locales/retirements.cy.yml
@@ -65,9 +65,9 @@ cy:
         text: Trefnwch eich sesiwn ganllaw Pension Wise rhad ac am ddim
         url: https://www.pensionwise.gov.uk
     section4:
-      view_all: Gweld yr holl…
       panels1:
         - title: Mathau o bensiwn
+          view_all: Gweld yr holl mewn mathau o bensiwn
           links:
             - text: Cynlluniau ymddeol cyfraniadau wedi’u diffinio
               url: /cy/articles/cynlluniau-pensiwn-cyfraniadau-wediu-diffinio
@@ -90,6 +90,7 @@ cy:
             - text: Pensiynau NEST
               url: /cy/articles/pensiynaur-ymddiriedolaeth-cynilion-cyflogaeth-genedlaethol-nest
         - title: Pensiynau gweithle
+          view_all: Gweld yr holl mewn pensiynau gweithle
           links:
             - text: Cofrestru awtomatig – cyflwyniad
               url: /cy/articles/cofrestriad-awtomatig-ar-bensiwn-man-gwaith
@@ -112,6 +113,7 @@ cy:
             - text: Cofrestru awtomatig os ydych chi dros oedran Pensiwn y Wladwriaeth
               url: /cy/articles/cofrestru-awtomatig-os-ydych-chi-dros-oedran-pensiwn-y-wladwriaeth
         - title: Cynilo ar gyfer ymddeoliad
+          view_all: Gweld yr holl mewn cynilo ar gyfer ymddeoliad
           links:
             - text: 'Canllaw pensiwn: ffeithiau allweddol a mathau o gynlluniau pensiwn'
               url: /cy/articles/canllaw-pensiwn-ffeithiau-allweddol-a-mathau-o-gynlluniau-pensiwn
@@ -143,6 +145,7 @@ cy:
               url: /cy/articles/eich-opsiynau-os-bydd-pethaun-mynd-o-le-gydach-pensiwn
       panels2:
         - title: Rheoli arian
+          view_all: Gweld yr holl mewn rheoli arian
           links:
             - text: Pa bryd alla i fforddio i ymddeol?
               url: /cy/articles/pa-bryd-alla-i-fforddio-i-ymddeol
@@ -161,6 +164,7 @@ cy:
             - text: Gofalu am eich disgynyddion wedi ymddeol
               url: /cy/articles/looking-after-your-dependants-in-retirement
         - title: Dewisiadau incwm ymddeol
+          view_all: Gweld yr holl mewn dewisiadau incwm ymddeol
           links:
             - text: Yr opsiynau ar gyfer defnyddio’ch cronfa bensiwn
               url: /cy/articles/yr-opsiynau-ar-gyfer-defnyddioch-cronfa-bensiwn
@@ -224,6 +228,7 @@ cy:
             - text: Canllaw i ffioedd cynghorwyr ariannol
               url: /cy/articles/canllaw-i-ffioedd-cynghorwyr-ariannol
         - title: Cymorth yn y blynyddoedd hŷn
+          view_all: Gweld yr holl mewn cymorth yn y blynyddoedd hŷn
           links:
             - text: Ymddeol dramor
               url: /cy/articles/retiring-abroad

--- a/config/locales/retirements.cy.yml
+++ b/config/locales/retirements.cy.yml
@@ -67,7 +67,7 @@ cy:
     section4:
       panels1:
         - title: Mathau o bensiwn
-          view_all: Gweld yr holl mewn mathau o bensiwn
+          view_all: Gewld y cyfan mewn mathau o bensiwn
           links:
             - text: Cynlluniau ymddeol cyfraniadau wedi’u diffinio
               url: /cy/articles/cynlluniau-pensiwn-cyfraniadau-wediu-diffinio
@@ -90,7 +90,7 @@ cy:
             - text: Pensiynau NEST
               url: /cy/articles/pensiynaur-ymddiriedolaeth-cynilion-cyflogaeth-genedlaethol-nest
         - title: Pensiynau gweithle
-          view_all: Gweld yr holl mewn pensiynau gweithle
+          view_all: Gewld y cyfan mewn pensiynau gweithle
           links:
             - text: Cofrestru awtomatig – cyflwyniad
               url: /cy/articles/cofrestriad-awtomatig-ar-bensiwn-man-gwaith
@@ -113,7 +113,7 @@ cy:
             - text: Cofrestru awtomatig os ydych chi dros oedran Pensiwn y Wladwriaeth
               url: /cy/articles/cofrestru-awtomatig-os-ydych-chi-dros-oedran-pensiwn-y-wladwriaeth
         - title: Cynilo ar gyfer ymddeoliad
-          view_all: Gweld yr holl mewn cynilo ar gyfer ymddeoliad
+          view_all: Gewld y cyfan mewn cynilo ar gyfer ymddeoliad
           links:
             - text: 'Canllaw pensiwn: ffeithiau allweddol a mathau o gynlluniau pensiwn'
               url: /cy/articles/canllaw-pensiwn-ffeithiau-allweddol-a-mathau-o-gynlluniau-pensiwn
@@ -145,7 +145,7 @@ cy:
               url: /cy/articles/eich-opsiynau-os-bydd-pethaun-mynd-o-le-gydach-pensiwn
       panels2:
         - title: Rheoli arian
-          view_all: Gweld yr holl mewn rheoli arian
+          view_all: Gewld y cyfan mewn rheoli arian
           links:
             - text: Pa bryd alla i fforddio i ymddeol?
               url: /cy/articles/pa-bryd-alla-i-fforddio-i-ymddeol
@@ -164,7 +164,7 @@ cy:
             - text: Gofalu am eich disgynyddion wedi ymddeol
               url: /cy/articles/looking-after-your-dependants-in-retirement
         - title: Dewisiadau incwm ymddeol
-          view_all: Gweld yr holl mewn dewisiadau incwm ymddeol
+          view_all: Gewld y cyfan mewn dewisiadau incwm ymddeol
           links:
             - text: Yr opsiynau ar gyfer defnyddio’ch cronfa bensiwn
               url: /cy/articles/yr-opsiynau-ar-gyfer-defnyddioch-cronfa-bensiwn
@@ -228,7 +228,7 @@ cy:
             - text: Canllaw i ffioedd cynghorwyr ariannol
               url: /cy/articles/canllaw-i-ffioedd-cynghorwyr-ariannol
         - title: Cymorth yn y blynyddoedd hŷn
-          view_all: Gweld yr holl mewn cymorth yn y blynyddoedd hŷn
+          view_all: Gewld y cyfan mewn cymorth yn y blynyddoedd hŷn
           links:
             - text: Ymddeol dramor
               url: /cy/articles/retiring-abroad

--- a/config/locales/retirements.en.yml
+++ b/config/locales/retirements.en.yml
@@ -65,9 +65,9 @@ en:
         text: Book your free Pension Wise guidance session
         url: https://www.pensionwise.gov.uk
     section4:
-      view_all: View all…
       panels1:
         - title: Types of pension
+          view_all: View all in types of pension
           links:
             - text: Defined contribution pension schemes
               url: /en/articles/defined-contribution-pension-schemes
@@ -90,6 +90,7 @@ en:
             - text: NEST pensions
               url: /en/articles/nest-pensions
         - title: Workplace pensions
+          view_all: View all in workplace pensions
           links:
             - text: Automatic enrolment - an introduction
               url: /en/articles/automatic-enrolment-into-a-workplace-pension
@@ -112,6 +113,7 @@ en:
             - text: Automatic enrolment if you’re above the State Pension age
               url: /en/articles/automatic-enrolment-if-youre-above-state-pension-age
         - title: 'Saving for retirement'
+          view_all: View all in saving for retirement
           links:
             - text: 'Pension information: guide to the basic facts'
               url: /en/articles/pension-information-guide-to-the-basic-facts
@@ -143,6 +145,7 @@ en:
               url: /en/articles/your-options-if-things-go-wrong-with-your-pension
       panels2:
         - title: Managing money
+          view_all: View all in managing money
           links:
             - text: When can I afford to retire?
               url: /en/articles/when-can-i-afford-to-retire
@@ -161,6 +164,7 @@ en:
             - text: Looking after your dependents in retirement
               url: /en/articles/looking-after-your-dependants-in-retirement
         - title: Retirement income choices
+          view_all: View all in retirement income choices
           links:
             - text: Options for using your pension pot
               url: /en/articles/options-for-using-your-pension-pot
@@ -224,6 +228,7 @@ en:
             - text: Guide to financial fees
               url: /en/articles/guide-to-financial-adviser-fees
         - title: Help in later life
+          view_all: View all in help later in life
           links:
             - text: Retiring abroad
               url: /en/articles/retiring-abroad


### PR DESCRIPTION
## Properly label the 'view all' link on the Pensions & Retirement Landing page

**Description of issue**
```
The Pensions and Retirements landing page has subcategories lists, listing the top 5 articles in each, featuring a 'view all' link. 

DAC reports that this 'view all' link does not have enough context for screen-reader users to understand what this link relates to.
 
This can be easily solved by renaming the 'view all' link to 'view all in x' (where x is the name of the subcategory).
```

**Solution**

Adding the 'View all...' text to the YAML files for Welsh and English for each category.

**Screenshots**

| English |
|--------|
|![image](https://cloud.githubusercontent.com/assets/13165846/18269730/440a026e-7421-11e6-82cb-95c5a0a2bc1f.png)|

| Welsh |
|-------|
|![image](https://cloud.githubusercontent.com/assets/13165846/18269671/f5337332-7420-11e6-96d5-8f5d49f79846.png)|

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1522)
<!-- Reviewable:end -->
