### PR TITLE
7725 - persist page feedback state in the client

### DIFF
--- a/app/assets/javascripts/components/OnPageFeedback.js
+++ b/app/assets/javascripts/components/OnPageFeedback.js
@@ -14,6 +14,8 @@ define(['jquery', 'featureDetect', 'DoughBaseComponent', 'common'], function($, 
     this.ajaxUrl = $el.attr('data-dough-on-page-feedback-post');
     this.likeCount = $el.find('[data-dough-feedback-like-count]');
     this.dislikeCount = $el.find('[data-dough-feedback-dislike-count]');
+    this.likeElement = $el.find('[data-dough-feedback-like-count]');
+    this.dislikeElement = $el.find('[data-dough-feedback-dislike-count]');
     this.pageId = window.location.pathname.match(/^.*\/([a-zA-Z0-9-_]+)$/)[1];
   };
 
@@ -73,9 +75,9 @@ define(['jquery', 'featureDetect', 'DoughBaseComponent', 'common'], function($, 
     total;
 
     if (interaction === 'like') {
-      el = this.likeCount;
+      el = this.likeElement;
     } else {
-      el = this.dislikeCount;
+      el = this.dislikeElement;
     };
 
     total = parseInt(el.text());
@@ -93,8 +95,8 @@ define(['jquery', 'featureDetect', 'DoughBaseComponent', 'common'], function($, 
   OnPageFeedback.prototype._updateCount = function(data) {
     var countResponse = data;
 
-    this.likeCount.text(countResponse.likes_count);
-    this.dislikeCount.text(countResponse.dislikes_count);
+    this.likeElement.text(countResponse.likes_count);
+    this.dislikeElement.text(countResponse.dislikes_count);
   };
 
   OnPageFeedback.prototype._showPage = function(pageName) {

--- a/app/assets/javascripts/components/OnPageFeedback.js
+++ b/app/assets/javascripts/components/OnPageFeedback.js
@@ -117,14 +117,18 @@ define(['jquery', 'featureDetect', 'DoughBaseComponent', 'common'], function($, 
     if (typeof(data) != 'undefined') {
       var json = JSON.parse(data)
 
-      this.likeElement.text(json.likes_count);
-      this.dislikeElement.text(json.dislikes_count);
-      this.currentState = json.last_state;
+      // Ignore stored data if more than 30 days old
+      if (json.time > (Date.now() - (30*24*60*60*1000))) {
+        this.likeElement.text(json.likes_count);
+        this.dislikeElement.text(json.dislikes_count);
+        this.currentState = json.last_state;
+      }
     }
   };
 
   OnPageFeedback.prototype._storeState = function() {
     var data = {
+      time: Date.now(),
       likes_count: this.likeElement.text(),
       dislikes_count: this.dislikeElement.text(),
       last_state: this.currentState

--- a/app/assets/javascripts/components/OnPageFeedback.js
+++ b/app/assets/javascripts/components/OnPageFeedback.js
@@ -1,4 +1,4 @@
-define(['jquery', 'DoughBaseComponent', 'common'], function($, DoughBaseComponent, MAS) {
+define(['jquery', 'featureDetect', 'DoughBaseComponent', 'common'], function($, FeatureDetect, DoughBaseComponent, MAS) {
   'use strict';
 
   var OnPageFeedback;
@@ -144,6 +144,8 @@ define(['jquery', 'DoughBaseComponent', 'common'], function($, DoughBaseComponen
   };
 
   OnPageFeedback.prototype.init = function(initialised) {
+    if (!FeatureDetect.localstorage) return
+
     this._bindHandlers();
     this._checkForStoredState();
     this._initialisedSuccess(initialised);


### PR DESCRIPTION
Originally intended to be done with a 30 day cookie, after chatting to @slaywell we decided to go with using localStorage. This is feature detected (and the feedback form will not appear at all if not found) but we are satisfied that support is ubiquitous.

localStorage is a simple key:value store, so we store the data as a serialized json object, with a key of `MAS.onPageFeedback.<article-slug>`.

One caveat: we only retrieve the number of likes and dislikes in the response after doing the actual like/dislike. Therefore, if we later on try to resume the process of asking to share or provide feedback, we don't have the figures to hand once that's complete to show them on the thumbs.

After discussing with Ed (who discussed with Mel), we decided to store the figures we get back after voting along with the other state, and display those.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1598)
<!-- Reviewable:end -->
