### PR TITLE
use rails sanitize gem not html_escape

### DIFF
--- a/app/views/styleguide/_element.html.erb
+++ b/app/views/styleguide/_element.html.erb
@@ -1,4 +1,4 @@
 <div class="styleguide-element">
   <span class="styleguide-modifier-name"><%= element.name %></span>
-  <%= source.gsub('$modifier_class', element.class_name).html_safe %>
+  <%= sanitize source.gsub('$modifier_class', element.class_name) %>
 </div>


### PR DESCRIPTION
Cross-Site Scripting opens up our application for manipulation in ways we never intended them to be used. This vulnerability puts user data at risk. It also has the potential to ruin the experience of other users of the MAS website. 

See more about this card on [Target Process](https://moneyadviceservice.tpondemand.com/entity/7578)

## Previously
![screen shot 2016-11-08 at 10 18 36](https://cloud.githubusercontent.com/assets/591781/20095298/e29f554e-a59c-11e6-89f1-d78b0a419b4a.png)

## Currently
![screen shot 2016-11-08 at 10 19 13](https://cloud.githubusercontent.com/assets/591781/20095310/ec5f593a-a59c-11e6-8736-a965863a4b2a.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1591)
<!-- Reviewable:end -->
