### PR TITLE
[DEV APPROVED] 7610 - BUG: Fix Re-circulation drivers appearing over the main content (Galaxy Tab2)

### DIFF
--- a/app/assets/javascripts/components/StickyColumn.js
+++ b/app/assets/javascripts/components/StickyColumn.js
@@ -105,6 +105,7 @@ define(['jquery', 'DoughBaseComponent', 'eventsWithPromises'], function($, Dough
   StickyColumn.prototype._showInSidebar = function() {
     this.$parent.css('height', this.contentHeight - this.topMargin);
     this.$el.css('width', this.$parent.width());
+    this.$el.css('left', this.$parent.offset().left);
   };
 
   /**


### PR DESCRIPTION
## The Problem

Issue is being reported by a customer, in which re-circulation drivers appear on top of main content (article pages), making it impossible to read the main content unless the page is expanded/ zoomed-in. The issue appears when user is scrolling down the page.
 
The problem seems to be at Samsung Galaxy Tab 2  10.1 , Samsung Note 10.1 (both running android 4)  as replicated through BrowserStack. (See Screenshots) 

![problem](https://cloud.githubusercontent.com/assets/13165846/18546718/56d62694-7b37-11e6-97a6-8c17c871376f.png)

## Solution

After messing around with CSS positioning for a day I decided to use javascript and calculate the left offset of the parent container and then applying this value as the left: attribute of the sticky recirculation section.  This fixes the problem on the older Samsung Tablets and also provides slightly more stability across all browsers.

## Tests

### Samsung Tablets

| Samsung Galaxy Tab 2 10.1 | Samsung Galaxy Note 10.1 |
|----------------------------|----------------------------|
|<img width="648" alt="galaxy tab 2 10 1" src="https://cloud.githubusercontent.com/assets/13165846/18546814/e75522d8-7b37-11e6-9370-f7a0b541eaaa.png">|<img width="664" alt="galaxy note 10 1" src="https://cloud.githubusercontent.com/assets/13165846/18546821/ee96dff0-7b37-11e6-9486-98ebdc6bf533.png">|

### iPad:

| iPad 2 | iPad 4 |
|-------|--------|
|<img width="530" alt="ipad 2" src="https://cloud.githubusercontent.com/assets/13165846/18546913/8c5482ce-7b38-11e6-911a-475a424e3ca5.png">|<img width="566" alt="ipad 4" src="https://cloud.githubusercontent.com/assets/13165846/18546914/91346bec-7b38-11e6-823a-2054806c7af2.png">|

### Internet Explorer:

| IE9 | IE11 | IE EDGE |
|----|-----|---------|
|![ie9](https://cloud.githubusercontent.com/assets/13165846/18546942/b097463a-7b38-11e6-94db-630dfd461c73.png)|![ie11](https://cloud.githubusercontent.com/assets/13165846/18546947/b4c7916a-7b38-11e6-8e2e-e0ef803de8bd.png)|![ie edge](https://cloud.githubusercontent.com/assets/13165846/18546955/b9ee3fb8-7b38-11e6-8611-14b16b543cfb.png)|

### Good Browsers:

| Chrome | Firefox | Safari |
|---------|--------|-------|
|<img width="877" alt="chrome" src="https://cloud.githubusercontent.com/assets/13165846/18546988/f264af62-7b38-11e6-8eee-0ca35b14548b.png">|<img width="892" alt="firefox" src="https://cloud.githubusercontent.com/assets/13165846/18546995/fbaad6f0-7b38-11e6-884b-c4351330d44b.png">|<img width="881" alt="screen shot 2016-09-15 at 11 39 45" src="https://cloud.githubusercontent.com/assets/13165846/18547023/25166234-7b39-11e6-8c83-8a881f303740.png">|

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1532)
<!-- Reviewable:end -->
