### PR TITLE
[DEV APPROVED] #7675 update tidy-html5 gem source to fix failing cucumber tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,7 +97,7 @@ group :test do
   gem 'shoulda-matchers'
   gem 'site_prism'
   gem 'sqlite3'
-  gem 'tidy-html5', github: 'moneyadviceservice/tidy-html5-gem'
+  gem 'tidy-html5'
   gem 'timecop'
   gem 'vcr'
   gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,12 +6,6 @@ GIT
       actionpack (>= 3.0.0)
 
 GIT
-  remote: git://github.com/moneyadviceservice/tidy-html5-gem.git
-  revision: 54b78c66e94b32ab73d9907508857f4ceee5e032
-  specs:
-    tidy-html5 (0.1.1)
-
-GIT
   remote: git@github.com:moneyadviceservice/mas-assets
   revision: 2e3ec1c60637f1ab30df999ace0d2795ebd4e216
   specs:
@@ -647,6 +641,7 @@ GEM
     syslog-logger (1.6.8)
     thor (0.19.1)
     thread_safe (0.3.5)
+    tidy-html5 (0.1.1)
     tilt (1.4.1)
     timecop (0.8.1)
     timelines (1.3.0.304)
@@ -779,7 +774,7 @@ DEPENDENCIES
   sqlite3
   statsd-ruby
   syslog-logger
-  tidy-html5!
+  tidy-html5
   timecop
   timelines (~> 1.3.0)
   uglifier
@@ -789,4 +784,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.13.1
+   1.13.2


### PR DESCRIPTION
update gem source in Gemfile for tidy-html5 gem to fix failing cucumber tests 

![screen shot 2016-10-10 at 10 34 22](https://cloud.githubusercontent.com/assets/10046127/19232009/3be31b4c-8ed5-11e6-8b06-1935c3a1359c.png)

error caused by versions being used of bundle, git, cucumber

running cucumber using bundle exec forces cucumber to run using gems listed in Gemfile, 

The Tidy-HTML5 gem source was pointing directly to GitHub repo, changing to pull gem from local gems on build server resolves the error.

Ideally we should update version of Git installed and used by both build servers (1.7.1) to > 1.7.11

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1555)
<!-- Reviewable:end -->
