### PR TITLE
[DEV APPROVED] 7673 - Adding focusable false to SVGs

### DIFF
--- a/app/views/shared/_footer_primary.html.erb
+++ b/app/views/shared/_footer_primary.html.erb
@@ -6,7 +6,7 @@
         <li class="l-footer-primary__list--left">
           <div class="footer-primary__list-item">
             <a class="button facebook-link t-facebook-link" lang="en" href="https://www.facebook.com/MoneyAdviceService?ref=mas" target="_blank">
-              <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--facebook" aria-labelledby="facebook-label">
+              <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--facebook" aria-labelledby="facebook-label" focusable="false">
                 <title id="facebook-label">Money Advice Service Facebook page</title>
                 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--facebook"></use>
               </svg>
@@ -23,7 +23,7 @@
         <li class="l-footer-primary__list--centre">
           <div class="footer-primary__list-item">
             <a class="button twitter-link t-twitter-link" lang="en" href="https://twitter.com/YourMoneyAdvice" target="_blank">
-              <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--twitter" aria-labelledby="twitter-label">
+              <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--twitter" aria-labelledby="twitter-label" focusable="false">
                 <title id="twitter-label">Money Advice Service Twitter page</title>
                 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--twitter"></use>
               </svg>
@@ -40,7 +40,7 @@
         <li class="l-footer-primary__list--right">
           <div class="footer-primary__list-item">
             <a class="button youtube-link t-youtube-link" lang="en" href="https://www.youtube.com/user/MoneyAdviceService" target="_blank">
-              <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--youtube" aria-labelledby="youtube-label">
+              <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--youtube" aria-labelledby="youtube-label" focusable="false">
                 <title id="youtube-label">Money Advice Service Youtube channel</title>
                 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--youtube"></use>
               </svg>

--- a/app/views/shared/_stripe_banner.html.erb
+++ b/app/views/shared/_stripe_banner.html.erb
@@ -4,7 +4,7 @@
       <span class="stripe-banner__content">
         <%= markdown item.promo_banner_content %>
       </span>
-      <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--stripe-banner-arrow">
+      <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--stripe-banner-arrow" focusable="false">
         <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--stripe-banner-arrow"></use>
       </svg>
       <span class="icon icon--stripe-banner-arrow"></span>

--- a/app/views/shared/svg/_use_icon.html.erb
+++ b/app/views/shared/svg/_use_icon.html.erb
@@ -27,7 +27,7 @@
 <% if svg_fallback_support %>
 <span class="<%= no_svg_icon_class %>">
 <% end %>
-<svg xmlns="http://www.w3.org/2000/svg" class="<%= svg_icon_class %>" <%= accessibility_title %>>
+<svg xmlns="http://www.w3.org/2000/svg" class="<%= svg_icon_class %>" focusable="false" <%= accessibility_title %>>
   <use xlink:href="#svg-icon--<%= local_assigns[:icon] %>"></use>
 </svg>
 <% if accessibility_description.length > 0 %>


### PR DESCRIPTION
## 7673 - Adding focusable false to SVGs

This PR removes SVG's from the tab order, ``tabindex="-1"`` was mentioned in the ticket for this task but had no effect in IE11, ``focusable="false"`` worked in all cases.

**Related PR's**

Publify
https://github.com/moneyadviceservice/publify/pull/214

Dough
https://github.com/moneyadviceservice/dough/pull/276

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1566)
<!-- Reviewable:end -->
