### PR TITLE
[DEV APPROVED]7804 new/old categories support

### DIFF
--- a/app/decorators/category_decorator.rb
+++ b/app/decorators/category_decorator.rb
@@ -1,5 +1,6 @@
 class CategoryDecorator < Draper::Decorator
   decorates_association :contents, with: CategoryContentDecorator
+  decorates_association :legacy_contents, with: CategoryContentDecorator
   delegate :title, :description, :id, :parent_id, :images, :links, :category_promos
 
   def path
@@ -16,14 +17,19 @@ class CategoryDecorator < Draper::Decorator
     end
   end
 
-  def render_contents
-    partial = if object.parent?
-                'child_categories'
-              elsif object.child?
-                'content_items_all'
-              end
+  def rendering_args
+    case
+    when object.legacy?
+      ['relay_page', contents: legacy_contents]
+    when object.parent?
+      ['child_categories', contents: contents]
+    when object.child?
+      ['content_items_all', contents: contents]
+    end
+  end
 
-    h.render partial, contents: contents
+  def render_contents
+    h.render *rendering_args
   end
 
   def large_image

--- a/app/views/categories/_relay_page.html.erb
+++ b/app/views/categories/_relay_page.html.erb
@@ -1,0 +1,19 @@
+<% contents.select(&:category?).each_with_index do |child_category, i| %>
+  <section class="category-detail" data-dough-component="Collapsable">
+    <%= heading_tag level: 2,
+                    id:    child_category.id,
+                    class: 'category-detail__heading' do
+    %>
+    <%= child_category.title %>
+    <% end %>
+    <p class="category-detail__intro"><%= child_category.description %></p>
+    <%= render 'category_promos', promos: child_category.category_promos unless !child_category.category_promos || child_category.category_promos.empty? %>
+    <% if child_category.contents.present? %>
+      <div class="category-detail__list-container">
+        <%= render 'content_items', initial_contents: child_category.initial_contents,
+                                    extended_contents: child_category.extended_contents,
+                                    child_category_id: child_category.id %>
+      </div>
+    <% end %>
+  </section>
+<% end %>

--- a/features/factories/category.rb
+++ b/features/factories/category.rb
@@ -5,6 +5,7 @@ FactoryGirl.define do
     description { Faker::Lorem.paragraph(1) }
     contents []
     legacy_contents []
+    legacy false
 
     initialize_with { new(id) }
 

--- a/features/factories/category.rb
+++ b/features/factories/category.rb
@@ -4,6 +4,7 @@ FactoryGirl.define do
     title { id.capitalize.sub(/-/, ' ') }
     description { Faker::Lorem.paragraph(1) }
     contents []
+    legacy_contents []
 
     initialize_with { new(id) }
 

--- a/lib/core/entity/category.rb
+++ b/lib/core/entity/category.rb
@@ -1,10 +1,14 @@
 module Core
   class Category < Entity
-    attr_accessor :type, :parent_id, :title, :description, :contents, :third_level_navigation, :images, :links, :category_promos
+    attr_accessor :type, :parent_id, :title, :description, :contents, :third_level_navigation, :images, :links, :category_promos, :legacy_contents, :legacy
     validates_presence_of :title
 
     def third_level_navigation?
       third_level_navigation
+    end
+
+    def legacy?
+      legacy
     end
 
     def child?
@@ -38,6 +42,7 @@ module Core
         title: title,
         description: description,
         contents: contents,
+        legacy_contents: legacy_contents,
         images: images,
         links: links
       }

--- a/lib/core/interactor/category_reader.rb
+++ b/lib/core/interactor/category_reader.rb
@@ -14,6 +14,7 @@ module Core
       if category.valid?
         category.tap do |cat|
           cat.contents = build_contents(cat.contents)
+          cat.legacy_contents = build_contents(cat.legacy_contents)
         end
       elsif block_given?
         yield category

--- a/spec/decorators/category_decorator_spec.rb
+++ b/spec/decorators/category_decorator_spec.rb
@@ -153,24 +153,39 @@ RSpec.describe CategoryDecorator do
 
   describe '#rendering_args' do
     context 'when object contains legacy contents' do
-      let(:category) { Core::Category.new(nil, legacy_contents: [:foo]) }
+      let(:category) { Core::Category.new(nil, legacy_contents: [:foo], legacy: true) }
 
-      specify { expect(subject.rendering_args.first).to eq 'relay_page' }
-      specify { expect(subject.rendering_args.last).to include(:contents) }
+      it 'first arg is partial name `relay_page`' do
+        expect(subject.rendering_args.first).to eq 'relay_page'
+      end
+
+      it 'second arg is a hash with contents key' do
+        expect(subject.rendering_args.last).to include(:contents)
+      end
     end
 
     context 'when object is a parent' do
       let(:category) { Core::Category.new(nil, contents: [double(:child? => true)], legacy_contents: []) }
 
-      specify { expect(subject.rendering_args.first).to eq 'child_categories' }
-      specify { expect(subject.rendering_args.last).to include(:contents) }
+      it 'first arg is partial name `child_categories`' do
+        expect(subject.rendering_args.first).to eq 'child_categories'
+      end
+
+      it 'second arg is a hash with contents key' do
+        expect(subject.rendering_args.last).to include(:contents)
+      end
     end
 
     context 'when object is a child' do
       let(:category) { Core::Category.new(nil, contents: [], legacy_contents: []) }
 
-      specify { expect(subject.rendering_args.first).to eq 'content_items_all' }
-      specify { expect(subject.rendering_args.last).to include(:contents) }
+      it 'first arg is partial name `content_items_all`' do
+        expect(subject.rendering_args.first).to eq 'content_items_all'
+      end
+
+      it 'second arg is a hash with contents key' do
+        expect(subject.rendering_args.last).to include(:contents)
+      end
     end
   end
 end

--- a/spec/decorators/category_decorator_spec.rb
+++ b/spec/decorators/category_decorator_spec.rb
@@ -150,4 +150,27 @@ RSpec.describe CategoryDecorator do
       end
     end
   end
+
+  describe '#rendering_args' do
+    context 'when object contains legacy contents' do
+      let(:category) { Core::Category.new(nil, legacy_contents: [:foo]) }
+
+      specify { expect(subject.rendering_args.first).to eq 'relay_page' }
+      specify { expect(subject.rendering_args.last).to include(:contents) }
+    end
+
+    context 'when object is a parent' do
+      let(:category) { Core::Category.new(nil, contents: [double(:child? => true)], legacy_contents: []) }
+
+      specify { expect(subject.rendering_args.first).to eq 'child_categories' }
+      specify { expect(subject.rendering_args.last).to include(:contents) }
+    end
+
+    context 'when object is a child' do
+      let(:category) { Core::Category.new(nil, contents: [], legacy_contents: []) }
+
+      specify { expect(subject.rendering_args.first).to eq 'content_items_all' }
+      specify { expect(subject.rendering_args.last).to include(:contents) }
+    end
+  end
 end

--- a/spec/lib/core/entity/category_spec.rb
+++ b/spec/lib/core/entity/category_spec.rb
@@ -10,20 +10,22 @@ module Core
         contents:    double,
         images:      double,
         links:       double,
-        category_promos: double
+        category_promos: double,
+        legacy_contents: double
       }
     end
 
-    it { is_expected.to have_attributes(:type, :parent_id, :title, :description, :contents, :images, :links, :category_promos) }
+    it { is_expected.to have_attributes(:type, :parent_id, :title, :description, :contents, :images, :links, :category_promos, :legacy_contents) }
     it { is_expected.to validate_presence_of(:title) }
 
     specify { expect(subject).to_not be_home }
     specify { expect(subject).to_not be_news }
 
-    describe 'category hierarchy' do
+    describe "category hierarchy" do
       let(:category_with_nil_contents) { build :category, contents: nil }
       let(:child_category) { build :category, contents: [build(:article), build(:action_plan)] }
       let(:parent_category) { build :category, contents: [child_category] }
+      let(:category_with_legacy_contents) { build :category, legacy_contents: [build(:article)] }
 
       specify { expect(category_with_nil_contents).to be_child }
 
@@ -32,6 +34,8 @@ module Core
 
       specify { expect(parent_category).to be_parent }
       specify { expect(parent_category).to_not be_child }
+
+      specify { expect(category_with_legacy_contents.legacy?).to be true }
     end
   end
 end

--- a/spec/lib/core/entity/category_spec.rb
+++ b/spec/lib/core/entity/category_spec.rb
@@ -25,7 +25,7 @@ module Core
       let(:category_with_nil_contents) { build :category, contents: nil }
       let(:child_category) { build :category, contents: [build(:article), build(:action_plan)] }
       let(:parent_category) { build :category, contents: [child_category] }
-      let(:category_with_legacy_contents) { build :category, legacy_contents: [build(:article)] }
+      let(:category_with_legacy_contents) { build :category, legacy_contents: [build(:article)], legacy: true }
 
       specify { expect(category_with_nil_contents).to be_child }
 

--- a/spec/lib/core/interactor/category_reader_spec.rb
+++ b/spec/lib/core/interactor/category_reader_spec.rb
@@ -87,6 +87,21 @@ module Core
         specify { expect(category).to be_a(Category) }
         specify { expect(category.contents).to be_empty }
       end
+
+      context 'when `legacy_contents` is provided' do
+        let(:legacy_contents) { %w(article_hash action_plan_hash).map(&method(:build)) }
+        let(:repo_category) { build :category_hash, id: id, legacy_contents: legacy_contents }
+        let(:repository) { Repository::Categories::Fake.new(repo_category) }
+        let(:category) { subject.call }
+
+        before do
+          allow(Registry::Repository).to receive(:[]).with(:category).and_return(repository)
+        end
+
+        [Article, ActionPlan].each_with_index do |klass, i|
+          specify { expect(category.legacy_contents[i]).to be_a(klass) }
+        end
+      end
     end
 
     context 'when category is redirected' do

--- a/spec/lib/core/interactor/category_reader_spec.rb
+++ b/spec/lib/core/interactor/category_reader_spec.rb
@@ -99,7 +99,9 @@ module Core
         end
 
         [Article, ActionPlan].each_with_index do |klass, i|
-          specify { expect(category.legacy_contents[i]).to be_a(klass) }
+          it "loads class #{klass}" do
+            expect(category.legacy_contents[i]).to be_a(klass)
+          end
         end
       end
     end


### PR DESCRIPTION
**Context**
The global nav works involves data changes which means that some existing urls will become unusable.
Some partners have links to certains of those pages and we will support (for some time?) the old urls of categories that have been splited up.

**Dependency**
- [x] Data changes [cms#366](https://github.com/moneyadviceservice/cms/pull/366)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1615)
<!-- Reviewable:end -->
