### PR TITLE
Removing the Sidenav from pages that don't need it

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -43,17 +43,7 @@ require(['common', 'jquery'], function(MAS, $) {
         .wrap('<div class="l-menu-nav"></div>');
 
       $('.mobile-nav__link--menu').attr('href', '#js-primary-nav');
-
-      // Mobile Nav
-      new Collapsable({
-        name: 'mobileNav',
-        closeOffFocus: false,
-        accordion: true,
-        triggerEl: '.mobile-nav a',
-        targetType: 'href',
-        parentWrapper: '#js-primary-nav'
-      });
-
+      
       // Article Collapsables
       new Collapsable({
         name: 'articleCollapsables',

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -7,7 +7,7 @@
   <%= render 'shared/breadcrumbs', breadcrumbs: @breadcrumbs unless @breadcrumbs.empty? %>
 <% end %>
 
-<div class="l-main editorial">
+<div class="l-2col-main editorial">
   <div class="l-main__row">
     <% if category.images? %>
       <%= render 'categories/category_image', small_url: category.small_image, large_url: category.large_image %>
@@ -30,7 +30,4 @@
 
 <div class="l-nav">
   <%= render 'shared/mas_sections_link' if category_within_corporate_section?(category) %>
-  <%= render 'shared/nav',
-             categories:        category_navigation(corporate_category?(category.object.id)),
-             active_categories: active_categories %>
 </div>

--- a/app/views/search_results/index.html.erb
+++ b/app/views/search_results/index.html.erb
@@ -1,7 +1,7 @@
 <% set_meta_tags(title:  t('.document_title'),
                  robots: 'noindex') %>
 
-<div class="l-main">
+<div class="l-2col-main">
   <div class="l-main__row">
     <main class="l-main__cell-single" role="main">
       <%= heading_tag t('.page_title') %>
@@ -11,8 +11,4 @@
       </div>
     </main>
   </div>
-</div>
-
-<div class="l-nav">
-  <%= render 'shared/nav', categories: category_navigation %>
 </div>

--- a/app/views/search_results/index_no_results.html.erb
+++ b/app/views/search_results/index_no_results.html.erb
@@ -8,7 +8,7 @@
   });
 </script>
 
-<div class="l-main">
+<div class="l-2col-main">
   <div class="l-main__row">
     <main class="l-main__cell-single" role="main">
       <%= heading_tag t('.page_title_html', query: params[:query]) %>
@@ -19,8 +19,4 @@
       </div>
     </main>
   </div>
-</div>
-
-<div class="l-nav">
-  <%= render 'shared/nav', categories: category_navigation %>
 </div>

--- a/app/views/search_results/index_with_results.html.erb
+++ b/app/views/search_results/index_with_results.html.erb
@@ -1,7 +1,7 @@
 <% set_meta_tags(title:  t('.document_title', query: params[:query]),
                  robots: 'noindex') %>
 
-<div class="l-main">
+<div class="l-2col-main">
   <div class="l-main__row">
     <main class="l-main__cell-single" role="main">
       <%= heading_tag t('.page_title_html', query: params[:query]) %>
@@ -17,8 +17,4 @@
       </div>
     </main>
   </div>
-</div>
-
-<div class="l-nav">
-  <%= render 'shared/nav', categories: category_navigation %>
 </div>


### PR DESCRIPTION
Removes the sidebar category nav from the search, search results, and Category pages. The only place we now show this is on the Article page.

![image](https://cloud.githubusercontent.com/assets/14920201/21053958/89ce647e-be23-11e6-8ae9-9e39fce178d1.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1624)
<!-- Reviewable:end -->
