### PR TITLE
[DEV APPROVED] Removing obsolete SCSS that generates warnings

### DIFF
--- a/app/assets/stylesheets/components/common/_directory.scss
+++ b/app/assets/stylesheets/components/common/_directory.scss
@@ -3,7 +3,7 @@
 // Styleguide Directory
 
 .directory {
-  @extend .clearfix;
+  @extend %clearfix;
   width:100%;
 
   @include respond-to($mq-m) {

--- a/app/assets/stylesheets/layout/page_specific/_category.scss
+++ b/app/assets/stylesheets/layout/page_specific/_category.scss
@@ -30,10 +30,6 @@
   }
 }
 
-.l-category__top__link-list-heading {
-  @extend %heading-smaller;
-}
-
 .l-category--image .l-category__top__content {
   width: 60%;
   

--- a/app/assets/stylesheets/layout/page_specific/_promos.scss
+++ b/app/assets/stylesheets/layout/page_specific/_promos.scss
@@ -1,5 +1,5 @@
 .l-tool-promos {
-  @extend .clearfix;
+  @extend %clearfix;
   overflow: hidden;
   position: relative;
   margin-top: $baseline-unit*6;
@@ -135,7 +135,7 @@
 }
 
 .l-promo-articles {
-  @extend .clearfix;
+  @extend %clearfix;
   overflow: hidden;
   position: relative;
   margin-top: $baseline-unit*6;
@@ -218,7 +218,7 @@
 
 .l-promo-corporate {
   @include row(12);
-  @extend .clearfix;
+  @extend %clearfix;
   overflow: hidden;
   position: relative;
   margin-top: $baseline-unit*3;
@@ -264,7 +264,7 @@
 // Promo partnerships
 
 .l-promo-partnerships {
-  @extend .clearfix;
+  @extend %clearfix;
   @include row(12);
   overflow: hidden;
   position: relative;


### PR DESCRIPTION
The Frontend project gives SCSS warnings every time it is started due to SCSS `@extends` that do not extend any selectors. This will error rather than warn in future versions of SASS.

So this PR removes the unnecessary code, and fixes the instances that pointed to an incorrect `clearfix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1580)
<!-- Reviewable:end -->
