### PR TITLE
[DEV APPROVED] 7717 - Fixing the 'skip-to' links within the profile area

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -1,4 +1,9 @@
 class FeedbackController < MountController
+
+  def display_skip_to_main_navigation?
+    false
+  end
+
   private
 
   def alternate_engine_id

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -13,6 +13,14 @@ class ProfileController < ArticlesController
     render :edit
   end
 
+  def display_skip_to_main_navigation?
+    false
+  end
+
+  def default_main_content_location?
+    true
+  end
+
   private
 
   def saved_tools


### PR DESCRIPTION
This PR relates to our 'skip-to' links - we have 'skip to main content' and 'skip to navigation':
![image](https://cloud.githubusercontent.com/assets/14920201/19804978/9a004a14-9d09-11e6-8c60-0752bb823e4e.png)

This PR:

- Removes 'skip to navigation' from the Profile and Feedback pages. These pages have no nav, so need no link
- Adds a 'main' ID to the main container in the Profile area. This fixes the 'skip to main content' link

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1581)
<!-- Reviewable:end -->
