### PR TITLE
[DEV APPROVED] 7615: Link underlining tweaks - 7639: Add underline to blue-box text links

### DIFF
--- a/app/assets/stylesheets/components/cms/_add-action.scss
+++ b/app/assets/stylesheets/components/cms/_add-action.scss
@@ -20,10 +20,11 @@
 
   a {
     border-bottom: 0;
+    text-decoration: underline;
 
     &:hover,
     &:focus {
-      text-decoration: underline;
+      text-decoration: none;
     }
   }
 }

--- a/app/assets/stylesheets/components/page_specific/_category_link_list.scss
+++ b/app/assets/stylesheets/components/page_specific/_category_link_list.scss
@@ -27,6 +27,10 @@
     // This is to override the highly specific .editorial list styling
     content: none !important;
   }
+
+  > .category-link-list__item__link {
+    text-decoration: none;
+  }
 }
 
 .category-link-list__item__link {
@@ -36,7 +40,6 @@
   &:focus,
   &:hover {
     border-bottom: 3px solid $color-true-black;
-    text-decoration: none;
   }
 
   &:focus,


### PR DESCRIPTION
## 7615: Link underlining tweaks

Since we have added underlines to improve link identification (for an accessibility requirement) there is a tweak we should make for a visual improvement.
 
There are now double underlines on in-page links - we should remove the black underline and keep the yellow border-bottom:

| Before |
|--------|
|<img width="536" alt="screen shot 2016-09-29 at 09 43 59" src="https://cloud.githubusercontent.com/assets/13165846/18947062/707e4eda-8629-11e6-95c9-07d29701543c.png">|

| After |
|------|
|<img width="505" alt="screen shot 2016-09-29 at 09 38 21" src="https://cloud.githubusercontent.com/assets/13165846/18946943/0239b25c-8629-11e6-9ca3-c62683daef76.png">|

## 7639: Add underline to blue-box text links

Text links on the core site are now underlined to make them stand out more. The links inside the div class "add-action", however, remain not-underlined.
 
To make them stand out, and bring them in-line with anchor text elsewhere in the site.
 
What needs to happen:
Update the link styling for links in the blue box <div class="add-action"> to underline the anchor text.

| Before |
|--------|
|<img width="593" alt="screen shot 2016-09-29 at 09 44 08" src="https://cloud.githubusercontent.com/assets/13165846/18947136/bd410f82-8629-11e6-8c2d-b4523a59b02c.png">|

| After |
|------|
|<img width="593" alt="screen shot 2016-09-29 at 09 24 03" src="https://cloud.githubusercontent.com/assets/13165846/18946948/05e087c8-8629-11e6-8cc8-f740a524b5a8.png">|

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1546)
<!-- Reviewable:end -->
