### PR TITLE
[DEV APPROVED] 7479 - Removing the fieldset element around signup checkbox

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -114,14 +114,12 @@
 
     <div class="registration__row">
       <div class="registration__field">
-        <fieldset class="form__group">
-          <div class="form__group-item">
-            <%= f.label :opt_in_for_research, class: "form__label-heading" do %>
-              <%= f.check_box :opt_in_for_research, class: "form__group-input" %>
-              <%= t("activerecord.attributes.user.opt_in_for_research") %>
-            <% end %>
-          </div>
-        </fieldset>
+        <div class="form__group-item">
+          <%= f.label :opt_in_for_research, class: "form__label-heading" do %>
+            <%= f.check_box :opt_in_for_research, class: "form__group-input" %>
+            <%= t("activerecord.attributes.user.opt_in_for_research") %>
+          <% end %>
+        </div>
       </div>
     </div>
 


### PR DESCRIPTION
A `<fieldset>` element should always contain a `<legend>` element to explain the purpose of he group of fields.

In this case, we no longer need the `<fieldset>` element, as there is only one field within the group, which is adequately explained in the field's label.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1579)
<!-- Reviewable:end -->
