### PR TITLE
[DEV APPROVED] 7510 - Correcting a JS error in informizely_tag

### DIFF
--- a/app/assets/javascripts/modules/informizely_tag.js
+++ b/app/assets/javascripts/modules/informizely_tag.js
@@ -20,7 +20,7 @@ define(['globals'], function(globals) {
       var date = new Date();
       date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
       var expires = '; expires=' + date.toUTCString();
-      document.cookie = 'izHideSurvey=true;' + expires + '; path=/';
+      document.cookie = 'izHideSurvey=true' + expires + '; path=/';
       document.cookie = 'izCount=0; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
     },
     incrementCountCookie: function() {


### PR DESCRIPTION
The string concatenation in the informizely_tag.js was inserting a duplicate semicolon, which was preventing a cookie being set in some browsers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1536)
<!-- Reviewable:end -->
