### PR TITLE
[DEV APPROVED] Removing the duplicate expand button on Category Page

### DIFF
--- a/app/assets/stylesheets/_print.scss
+++ b/app/assets/stylesheets/_print.scss
@@ -79,7 +79,6 @@
   }
 
   // expand collapsed content
-  .is-off.category-detail__list-container,
   .editorial .is-off.collapsible-section {
     display: block;
   }

--- a/app/assets/stylesheets/components/page_specific/_category_detail.scss
+++ b/app/assets/stylesheets/components/page_specific/_category_detail.scss
@@ -22,69 +22,6 @@
   border: 0;
 }
 
-.category-detail__view-more {
-  padding-left: $baseline-unit*7;
-  min-height: $baseline-unit*7;
-  display: block;
-  position: relative;
-
-  .category-detail__view-more__label-more,
-  .category-detail__view-more__label-less,
-  .svg-icon {
-    display: none;
-  }
-
-  .unstyled-button {
-    @include body(18, 24);
-    display: inline-block;
-    background: $color-grey-pale;
-    color: $color-link-default;
-    position: absolute;
-    bottom: 0;
-    right: 0;
-    user-select: none;
-    padding: 8px 18px;
-    padding-left: $baseline-unit*7;
-
-    .category-detail__view-more__label-more {
-      display: inline;
-    }
-
-    .category-detail__view-more__label-less {
-      display: none;
-    }
-
-    .svg-icon {
-      position: absolute;
-      display: block;
-      top: 12px;
-      left: 12px;
-    }
-
-    .collapsable__trigger-icon {
-      display: none;
-    }
-
-    &.is-active {
-      .category-detail__view-more__label-more {
-        display: none;
-      }
-
-      .category-detail__view-more__label-less {
-        display: inline;
-      }
-
-      .svg-icon--plus--blue {
-        display: none;
-      }
-    }
-
-    &:hover {
-      text-decoration: underline;
-    }
-  }
-}
-
 .category-detail__list-item {
   margin-bottom: $baseline-unit*3;
 
@@ -104,8 +41,9 @@
     @include body(16, 26);
     color: $color-black;
     font-weight: 700;
-    display: inline;
-    padding-left: 34px;
+    display: inline-block;
+    padding-left: $baseline-unit*6;
+    padding-bottom: $baseline-unit*3;
   }
 
   &:before {
@@ -116,11 +54,7 @@
     width: 31px;
     height: 31px;
     position: absolute;
-    left: 36px;
-
-    @if $responsive == false {
-      background-position: -781px -443px;
-    }
+    left: 0;
   }
 
   &:hover,
@@ -134,82 +68,11 @@
   }
 }
 
-.category-detail__list-container {
-  .js & {
-    display: none;
-  }
-
-  &.is-active {
-    display: block;
-  }
-}
-
-.category-detail__heading {
-  .svg-icon {
-    display: none;
-  }
-
-  .js & {
-    position: relative;
-    padding-left: $category-inset;
-    user-select: none;
-
-    button {
-      margin-left: -$category-inset;
-      padding-left: $category-inset;
-      text-align: left;
-
-      &:focus,
-      &:hover {
-        margin-bottom: -2px;
-      }
-
-      &:hover {
-        border-bottom: 2px solid $color-green-dark;
-        outline: none;
-
-        svg {
-          fill: $color-green-dark;
-        }
-      }
-
-      &:focus {
-        color: $color-focus-fg;
-        border-bottom: 2px solid $color-focus-fg;
-        background: $color-focus-bg;
-
-        svg {
-          fill: $color-focus-fg;
-        }
-      }
-    }
-
-    .collapsable__trigger-icon {
-      display: none;
-    }
-
-    .svg-icon {
-      position: absolute;
-      top: 8px;
-      left: 0;
-      display: block;
-    }
-
-    .is-active .svg-icon--plus--yellow {
-      display: none;
-    }
-  }
-}
-
 .js .category-detail__intro {
   display: none;
 
   @include respond-to($mq-s) {
-    padding-left: $category-inset;
     display: block;
   }
 }
 
-.js .category-detail__list-container {
-  padding-left: $category-inset;
-}

--- a/app/assets/stylesheets/components/page_specific/_featured_links.scss
+++ b/app/assets/stylesheets/components/page_specific/_featured_links.scss
@@ -8,10 +8,6 @@
   margin: $baseline-unit*5 0 0 0;
   overflow: hidden;
   @include row(12);
-
-  .js & {
-    padding-left: $baseline-unit*6;
-  }
 }
 
 .featured-links__item {

--- a/app/decorators/category_content_decorator.rb
+++ b/app/decorators/category_content_decorator.rb
@@ -4,11 +4,11 @@ class CategoryContentDecorator < Draper::Decorator
   delegate :id, :title, :description, :category_promos
 
   def initial_contents
-    contents.take(6)
+    contents.take(3)
   end
 
   def extended_contents
-    contents[6..-1] || []
+    contents[3..-1] || []
   end
 
   def label

--- a/app/views/categories/_child_categories.html.erb
+++ b/app/views/categories/_child_categories.html.erb
@@ -2,28 +2,18 @@
   <section class="category-detail" data-dough-component="Collapsable">
     <%= heading_tag level: 2,
                     id:    child_category.id,
-                    class: 'category-detail__heading',
-                    data: { dough_collapsable_trigger: 'category_' + child_category.id } do
+                    class: 'category-detail__heading' do
     %>
-      <%= render 'shared/svg/use_icon', icon: 'plus', variant: 'yellow' %>
-      <%= render 'shared/svg/use_icon', icon: 'minus', variant: 'yellow' %>
-      <%= child_category.title %>
+    <%= child_category.title %>
     <% end %>
     <p class="category-detail__intro"><%= child_category.description %></p>
     <%= render 'category_promos', promos: child_category.category_promos unless !child_category.category_promos || child_category.category_promos.empty? %>
     <% if child_category.contents.present? %>
-      <div class="category-detail__list-container" data-dough-collapsable-target="category_<%= child_category.id %>">
+      <div class="category-detail__list-container">
         <%= render 'content_items', initial_contents: child_category.initial_contents,
                                     extended_contents: child_category.extended_contents,
                                     child_category_id: child_category.id %>
       </div>
-      <span class="js-category-detail__view-more category-detail__view-more" data-dough-component="ScrollTo" data-anchor="<%= child_category.id %>" data-dough-collapsable-trigger="category_<%= child_category.id %>">
-        <%= render 'shared/svg/use_icon', icon: 'plus', variant: 'blue' %>
-        <%= render 'shared/svg/use_icon', icon: 'minus', variant: 'blue' %>
-        <span class="category-detail__view-more__label-more"><%= t('categories.show.view_more') %></span>
-        <span class="category-detail__view-more__label-less"><%= t('categories.show.view_less') %></span>
-        <span class="visually-hidden"> <%= child_category.title %></span>
-      </span>
     <% end %>
   </section>
 <% end %>

--- a/spec/decorators/category_content_decorator_spec.rb
+++ b/spec/decorators/category_content_decorator_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CategoryContentDecorator do
   before { allow(I18n).to receive(:locale) { locale } }
 
   subject(:decorator) { described_class.decorate(item) }
-
+ 
   it { is_expected.to respond_to(:id) }
   it { is_expected.to respond_to(:path) }
   it { is_expected.to respond_to(:label) }
@@ -32,8 +32,8 @@ RSpec.describe CategoryContentDecorator do
         allow(subject).to receive(:contents) { (1..10).to_a }
       end
 
-      it 'returns 6 items' do
-        expect(subject.initial_contents.size).to eql(6)
+      it 'returns 3 items' do
+        expect(subject.initial_contents.size).to eql(3)
       end
     end
   end
@@ -54,8 +54,8 @@ RSpec.describe CategoryContentDecorator do
         allow(subject).to receive(:contents) { (1..10).to_a }
       end
 
-      it 'returns 4 items' do
-        expect(subject.extended_contents.size).to eql(4)
+      it 'returns 7 items' do
+        expect(subject.extended_contents.size).to eql(7)
       end
     end
   end


### PR DESCRIPTION
## Current functionality
The Category page has an 'expand / contract' button that toggles visibility on the first 6 items _and_ a 'View all' button that shows _all_ items. This is pretty confusing for users, and has been highlighted by DAC as a usability issue:

![image](https://cloud.githubusercontent.com/assets/14920201/20481841/3625e18a-afe1-11e6-9d40-bcfd64073720.png)

## Changes
This PR:
- removes the 'expand/contract' button
- displays the first **three** links by default
- retains the 'View all' button which expands the whole list

![image](https://cloud.githubusercontent.com/assets/14920201/20481820/1374f4e6-afe1-11e6-8ae0-2eec5565c171.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1605)
<!-- Reviewable:end -->
