### PR TITLE
[DEV APPROVED] 7657 - Adding page title to pensions timeline

### DIFF
--- a/app/views/retirements/pension_savings_timeline.html.erb
+++ b/app/views/retirements/pension_savings_timeline.html.erb
@@ -1,3 +1,5 @@
+<% set_meta_tags(title: t('pension_savings_timeline.page_title')) %>
+
 <%= render 'retirements/pension_savings/intro_section' %>
 <%= render 'retirements/pension_savings/starting_out_section' %>
 <%= render 'retirements/pension_savings/throughout_working_life_section' %>

--- a/config/locales/landing_pages/pension_savings_timeline.cy.yml
+++ b/config/locales/landing_pages/pension_savings_timeline.cy.yml
@@ -1,5 +1,6 @@
 cy:
   pension_savings_timeline:
+    page_title: Llinell amser cynilion pensiwn
     intro_section:
       title: Llinell amser cynilion pensiwn
       text: Pa un a ydych chi yn dechrau ar eich swydd gyntaf, hanner ffordd trwy'ch bywyd gwaith, yn agosáu at ymddeol neu wedi ymddeol, bydd y llinell amser hon yn eich helpu chi i ddeall buddion cynilo pensiwn hirdymor ac ymroi i reoli'ch arian i sicrhau bod gennych ddigon o arian i fyw arno am oes.

--- a/config/locales/landing_pages/pension_savings_timeline.en.yml
+++ b/config/locales/landing_pages/pension_savings_timeline.en.yml
@@ -1,5 +1,6 @@
 en:
   pension_savings_timeline:
+    page_title: Pensions Savings Timeline
     intro_section:
       title: Pension savings timeline
       text: Whether you're just starting your first job, mid-way through your working life, approaching retirement or retired, this timeline will help you understand the benefits of long-term pension saving and of actively managing your money to ensure you have enough to live on for life.


### PR DESCRIPTION
## 7657 - Adding page title to pensions timeline

Adds English and Welsh page titles to the Pensions Timeline

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1551)
<!-- Reviewable:end -->
