### PR TITLE
[DEV APPROVED] 7672 - Adding PDF download icon

### DIFF
--- a/app/assets/stylesheets/components/common/_download_link.scss
+++ b/app/assets/stylesheets/components/common/_download_link.scss
@@ -1,0 +1,11 @@
+// For links that contain download attribute
+
+.download-link--pdf {
+  &:after {
+    @extend %icon;
+    @extend .icon--pdf;
+    content: '';
+    margin-left: 6px;
+    display: inline-block;
+  }
+}

--- a/config/locales/retirements.cy.yml
+++ b/config/locales/retirements.cy.yml
@@ -14,7 +14,7 @@ cy:
         - Dysgwch am eich dewisiadau ar gyfer ymddeol
         - Ceisiwch help gyda materion blynyddoedd hŷn
         - Darganfyddwch pa gymorth a chyngor sydd ar gael
-      video_caption_html: 'Y newyddiadurwr ariannol Paul Lewis yn esbonio sut i wneud y gorau o gynllunio ar gyfer ymddeol <a href="https://masjumpprdstorage.blob.core.windows.net/video-transcripts/retirement-video-transcript.cy.pdf">(lawrlwythwch y trawsgrifiad)</a>'
+      video_caption_html: 'Y newyddiadurwr ariannol Paul Lewis yn esbonio sut i wneud y gorau o gynllunio ar gyfer ymddeol <a href="https://masjumpprdstorage.blob.core.windows.net/video-transcripts/retirement-video-transcript.cy.pdf" class="download-link--pdf" download="retirement-video-transcript">Lawrlwythwch sgript y fideo</a>'
     section2:
       - text: Llinell amser cynilion pensiwn
         url: /cy/pensions-and-retirement/pension-savings-timeline
@@ -264,7 +264,7 @@ cy:
       canonical: 'https://www.moneyadviceservice.org.uk/cy/pensions-and-retirement/budgeting'
     section1:
       title: Cynllunio cyllideb ar gyfer ymddeoliad
-      video_caption_html: "Gwyliwch y fideo byr hwn o’r newyddiadurwr ariannol Paul Lewis yn egluro sut i gyllidebu mewn ymddeoliad. <a href=\"https://masjumpprdstorage.blob.core.windows.net/video-transcripts/budgeting_landing_page_transcript.cy.pdf\">Lawrlwythwch sgript y fideo</a>"
+      video_caption_html: "Gwyliwch y fideo byr hwn o’r newyddiadurwr ariannol Paul Lewis yn egluro sut i gyllidebu mewn ymddeoliad. <a href=\"https://masjumpprdstorage.blob.core.windows.net/video-transcripts/budgeting_landing_page_transcript.cy.pdf\" class=\"download-link--pdf\" download=\"budgeting_landing_page_transcript\">Lawrlwythwch sgript y fideo</a>"
       intro: Os hoffech chi wybod faint o arian fydd gennych chi pan fyddwch chi’n ymddeol, mae creu cyllideb yn ffordd dda iawn o ddechrau.
       bullets:
         - Deallwch pam mae cyllidebu mewn ymddeoliad yn ddefnyddiol

--- a/config/locales/retirements.en.yml
+++ b/config/locales/retirements.en.yml
@@ -14,7 +14,7 @@ en:
         - Learn about your choices for retirement
         - Get help with later life matters
         - Find out what support and advice is available
-      video_caption_html: Financial journalist Paul Lewis explains how to make the most of planning for retirement <a href="https://masjumpprdstorage.blob.core.windows.net/video-transcripts/retirement-video-transcript.en.pdf">(download the transcript)</a>
+      video_caption_html: Financial journalist Paul Lewis explains how to make the most of planning for retirement <a href="https://masjumpprdstorage.blob.core.windows.net/video-transcripts/retirement-video-transcript.en.pdf" class="download-link--pdf" download="retirement-video-transcript">Download the video transcript</a>
     section2:
       - text: Pension savings timeline
         url: /en/pensions-and-retirement/pension-savings-timeline
@@ -264,7 +264,7 @@ en:
       canonical: https://www.moneyadviceservice.org.uk/en/pensions-and-retirement/budgeting'
     section1:
       title: Retirement budget planning
-      video_caption_html: "Watch this short video of financial journalist Paul Lewis explaining budgeting in retirement. <a href=\"https://masjumpprdstorage.blob.core.windows.net/video-transcripts/budgeting_landing_page_transcript.en.pdf\">Download the video transcript</a>"
+      video_caption_html: "Watch this short video of financial journalist Paul Lewis explaining budgeting in retirement. <a href=\"https://masjumpprdstorage.blob.core.windows.net/video-transcripts/budgeting_landing_page_transcript.en.pdf\" class=\"download-link--pdf\" download=\"budgeting_landing_page_transcript\">Download the video transcript</a>"
       intro: If you want to know how much money you’ll have when you retire, creating a budget is a really good way to start.
       bullets:
         - Understand why budgeting in retirement is useful


### PR DESCRIPTION
The video transcript on this Retirement page is a PDF download, that opens in the browser window. This causes problems for many users, who are subsequently unable to navigate back to the page, and are given no warning that this will happen. 

This changes the functionality to download the file and adds a PDF icon to any link with a download attribute.

| English | Welsh |
|---------|-------|
|<img width="587" alt="screen shot 2016-10-13 at 14 11 35" src="https://cloud.githubusercontent.com/assets/13165846/19350358/4f53560c-914f-11e6-9aca-e0d214419f3a.png">|<img width="585" alt="screen shot 2016-10-13 at 14 11 40" src="https://cloud.githubusercontent.com/assets/13165846/19350362/54d0653e-914f-11e6-98ef-a5b885c9024e.png">|

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1561)
<!-- Reviewable:end -->
