### PR TITLE
Removed link saying "view online" from BP3 static pages

### DIFF
--- a/public/cy/budget-planner-hysbysu.html
+++ b/public/cy/budget-planner-hysbysu.html
@@ -393,15 +393,6 @@
               <tr>
                 <td align="center" valign="top" width="500">
           <![endif]-->
-          <table width="100%" border="0" cellspacing="0" cellpadding="0" align="center" style="-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%;mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse !important;max-width: 700px;" class="responsive-table">
-            <tr>
-              <td align="center" style="-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%;mso-table-lspace:0pt;mso-table-rspace:0pt;font-size: 12px; line-height: 18px; font-family: Helvetica, Arial, sans-serif; color:#666666;">
-                <a href="/cy/budget-planner-hysbysu.html" target="_blank" style="-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%;color: #ffffff; text-decoration: none;">
-                  Gweld e-bost hwn ar-lein</a><span style="font-family: Arial, sans-serif; font-size: 12px; color: #ffffff;">&nbsp;&nbsp;|&nbsp;&nbsp;</span><a href="/en/budget-planner-notification.html" target="_blank" style="-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%;color: #ffffff; text-decoration: none;">
-                  View this in English</a> <span style="font-family: Arial, sans-serif; font-size: 12px; color: #ffffff;">&nbsp;&nbsp;|&nbsp;&nbsp;</span> <a href="https://www.moneyadviceservice.org.uk/cy" target="_blank" style="-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%;color: #ffffff; text-decoration: none;">Gwasanaeth Cynghori Ariannol Ymweliad</a>
-              </td>
-            </tr>
-          </table>
           <!--[if (gte mso 9)|(IE)]>
           </td>
         </tr>

--- a/public/en/budget-planner-notification.html
+++ b/public/en/budget-planner-notification.html
@@ -394,13 +394,6 @@
               <tr>
                 <td align="center" valign="top" width="500">
           <![endif]-->
-          <table width="100%" border="0" cellspacing="0" cellpadding="0" align="center" style="-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%;mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse !important;max-width: 700px;" class="responsive-table">
-            <tr>
-              <td align="center" style="-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%;mso-table-lspace:0pt;mso-table-rspace:0pt;font-size: 12px; line-height: 18px; font-family: Helvetica, Arial, sans-serif; color:#666666;">
-                <a href="/en/budget-planner-notification.html" target="_blank" style="-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%;color: #ffffff; text-decoration: none;">View this email online</a><span style="font-family: Arial, sans-serif; font-size: 12px; color: #ffffff;">&nbsp;&nbsp;|&nbsp;&nbsp;</span><a href="/cy/budget-planner-hysbysu.html" target="_blank" style="-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%;color: #ffffff; text-decoration: none;">View this in Welsh</a> <span style="font-family: Arial, sans-serif; font-size: 12px; color: #ffffff;">&nbsp;&nbsp;|&nbsp;&nbsp;</span> <a href="https://www.moneyadviceservice.org.uk" target="_blank" style="-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%;color: #ffffff; text-decoration: none;">Visit Money Advice Service</a>
-              </td>
-            </tr>
-          </table>
           <!--[if (gte mso 9)|(IE)]>
           </td>
         </tr>


### PR DESCRIPTION
**Task**
Remove link saying view online on static pages for short from budget planner deprecation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1582)
<!-- Reviewable:end -->
