### PR TITLE
Being more specific with Yeast versioning

### DIFF
--- a/bower.json.erb
+++ b/bower.json.erb
@@ -12,7 +12,7 @@
     "jquery-ujs": "*",
     "bind-polyfill": "^1.0.0",
 
-    "yeast": "^1.0.0",
+    "yeast": "~1.0.0",
 
     "advice_plans": "<%= gem_path('advice_plans') %>",
     "car_cost_tool": "<%= gem_path('car_cost_tool') %>",


### PR DESCRIPTION
Our Yeast bower versioning on Production is not strict enough and has automatically upgraded from 1.0.0 to 1.1.0 when I released version 1.1.0.

This change will lock updates to _patch_ versions according to semver, e.g. 1.0.0 to 1.0.x

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1614)
<!-- Reviewable:end -->
