### PR TITLE
Clearing localStorage within Karma test

### DIFF
--- a/spec/javascripts/tests/OnPageFeedback_spec.js
+++ b/spec/javascripts/tests/OnPageFeedback_spec.js
@@ -18,8 +18,9 @@ describe('OnPageFeedback', function() {
         self.dislikesElement = self.$html.find('[data-dough-feedback-dislike-count]');
 
         // Override _getPageId, since we don't have a DOM for it to access
-        OnPageFeedback.prototype._getPageId = function() { return '' };
+        OnPageFeedback.prototype._getPageId = function() { return '1' };
 
+        localStorage.clear();
         self.OnPageFeedback = new OnPageFeedback(self.$html).init();
 
         server = sinon.fakeServer.create();


### PR DESCRIPTION
The OnPageFeedback Karma test was failing because the component was adding data to localStorage, which was breaking future tests. This PR clears the localStorage before each run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1601)
<!-- Reviewable:end -->
