### PR TITLE
[DEV APPROVED] 7619 - Adding translation for welsh

### DIFF
--- a/app/views/shared/_footer_secondary.html.erb
+++ b/app/views/shared/_footer_secondary.html.erb
@@ -21,7 +21,7 @@
           <form target="_blank" class="accessin" id="AccessIN_form" action="https://accessin.org/app/accessin/index.php/welcome/index_AccessIN" method="post">
               <input type="hidden" name="ai_url" id="AccessIN_url" value="unset">
               <input type="hidden" name="ai_dom" id="AccessIN_dom" value="unset">
-             <button type="submit" class="accessin__submit"><span class="icon icon--accessibility"></span>Report an accessibility problem</button>
+             <button type="submit" class="accessin__submit"><span class="icon icon--accessibility"></span><%= t('footer_secondary.title') %></button>
           </form>
 
           <% content_for(:javascripts) do %>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -254,7 +254,7 @@ cy:
       %209am-1pm%20%0ADydd%20Sul%20a%20Gwyliau%20Banc%3A%20ar%20gau
 
   footer_secondary:
-    title: Adrodd ar broblem hygyrchedd
+    title: Adroddwch broblem mynediad
     link_title: Defnyddiwch y botwm hwn i ddweud wrthym os oes gennych chi unrhyw faterion hygyrchedd i'w hadrodd am y wefan
     hidden_accessibility: Ffurflen adborth yn agor mewn ffenestr newydd
 


### PR DESCRIPTION
## 7619 - Add translation for AccessIn 'Report an Accessibility Problem' on Welsh site

Description from ticket:

```
When I go to the Welsh version of the MAS webiste at https://www.moneyadviceservice.org.uk/cy
I want to be able to read the AccessIn 'Report an Accessibility Problem' link in the bottome left footer in Welsh
So I can use my own language
```

The translation was already present in the Welsh YAML, however the English text was hardcoded into the footer_secondary partial, this has now been fixed.

### Screenshots

| English | Welsh |
|--------|--------|
|<img width="269" alt="english" src="https://cloud.githubusercontent.com/assets/13165846/18630436/893ab138-7e64-11e6-8a13-a96053fcbd67.png">|<img width="248" alt="screen shot 2016-09-19 at 12 28 33" src="https://cloud.githubusercontent.com/assets/13165846/18630448/9fd4576e-7e64-11e6-9f44-69ee25c9b6dc.png">|

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1537)
<!-- Reviewable:end -->
