### PR TITLE
[DEV APPROVED] Add seed_dump to facilitate pulling out cost calculator data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem 'psych', '>= 2.0.5' # https://www.ruby-lang.org/en/news/2014/03/29/heap-over
 gem 'redcarpet'
 gem 'rouge'
 gem 'rubytree'
+gem 'seed_dump'
 gem 'statsd-ruby'
 gem 'uglifier', '>= 1.3.0'
 gem 'postcode_anywhere-email_validation'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -617,6 +617,9 @@ GEM
     sdoc (0.4.0)
       json (~> 1.8)
       rdoc (~> 4.0, < 5.0)
+    seed_dump (3.2.4)
+      activerecord (>= 4)
+      activesupport (>= 4)
     sexp_processor (4.7.0)
     shoulda-matchers (2.6.2)
       activesupport (>= 3.0.0)
@@ -778,6 +781,7 @@ DEPENDENCIES
   sass-rails (~> 4.0.0)
   savings_calculator (~> 1.6.0)
   sdoc
+  seed_dump
   shoulda-matchers
   site_prism
   sqlite3


### PR DESCRIPTION
Seed_dump is a gem that allows you to pull out specific data from an existing rails database and formats it into a seed file to populate a rails app via a rake command.  Once we've pulled out all of the cost calculator data we'll remove the gem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1548)
<!-- Reviewable:end -->
