### PR TITLE
7726 - adding a way to prevent the feedback panel being shown on certain pages

### DIFF
--- a/app/controllers/page_feedbacks_controller.rb
+++ b/app/controllers/page_feedbacks_controller.rb
@@ -1,4 +1,6 @@
 class PageFeedbacksController < ApplicationController
+  before_action :check_accepts_feedback
+
   def create
     page_feedback = Core::PageFeedbackCreator.new.call(page_feedback_params)
 
@@ -21,6 +23,12 @@ class PageFeedbacksController < ApplicationController
 
   private
 
+  def check_accepts_feedback
+    if !Core::Article.new(params[:article_id]).accepts_feedback?
+      render json: {}, status: 403
+    end
+  end
+
   def page_feedback_params
     params.permit(:liked, :shared_on, :comment, :article_id).merge(
       session_id: session.id,
@@ -28,4 +36,3 @@ class PageFeedbacksController < ApplicationController
     )
   end
 end
-

--- a/app/decorators/content_item_decorator.rb
+++ b/app/decorators/content_item_decorator.rb
@@ -3,7 +3,7 @@ require 'html_processor'
 class ContentItemDecorator < Draper::Decorator
   decorates_association :categories, with: CategoryDecorator
 
-  delegate :title, :type, :slug, :description, :id
+  delegate :title, :type, :slug, :description, :id, :accepts_feedback?
 
   def initialize(object, options = {})
     super

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -35,7 +35,7 @@
 
       <%= article.content %>
 
-      <% if Feature.active?(:page_feedback) %>
+      <% if article.accepts_feedback? && Feature.active?(:page_feedback) %>
         <%= render 'shared/on_page_feedback' %>
       <% end %>
 

--- a/lib/core/entity/article.rb
+++ b/lib/core/entity/article.rb
@@ -41,6 +41,16 @@ module Core
       false
     end
 
+    EXCLUDED_FROM_FEEDBACK = [
+      'baby-costs-calculator',
+      'cyfrifiannell-costau-babi',
+      'debt-management-companies'
+    ]
+
+    def accepts_feedback?
+      !EXCLUDED_FROM_FEEDBACK.include?(slug)
+    end
+
     private
 
     def build_article_links(key)


### PR DESCRIPTION
We only have a handful of pages that need this right now and it's not expected to change frequently, so went with simply hard coding a list of slugs into a constant.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1594)
<!-- Reviewable:end -->
