### PR TITLE
add turnout Gem to frontend to enable maintenace mode

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem 'rubytree'
 gem 'sass-rails'
 gem 'statsd-ruby'
 gem 'postcode_anywhere-email_validation'
+gem 'turnout'
 
 gem 'action_plans', '~> 4.3.0'
 gem 'advice_plans', '~> 3.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -492,6 +492,8 @@ GEM
       jquery-rails
       rails (>= 4, < 5)
     rack (1.6.4)
+    rack-accept (0.4.5)
+      rack (>= 0.4)
     rack-livereload (0.3.16)
       rack
     rack-test (0.6.3)
@@ -652,6 +654,11 @@ GEM
       rails (>= 4, < 5)
       sass-rails
     transitions (0.1.13)
+    turnout (2.4.0)
+      i18n (~> 0.7)
+      rack (>= 1.3, < 3)
+      rack-accept (~> 0.4)
+      tilt (>= 1.4, < 3)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (3.0.2)
@@ -777,6 +784,7 @@ DEPENDENCIES
   tidy-html5
   timecop
   timelines (~> 1.4.0)
+  turnout
   uglifier
   unicorn-rails
   validate_url (= 1.0.0)


### PR DESCRIPTION
enables setting maintenance mode serving a static holding page instead of nginx 500 error when database is unavailable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1586)
<!-- Reviewable:end -->
