### PR TITLE
7737 - Bumping rio to 1.11.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,7 @@ gem 'mortgage_calculator', '~> 1.5.1'
 gem 'payday_loans_intervention', '~> 1.6.0'
 gem 'pensions_calculator', '~> 1.3.1'
 gem 'quiz', '~> 1.1.0', source: 'http://gems.dev.mas.local'
-gem 'rio', '1.10.0', source: 'http://gems.dev.mas.local'
+gem 'rio', '1.11.0', source: 'http://gems.dev.mas.local'
 gem 'savings_calculator', '~> 1.6.0'
 gem 'timelines', '~> 1.4.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -537,7 +537,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
-    rio (1.10.0)
+    rio (1.11.0)
       bowndler
       dough-ruby
       pensions_calculator-calculations (~> 1.4.0)
@@ -766,7 +766,7 @@ DEPENDENCIES
   rack-livereload
   rails (= 4.2.7.1)
   redcarpet
-  rio (= 1.10.0)!
+  rio (= 1.11.0)!
   rouge
   rspec-html-matchers
   rspec-rails


### PR DESCRIPTION
## Bumping rio to 1.11.0 for 7737

Original RIO PR: https://github.com/moneyadviceservice/rio/pull/108

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1603)
<!-- Reviewable:end -->
