### PR TITLE
[DEV APPROVED] TP: 7603, Comment: Updates version number for Savings Calculator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,7 @@ gem 'payday_loans_intervention', '~> 1.4'
 gem 'pensions_calculator', '~> 1.2.0'
 gem 'quiz', '~> 1.1.0'
 gem 'rio', '1.6.0', source: 'http://gems.dev.mas.local'
-gem 'savings_calculator', '~> 1.4.0'
+gem 'savings_calculator', '~> 1.5.0'
 gem 'timelines', '~> 1.3.0'
 
 # 1.0.2 has breaking changes as it adds japanese and turkish locales

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -608,7 +608,7 @@ GEM
       sass (~> 3.2.2)
       sprockets (~> 2.8, < 3.0)
       sprockets-rails (~> 2.0)
-    savings_calculator (1.4.0.140)
+    savings_calculator (1.5.0.142)
       autoprefixer-rails
       dough-ruby (~> 5.0)
       jquery-rails
@@ -778,7 +778,7 @@ DEPENDENCIES
   rubocop
   rubytree
   sass-rails (~> 4.0.0)
-  savings_calculator (~> 1.4.0)
+  savings_calculator (~> 1.5.0)
   sdoc
   shoulda-matchers
   site_prism


### PR DESCRIPTION
Increments the version number for the Savings Calculator.
Required by the following PRs:

- PR26 (https://github.com/moneyadviceservice/savings_calculator/pull/26)
- PR27 (https://github.com/moneyadviceservice/savings_calculator/pull/27)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1529)
<!-- Reviewable:end -->
