### PR TITLE
[DEV APPROVED] 7671 Adding new window label to social links in footer

### DIFF
--- a/app/views/shared/_footer_primary.html.erb
+++ b/app/views/shared/_footer_primary.html.erb
@@ -11,7 +11,7 @@
                 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--facebook"></use>
               </svg>
               <span class="icon icon--facebook"></span>
-              <span class="visually-hidden">Facebook</span>
+              <span class="visually-hidden">Facebook - <%= t('footer.new-window-label') %></span>
             </a>
             <p class="social-sharing__counter">
               <span class="social-sharing__counter__total">72k</span>
@@ -28,7 +28,7 @@
                 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--twitter"></use>
               </svg>
               <span class="icon icon--twitter"></span>
-              <span class="visually-hidden">Twitter</span>
+              <span class="visually-hidden">Twitter - <%= t('footer.new-window-label') %></span>
             </a>
             <p class="social-sharing__counter">
               <span class="social-sharing__counter__total">42k</span>
@@ -45,7 +45,7 @@
                 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--youtube"></use>
               </svg>
               <span class="icon icon--youtube"></span>
-              <span class="visually-hidden">YouTube</span>
+              <span class="visually-hidden">Youtube - <%= t('footer.new-window-label') %></span>
             </a>
             <p class="social-sharing__counter">
               <span class="social-sharing__counter__total">5.5m</span>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -293,6 +293,7 @@ cy:
         Drwy barhau i ddefnyddio ein gwefan rydych yn cytuno â'r defnydd a wneir ohoni.
         <a class="cookie-message__link" href="%{url}">Canfyddwch fwy am cwcis.</a>
       close_button: Cau
+    new-window-label: Yn agor mewn ffenestr newydd
     facebook-likes: Wedi hoffi
     twitter-followers: Dilynwyr
     youtube-views: Gwelwyd

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -294,6 +294,7 @@ en:
         By continuing to use our website you are agreeing to their use.
         <a class="cookie-message__link" href="%{url}">Find out more about cookies.</a>
       close_button: Close cookie message
+    new-window-label: Opens in a new window
     facebook-likes: Likes
     twitter-followers: Followers
     youtube-views: Views


### PR DESCRIPTION
The social media buttons on the foot of the main site are SVGs, which, when clicked open the relevant social media page in a new window.

If users are not made aware that this will open in a new window then they will become disoriented and unable to use the browser's back button to get back to their page.
 
This has been solved in this PR for some readers by adding 
 
<span class="visually-hidden">Facebook - opens in a new window</span>
 to each of the social media links.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1556)
<!-- Reviewable:end -->
