### PR TITLE
[DEV APPROVED] 7737 - A11Y: Transcript description

### DIFF
--- a/config/locales/retirements.cy.yml
+++ b/config/locales/retirements.cy.yml
@@ -14,7 +14,7 @@ cy:
         - Dysgwch am eich dewisiadau ar gyfer ymddeol
         - Ceisiwch help gyda materion blynyddoedd hŷn
         - Darganfyddwch pa gymorth a chyngor sydd ar gael
-      video_caption_html: 'Y newyddiadurwr ariannol Paul Lewis yn esbonio sut i wneud y gorau o gynllunio ar gyfer ymddeol <a href="https://masjumpprdstorage.blob.core.windows.net/video-transcripts/retirement-video-transcript.cy.pdf" class="download-link--pdf" download="retirement-video-transcript">Lawrlwythwch sgript y fideo</a>'
+      video_caption_html: 'Y newyddiadurwr ariannol Paul Lewis yn esbonio sut i wneud y gorau o gynllunio ar gyfer ymddeol <a href="https://masjumpprdstorage.blob.core.windows.net/video-transcripts/retirement-video-transcript.cy.pdf" class="download-link--pdf" download="retirement-video-transcript" aria-label="Lawrlwythwch sgript y fideo, PDF file 32 kilobytes">Lawrlwythwch sgript y fideo</a>'
     section2:
       - text: Llinell amser cynilion pensiwn
         url: /cy/pensions-and-retirement/pension-savings-timeline

--- a/config/locales/retirements.en.yml
+++ b/config/locales/retirements.en.yml
@@ -14,7 +14,7 @@ en:
         - Learn about your choices for retirement
         - Get help with later life matters
         - Find out what support and advice is available
-      video_caption_html: Financial journalist Paul Lewis explains how to make the most of planning for retirement <a href="https://masjumpprdstorage.blob.core.windows.net/video-transcripts/retirement-video-transcript.en.pdf" class="download-link--pdf" download="retirement-video-transcript">Download the video transcript</a>
+      video_caption_html: Financial journalist Paul Lewis explains how to make the most of planning for retirement <a href="https://masjumpprdstorage.blob.core.windows.net/video-transcripts/retirement-video-transcript.en.pdf" class="download-link--pdf" download="retirement-video-transcript" aria-label="Download the video transcript, PDF file 21 kilobytes">Download the video transcript</a>
     section2:
       - text: Pension savings timeline
         url: /en/pensions-and-retirement/pension-savings-timeline


### PR DESCRIPTION
## Adding file size and type to transcript links

Adding file type and size to the video transcript PDF for screen reader users:

<img width="713" alt="screen shot 2016-11-18 at 10 27 20" src="https://cloud.githubusercontent.com/assets/13165846/20427032/ce5ff914-ad79-11e6-83b2-36c26d6a8726.png">

Related PR: https://github.com/moneyadviceservice/rio/pull/108

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1602)
<!-- Reviewable:end -->
