### PR TITLE
[DEV APPROVED] 7802 - Removing like and dislike count from OnPageFeedback

### DIFF
--- a/app/assets/javascripts/components/OnPageFeedback.js
+++ b/app/assets/javascripts/components/OnPageFeedback.js
@@ -12,8 +12,8 @@ define(['jquery', 'featureDetect', 'DoughBaseComponent', 'common'], function($, 
     this.submitBtn = $el.find('[data-dough-feedback-submit]');
     this.submitForm = $el.find('[data-dough-feedback-form]');
     this.ajaxUrl = $el.attr('data-dough-on-page-feedback-post');
-    this.likeElement = $el.find('[data-dough-feedback-like-count]');
-    this.dislikeElement = $el.find('[data-dough-feedback-dislike-count]');
+    this.likeElement = $el.find('[data-dough-feedback-like-container]');
+    this.dislikeElement = $el.find('[data-dough-feedback-dislike-container]');
     this.pageId = this._getPageId();
     this.currentPage = 'start';
   };
@@ -34,7 +34,6 @@ define(['jquery', 'featureDetect', 'DoughBaseComponent', 'common'], function($, 
 
     var submitInteraction = $.post(this.ajaxUrl, postObject, function(data){
       this._showPage(interaction);
-      this._updateCount(data);
       this._storeState();
     }.bind(this))
     .fail(function() {
@@ -84,23 +83,9 @@ define(['jquery', 'featureDetect', 'DoughBaseComponent', 'common'], function($, 
       el = this.dislikeElement;
     };
 
-    total = parseInt(el.text());
-    el.text(total - 1);
-
     window.setTimeout(function(){
       el.closest('.on-page-feedback__results-item').addClass('is-animating');
     }.bind(this), 300);
-    window.setTimeout(function(){
-      el.text(total);
-    }.bind(this), 600);
-  };
-
-  OnPageFeedback.prototype._updateCount = function(data) {
-    this.likesCount = data.likes_count;
-    this.dislikesCount = data.dislikes_count;
-
-    this.likeElement.text(this.likesCount);
-    this.dislikeElement.text(this.dislikesCount);
   };
 
   OnPageFeedback.prototype._showPage = function(pageName) {
@@ -117,7 +102,6 @@ define(['jquery', 'featureDetect', 'DoughBaseComponent', 'common'], function($, 
 
       // Ignore stored data if more than 30 days old
       if (json.time > (Date.now() - (30*24*60*60*1000))) {
-        this._updateCount(json);
         this.currentPage = json.current_page;
       }
     }
@@ -126,8 +110,6 @@ define(['jquery', 'featureDetect', 'DoughBaseComponent', 'common'], function($, 
   OnPageFeedback.prototype._storeState = function() {
     var data = {
       time: Date.now(),
-      likes_count: this.likesCount,
-      dislikes_count: this.dislikesCount,
       current_page: this.currentPage
     }
 
@@ -160,7 +142,9 @@ define(['jquery', 'featureDetect', 'DoughBaseComponent', 'common'], function($, 
     this._bindHandlers();
     this._restoreState();
 
-    if (this.currentPage != 'start') {
+    if (this.currentPage === 'results') {
+      return;
+    } else if (this.currentPage != 'start') {
       this._showPage(this.currentPage);
     }
 

--- a/app/assets/stylesheets/components/page_specific/_on_page_feedback.scss
+++ b/app/assets/stylesheets/components/page_specific/_on_page_feedback.scss
@@ -99,7 +99,7 @@
 
 .on-page-feedback__results-item-front, .on-page-feedback__results-item-back {
   backface-visibility: hidden;
-  padding-top: 10px;
+  padding-top: 18px;
   position: absolute;
   top: 0;
   left: 0;

--- a/app/views/shared/_on_page_feedback.html.erb
+++ b/app/views/shared/_on_page_feedback.html.erb
@@ -46,7 +46,7 @@
   </div>
   <div class="on-page-feedback__results is-hidden" data-dough-feedback-page="results">
     <h2 class="on-page-feedback__title"><%= t('articles.on_page_feedback.thankyou_heading') %></h2>
-    <div class="on-page-feedback__results-item">
+    <div class="on-page-feedback__results-item" data-dough-feedback-like-container>
       <div class="on-page-feedback__results-item-card">
         <div class="on-page-feedback__results-item-front">
           <svg xmlns="http://www.w3.org/2000/svg"
@@ -55,13 +55,11 @@
           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--thumb-icon-up"></use>
         </svg>
         <span class="icon icon--thumb-icon-up"></span>
-        <span class="visually-hidden"><%= t('articles.on_page_feedback.total_likes') %></span>
-        <div class="on-page-feedback__results-item-number" data-dough-feedback-like-count></div>
         </div>
         <div class="on-page-feedback__results-item-back"></div>
       </div>
     </div>
-    <div class="on-page-feedback__results-item">
+    <div class="on-page-feedback__results-item"  data-dough-feedback-dislike-container>
       <div class="on-page-feedback__results-item-card">
         <div class="on-page-feedback__results-item-front">
         <svg xmlns="http://www.w3.org/2000/svg"
@@ -70,8 +68,6 @@
           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--thumb-icon-down"></use>
         </svg>
         <span class="icon icon--thumb-icon-down"></span>
-        <span class="visually-hidden"><%= t('articles.on_page_feedback.total_dislikes') %></span>
-        <div class="on-page-feedback__results-item-number" data-dough-feedback-dislike-count></div>
         </div>
         <div class="on-page-feedback__results-item-back"></div>
       </div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -328,8 +328,6 @@ cy:
       thankyou_heading: Diolch am eich adborth
       user_feedback_submit: Cyflwyno
       feedback_placeholder: Teipiwch yma...
-      total_likes: Nifer wedi hoffi
-      total_dislikes: Nifer ddim wedi hoffi
       empty_validation: Please leave a comment
 
     sharing:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -329,8 +329,6 @@ en:
       thankyou_heading: Thank you for your feedback
       user_feedback_submit: Submit
       feedback_placeholder: Type here...
-      total_likes: Total likes
-      total_dislikes: Total dislikes
       empty_validation: Please leave a comment
       
     sharing:

--- a/spec/javascripts/tests/OnPageFeedback_spec.js
+++ b/spec/javascripts/tests/OnPageFeedback_spec.js
@@ -64,16 +64,6 @@ describe('OnPageFeedback', function() {
     }); 
   });
 
-  describe('Updating the like / dislike count', function(){
-    it('Shows total likes', function(){
-      this.interactionBtn.filter('[data-dough-feedback=positive]').trigger('click');
-      server.respond();
-      expect(this.likesElement.html()).to.equal('12');
-      expect(this.dislikesElement.html()).to.equal('5');
-    });
-  });
-
-
   afterEach(function () {
     this.$html.remove();
     server.restore();


### PR DESCRIPTION
We are removing the total 'likes' and 'dislikes' from the On-page feedback component (for now, at least).

This PR removes the JavaScript, markup, CSS, locale text and JS tests that comprise this part of the feature.

Note: if a user who has previously completed the On Page Feedback form re-visits the page, the component will not display at all (see line 145 of OnPageFeedback.js).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1610)
<!-- Reviewable:end -->
