### PR TITLE
[DEV APPROVED] - Add CMS API authentication on page feedbacks endpoints

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,6 @@
 MAS_PUBLIC_WEBSITE_URL=https://www.moneyadviceservice.org.uk/:locale/
 MAS_CMS_URL=http://cms.qa.dev.mas.local
+MAS_CMS_API_TOKEN=mytoken
 MAS_CONTENT_SERVICE_URL=http://localhost:8080/content-service/
 GOOGLE_API_KEY=AIzaSyCydfZlpTZlIUUUSbtab5t0oOE-y1GzHy0
 GOOGLE_API_CX_EN=011931388747222259444:razn90vopwc

--- a/app/assets/javascripts/components/OnPageFeedback.js
+++ b/app/assets/javascripts/components/OnPageFeedback.js
@@ -12,8 +12,6 @@ define(['jquery', 'featureDetect', 'DoughBaseComponent', 'common'], function($, 
     this.submitBtn = $el.find('[data-dough-feedback-submit]');
     this.submitForm = $el.find('[data-dough-feedback-form]');
     this.ajaxUrl = $el.attr('data-dough-on-page-feedback-post');
-    this.likeCount = $el.find('[data-dough-feedback-like-count]');
-    this.dislikeCount = $el.find('[data-dough-feedback-dislike-count]');
     this.likeElement = $el.find('[data-dough-feedback-like-count]');
     this.dislikeElement = $el.find('[data-dough-feedback-dislike-count]');
     this.pageId = this._getPageId();
@@ -97,12 +95,12 @@ define(['jquery', 'featureDetect', 'DoughBaseComponent', 'common'], function($, 
     }.bind(this), 600);
   };
 
-
   OnPageFeedback.prototype._updateCount = function(data) {
-    var countResponse = data;
+    this.likesCount = data.likes_count;
+    this.dislikesCount = data.dislikes_count;
 
-    this.likeElement.text(countResponse.likes_count);
-    this.dislikeElement.text(countResponse.dislikes_count);
+    this.likeElement.text(this.likesCount);
+    this.dislikeElement.text(this.dislikesCount);
   };
 
   OnPageFeedback.prototype._showPage = function(pageName) {
@@ -119,8 +117,7 @@ define(['jquery', 'featureDetect', 'DoughBaseComponent', 'common'], function($, 
 
       // Ignore stored data if more than 30 days old
       if (json.time > (Date.now() - (30*24*60*60*1000))) {
-        this.likeElement.text(json.likes_count);
-        this.dislikeElement.text(json.dislikes_count);
+        this._updateCount(json);
         this.currentPage = json.current_page;
       }
     }
@@ -129,8 +126,8 @@ define(['jquery', 'featureDetect', 'DoughBaseComponent', 'common'], function($, 
   OnPageFeedback.prototype._storeState = function() {
     var data = {
       time: Date.now(),
-      likes_count: this.likeElement.text(),
-      dislikes_count: this.dislikeElement.text(),
+      likes_count: this.likesCount,
+      dislikes_count: this.dislikesCount,
       current_page: this.currentPage
     }
 

--- a/app/views/shared/_on_page_feedback.html.erb
+++ b/app/views/shared/_on_page_feedback.html.erb
@@ -27,10 +27,11 @@
       <div class="form__row">
         <textarea id="on-page-user-feedback"
         name="on-page-user-feedback"
-        placeholder="<%= t('articles.on_page_feedback.feedback_placeholder') %>" 
+        placeholder="<%= t('articles.on_page_feedback.feedback_placeholder') %>"
         data-dough-validation-empty="Please leave a comment"
         aria-required
-        required></textarea>
+        required
+        data-dough-feedback-comment></textarea>
       </div>
         <input class="on-page-feedback__form-submit button button--primary" type="submit" data-dough-feedback-submit value="<%= t('articles.on_page_feedback.user_feedback_submit') %>"/>
     </form>

--- a/lib/core/repository/cms/page_feedback.rb
+++ b/lib/core/repository/cms/page_feedback.rb
@@ -2,6 +2,8 @@ module Core
   module Repository
     module CMS
       class PageFeedback < ::Core::Repository::CMS::CMS
+        MAS_CMS_API_TOKEN = ENV.fetch('MAS_CMS_API_TOKEN')
+
         def create(params)
           request(:post, params)
         end
@@ -11,6 +13,7 @@ module Core
         end
 
         def request(verb, params)
+          connection.token_auth(MAS_CMS_API_TOKEN)
           response = connection.send(verb, resource_url(params), params)
           response.body
         rescue

--- a/spec/cassettes/en/articles/example-article/page_feedbacks.yml
+++ b/spec/cassettes/en/articles/example-article/page_feedbacks.yml
@@ -8,8 +8,10 @@ http_interactions:
       string: '{"liked":true,"article_id":"example-article","session_id":"ae2fcba004e16dffa54f91a46d274238","locale":"en","slug":"example-article"}'
     headers:
       User-Agent:
-      - Mas-Responsive/1.0 (Tomas-Destefi-00119.local; tomasdestefi; 20858) ruby/2.2.5
+      - Mas-Responsive/1.0 (Tomas-Destefi-00119.local; tomasdestefi; 13608) ruby/2.2.5
         (319; x86_64-darwin15)
+      Authorization:
+      - Token token="mytoken"
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -22,7 +24,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 24 Oct 2016 14:53:24 GMT
+      - Tue, 15 Nov 2016 16:57:06 GMT
       Status:
       - 201 Created
       Connection:
@@ -36,16 +38,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - '"cfea846ce230cfdd6ef5ec0253881c57"'
+      - '"599f8cb1a5f382bd62079c3e99869809"'
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - c49aaa07-e92f-449f-a826-30958d085a94
+      - 4ec01f8e-42f9-4220-aad5-cb73946402e1
       X-Runtime:
-      - '0.312014'
+      - '0.057154'
     body:
       encoding: UTF-8
-      string: '{"id":17,"page_id":1,"liked":true,"session_id":"ae2fcba004e16dffa54f91a46d274238","comment":null,"shared_on":null,"likes_count":14,"dislikes_count":3}'
+      string: '{"id":21,"page_id":1,"liked":true,"session_id":"ae2fcba004e16dffa54f91a46d274238","comment":null,"shared_on":null,"likes_count":18,"dislikes_count":3}'
     http_version: 
-  recorded_at: Mon, 24 Oct 2016 14:53:24 GMT
+  recorded_at: Tue, 15 Nov 2016 16:57:06 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/en/articles/example/page_feedbacks-invalid.yml
+++ b/spec/cassettes/en/articles/example/page_feedbacks-invalid.yml
@@ -2,14 +2,16 @@
 http_interactions:
 - request:
     method: post
-    uri: http://localhost:3000/api/page_feedbacks
+    uri: http://localhost:3000/api/en/example-article/page_feedbacks
     body:
       encoding: UTF-8
-      string: "{}"
+      string: '{"locale":"en","article_id":"example-article"}'
     headers:
       User-Agent:
-      - Mas-Responsive/1.0 (Tomas-Destefi-00119.local; tomasdestefi; 20661) ruby/2.2.5
+      - Mas-Responsive/1.0 (Tomas-Destefi-00119.local; tomasdestefi; 13608) ruby/2.2.5
         (319; x86_64-darwin15)
+      Authorization:
+      - Token token="mytoken"
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -19,152 +21,31 @@ http_interactions:
   response:
     status:
       code: 422
-      message: 'Unprocessable Entity '
+      message: Unprocessable Entity
     headers:
-      Content-Type:
-      - text/plain; charset=utf-8
-      X-Request-Id:
-      - 00e816d8-2215-4526-9e08-9ff11cc89553
-      X-Runtime:
-      - '0.039447'
-      Server:
-      - WEBrick/1.3.1 (Ruby/2.2.5/2016-04-26)
       Date:
-      - Mon, 24 Oct 2016 14:48:53 GMT
-      Content-Length:
-      - '10992'
+      - Tue, 15 Nov 2016 16:57:05 GMT
+      Status:
+      - 422 Unprocessable Entity
       Connection:
-      - Keep-Alive
+      - close
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - b04305aa-64de-475c-bc6c-5a85c091453f
+      X-Runtime:
+      - '0.539770'
     body:
       encoding: UTF-8
-      string: "ActionController::InvalidAuthenticityToken at /api/page_feedbacks\n=================================================================\n\n>
-        ActionController::InvalidAuthenticityToken\n\napp/middleware/version_header.rb,
-        line 13\n-----------------------------------------\n\n``` ruby\n    8       json
-        = File.read(version_file)\n    9       @version = JSON.parse(json)['version']\n
-        \  10     end\n   11   \n   12     def call(env)\n>  13       status, headers,
-        body = @app.call(env)\n   14   \n   15       headers.merge!('X-Mas-Version'
-        => @version) if @version\n   16   \n   17       [status, headers, body]\n
-        \  18     end\n```\n\nApp backtrace\n-------------\n\n - app/middleware/version_header.rb:13:in
-        `call'\n - app/middleware/route_probe.rb:19:in `call'\n - app/middleware/override_head.rb:13:in
-        `call'\n - app/middleware/capture_request_id.rb:11:in `call'\n\nFull backtrace\n--------------\n\n
-        - actionpack (4.2.7.1) lib/action_controller/metal/request_forgery_protection.rb:181:in
-        `handle_unverified_request'\n - actionpack (4.2.7.1) lib/action_controller/metal/request_forgery_protection.rb:209:in
-        `handle_unverified_request'\n - devise (4.2.0) lib/devise/controllers/helpers.rb:253:in
-        `handle_unverified_request'\n - actionpack (4.2.7.1) lib/action_controller/metal/request_forgery_protection.rb:204:in
-        `verify_authenticity_token'\n - activesupport (4.2.7.1) lib/active_support/callbacks.rb:432:in
-        `block in make_lambda'\n - activesupport (4.2.7.1) lib/active_support/callbacks.rb:164:in
-        `block in halting'\n - activesupport (4.2.7.1) lib/active_support/callbacks.rb:504:in
-        `block in call'\n - activesupport (4.2.7.1) lib/active_support/callbacks.rb:504:in
-        `call'\n - activesupport (4.2.7.1) lib/active_support/callbacks.rb:92:in `__run_callbacks__'\n
-        - activesupport (4.2.7.1) lib/active_support/callbacks.rb:778:in `_run_process_action_callbacks'\n
-        - activesupport (4.2.7.1) lib/active_support/callbacks.rb:81:in `run_callbacks'\n
-        - actionpack (4.2.7.1) lib/abstract_controller/callbacks.rb:19:in `process_action'\n
-        - actionpack (4.2.7.1) lib/action_controller/metal/rescue.rb:29:in `process_action'\n
-        - actionpack (4.2.7.1) lib/action_controller/metal/instrumentation.rb:32:in
-        `block in process_action'\n - activesupport (4.2.7.1) lib/active_support/notifications.rb:164:in
-        `block in instrument'\n - activesupport (4.2.7.1) lib/active_support/notifications/instrumenter.rb:20:in
-        `instrument'\n - activesupport (4.2.7.1) lib/active_support/notifications.rb:164:in
-        `instrument'\n - actionpack (4.2.7.1) lib/action_controller/metal/instrumentation.rb:30:in
-        `process_action'\n - actionpack (4.2.7.1) lib/action_controller/metal/params_wrapper.rb:250:in
-        `process_action'\n - activerecord (4.2.7.1) lib/active_record/railties/controller_runtime.rb:18:in
-        `process_action'\n - actionpack (4.2.7.1) lib/abstract_controller/base.rb:137:in
-        `process'\n - actionview (4.2.7.1) lib/action_view/rendering.rb:30:in `process'\n
-        - actionpack (4.2.7.1) lib/action_controller/metal.rb:196:in `dispatch'\n
-        - actionpack (4.2.7.1) lib/action_controller/metal/rack_delegation.rb:13:in
-        `dispatch'\n - actionpack (4.2.7.1) lib/action_controller/metal.rb:237:in
-        `block in action'\n - actionpack (4.2.7.1) lib/action_dispatch/routing/route_set.rb:74:in
-        `dispatch'\n - actionpack (4.2.7.1) lib/action_dispatch/routing/route_set.rb:43:in
-        `serve'\n - actionpack (4.2.7.1) lib/action_dispatch/journey/router.rb:43:in
-        `block in serve'\n - actionpack (4.2.7.1) lib/action_dispatch/journey/router.rb:30:in
-        `serve'\n - actionpack (4.2.7.1) lib/action_dispatch/routing/route_set.rb:817:in
-        `call'\n - newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in
-        `call'\n - i18n-js (3.0.0.mas) lib/i18n-js/middleware.rb:11:in `call'\n -
-        newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in
-        `call'\n - newrelic_rpm (3.16.3.323) lib/new_relic/rack/agent_hooks.rb:30:in
-        `traced_call'\n - newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in
-        `call'\n - newrelic_rpm (3.16.3.323) lib/new_relic/rack/browser_monitoring.rb:32:in
-        `traced_call'\n - newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in
-        `call'\n - app/middleware/version_header.rb:13:in `call'\n - newrelic_rpm
-        (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in
-        `call'\n - app/middleware/route_probe.rb:19:in `call'\n - newrelic_rpm (3.16.3.323)
-        lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'\n -
-        app/middleware/override_head.rb:13:in `call'\n - newrelic_rpm (3.16.3.323)
-        lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'\n -
-        app/middleware/capture_request_id.rb:11:in `call'\n - newrelic_rpm (3.16.3.323)
-        lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'\n -
-        warden (1.2.6) lib/warden/manager.rb:35:in `block in call'\n - warden (1.2.6)
-        lib/warden/manager.rb:34:in `call'\n - newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in
-        `call'\n - rack (1.6.4) lib/rack/etag.rb:24:in `call'\n - newrelic_rpm (3.16.3.323)
-        lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'\n -
-        rack (1.6.4) lib/rack/conditionalget.rb:38:in `call'\n - newrelic_rpm (3.16.3.323)
-        lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'\n -
-        rack (1.6.4) lib/rack/head.rb:13:in `call'\n - newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in
-        `call'\n - actionpack (4.2.7.1) lib/action_dispatch/middleware/params_parser.rb:27:in
-        `call'\n - newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in
-        `call'\n - actionpack (4.2.7.1) lib/action_dispatch/middleware/flash.rb:260:in
-        `call'\n - newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in
-        `call'\n - rack (1.6.4) lib/rack/session/abstract/id.rb:225:in `context'\n
-        - rack (1.6.4) lib/rack/session/abstract/id.rb:220:in `call'\n - newrelic_rpm
-        (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in
-        `call'\n - actionpack (4.2.7.1) lib/action_dispatch/middleware/cookies.rb:560:in
-        `call'\n - newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in
-        `call'\n - activerecord (4.2.7.1) lib/active_record/query_cache.rb:36:in `call'\n
-        - newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in
-        `call'\n - activerecord (4.2.7.1) lib/active_record/connection_adapters/abstract/connection_pool.rb:653:in
-        `call'\n - newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in
-        `call'\n - activerecord (4.2.7.1) lib/active_record/migration.rb:377:in `call'\n
-        - newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in
-        `call'\n - actionpack (4.2.7.1) lib/action_dispatch/middleware/callbacks.rb:29:in
-        `block in call'\n - activesupport (4.2.7.1) lib/active_support/callbacks.rb:88:in
-        `__run_callbacks__'\n - activesupport (4.2.7.1) lib/active_support/callbacks.rb:778:in
-        `_run_call_callbacks'\n - activesupport (4.2.7.1) lib/active_support/callbacks.rb:81:in
-        `run_callbacks'\n - actionpack (4.2.7.1) lib/action_dispatch/middleware/callbacks.rb:27:in
-        `call'\n - newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in
-        `call'\n - actionpack (4.2.7.1) lib/action_dispatch/middleware/reloader.rb:73:in
-        `call'\n - newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in
-        `call'\n - actionpack (4.2.7.1) lib/action_dispatch/middleware/remote_ip.rb:78:in
-        `call'\n - newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in
-        `call'\n - bugsnag (5.0.1) lib/bugsnag/rack.rb:33:in `call'\n - newrelic_rpm
-        (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in
-        `call'\n - better_errors (2.1.1) lib/better_errors/middleware.rb:84:in `protected_app_call'\n
-        - better_errors (2.1.1) lib/better_errors/middleware.rb:79:in `better_errors_call'\n
-        - better_errors (2.1.1) lib/better_errors/middleware.rb:57:in `call'\n - newrelic_rpm
-        (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in
-        `call'\n - actionpack (4.2.7.1) lib/action_dispatch/middleware/debug_exceptions.rb:17:in
-        `call'\n - newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in
-        `call'\n - actionpack (4.2.7.1) lib/action_dispatch/middleware/show_exceptions.rb:30:in
-        `call'\n - newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in
-        `call'\n - railties (4.2.7.1) lib/rails/rack/logger.rb:38:in `call_app'\n
-        - railties (4.2.7.1) lib/rails/rack/logger.rb:20:in `block in call'\n - activesupport
-        (4.2.7.1) lib/active_support/tagged_logging.rb:68:in `block in tagged'\n -
-        activesupport (4.2.7.1) lib/active_support/tagged_logging.rb:26:in `tagged'\n
-        - activesupport (4.2.7.1) lib/active_support/tagged_logging.rb:68:in `tagged'\n
-        - railties (4.2.7.1) lib/rails/rack/logger.rb:20:in `call'\n - newrelic_rpm
-        (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in
-        `call'\n - request_store (1.3.1) lib/request_store/middleware.rb:9:in `call'\n
-        - newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in
-        `call'\n - actionpack (4.2.7.1) lib/action_dispatch/middleware/request_id.rb:21:in
-        `call'\n - newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in
-        `call'\n - rack (1.6.4) lib/rack/methodoverride.rb:22:in `call'\n - newrelic_rpm
-        (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in
-        `call'\n - rack (1.6.4) lib/rack/runtime.rb:18:in `call'\n - newrelic_rpm
-        (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in
-        `call'\n - dragonfly (1.0.12) lib/dragonfly/cookie_monster.rb:9:in `call'\n
-        - newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in
-        `call'\n - rack (1.6.4) lib/rack/lock.rb:17:in `call'\n - newrelic_rpm (3.16.3.323)
-        lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'\n -
-        actionpack (4.2.7.1) lib/action_dispatch/middleware/static.rb:120:in `call'\n
-        - newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in
-        `call'\n - rack (1.6.4) lib/rack/sendfile.rb:113:in `call'\n - newrelic_rpm
-        (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in
-        `call'\n - railties (4.2.7.1) lib/rails/engine.rb:518:in `call'\n - railties
-        (4.2.7.1) lib/rails/application.rb:165:in `call'\n - newrelic_rpm (3.16.3.323)
-        lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'\n -
-        rack (1.6.4) lib/rack/lock.rb:17:in `call'\n - rack (1.6.4) lib/rack/content_length.rb:15:in
-        `call'\n - rack (1.6.4) lib/rack/handler/webrick.rb:88:in `service'\n - /Users/tomasdestefi/.rvm/rubies/ruby-2.2.5/lib/ruby/2.2.0/webrick/httpserver.rb:138:in
-        `service'\n - /Users/tomasdestefi/.rvm/rubies/ruby-2.2.5/lib/ruby/2.2.0/webrick/httpserver.rb:94:in
-        `run'\n - /Users/tomasdestefi/.rvm/rubies/ruby-2.2.5/lib/ruby/2.2.0/webrick/server.rb:294:in
-        `block in start_thread'\n\n"
+      string: '{"errors":["Session can''t be blank"]}'
     http_version: 
-  recorded_at: Mon, 24 Oct 2016 14:48:53 GMT
+  recorded_at: Tue, 15 Nov 2016 16:57:05 GMT
 recorded_with: VCR 3.0.3

--- a/spec/lib/core/repository/cms/page_feedback_spec.rb
+++ b/spec/lib/core/repository/cms/page_feedback_spec.rb
@@ -15,10 +15,10 @@ module Core::Repository::CMS
           }
         end
 
-        it 'returns ' do
+        it 'returns page feedback' do
           VCR.use_cassette('/en/articles/example-article/page_feedbacks') do
             expect(subject).to include(
-              'id'         => 17,
+              'id'         => 21,
               'liked'      => true,
               'session_id' => 'ae2fcba004e16dffa54f91a46d274238')
           end
@@ -26,7 +26,12 @@ module Core::Repository::CMS
       end
 
       context 'when invalid' do
-        let(:params) { {} }
+        let(:params) do
+          {
+            locale: 'en',
+            article_id: 'example-article'
+          }
+        end
 
         it 'returns false' do
           VCR.use_cassette('/en/articles/example/page_feedbacks-invalid') do


### PR DESCRIPTION
Since I added the token auth on CMS (you can see here: https://github.com/moneyadviceservice/cms/pull/355) I need to add on the client too (this PR!). 

This still requires work on the puppet scripts to add the token environment variable. More details you can see here: https://github.com/moneyadviceservice/scripts/pull/816

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1599)
<!-- Reviewable:end -->
