### PR TITLE
[DEV APPROVED] 7666 - Search form visual display bug fix

### DIFF
--- a/app/assets/stylesheets/components/common/_search.scss
+++ b/app/assets/stylesheets/components/common/_search.scss
@@ -46,6 +46,10 @@
   }
 }
 
+.search--inpage {
+  min-height: $baseline-unit*9;
+}
+
 .search__submit {
   @extend .unstyled-button;
   position: absolute;
@@ -112,6 +116,7 @@
   position: relative;
   width: 100%;
   margin-top: $baseline-unit;
+  background-color: $color-button-primary;
 
   @include respond-to($mq-s) {
     @include column(3);

--- a/app/views/shared/_search.html.erb
+++ b/app/views/shared/_search.html.erb
@@ -1,4 +1,4 @@
-<form data-dough-component="ClearInput" action="<% if hide_elements_irrelevant_for_third_parties? %>https://www.moneyadviceservice.org.uk<% end %><%= main_app.search_results_path %>" method="get" role="search" class="search">
+<form data-dough-component="ClearInput" action="<% if hide_elements_irrelevant_for_third_parties? %>https://www.moneyadviceservice.org.uk<% end %><%= main_app.search_results_path %>" method="get" role="search" class="search <%= 'search--inpage' unless search_in_page_header %>" >
   <label class="visually-hidden" for="search"><%= t('search_box.label') %></label>
   
   <% if search_in_page_header %>


### PR DESCRIPTION
## The problem

There is a current display issue on the production site, where after performing a search on the search page (https://www.moneyadviceservice.org.uk/en/search) for a brief moment the results will be tucked underneath the search input and button section.

<img width="675" alt="screen shot 2016-10-07 at 09 29 15" src="https://cloud.githubusercontent.com/assets/13165846/19184129/92d54dee-8c73-11e6-85a1-191f30db6592.png">

## The solution

The search form now has a minumum height to ensure that the results begin after the search form element, ``@extend %clearfix;`` was unsuccessful as the typeahead component relies on absolute positioning which rendered the clearfix unable to help in this case.  There is also a conditional which adds a modifier class to the in page search form as this only applies to the form on that page, not the one in the header.

<img width="690" alt="screen shot 2016-10-07 at 09 53 45" src="https://cloud.githubusercontent.com/assets/13165846/19184209/fa9c4ca2-8c73-11e6-9e78-265d2aa5fef4.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1552)
<!-- Reviewable:end -->
