### PR TITLE
7510 - Adding path=/ to the Informizely cookie code

### DIFF
--- a/app/assets/javascripts/modules/informizely_tag.js
+++ b/app/assets/javascripts/modules/informizely_tag.js
@@ -20,12 +20,12 @@ define(['globals'], function(globals) {
       var date = new Date();
       date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
       var expires = '; expires=' + date.toUTCString();
-      document.cookie = 'izHideSurvey=true;' + expires;
-      document.cookie = 'izCount=0; expires=Thu, 01 Jan 1970 00:00:00 GMT';
+      document.cookie = 'izHideSurvey=true;' + expires + '; path=/';
+      document.cookie = 'izCount=0; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
     },
     incrementCountCookie: function() {
       var count = this.getCountCookie() + 1;
-      document.cookie = 'izCount=' + count + ';';
+      document.cookie = 'izCount=' + count + '; path=/';
     },
     getCountCookie: function() {
       var timesShown = this.getCookie('izCount');


### PR DESCRIPTION
The cookies that the Informizely tag code sets need to have 'path = /' otherwise duplicates are getting set across different pages on the site when the code is ran from different locations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1534)
<!-- Reviewable:end -->
