### PR TITLE
[DEV APPROVED] - Fixes SCSS deprecation errors

### DIFF
--- a/app/assets/stylesheets/components/common/_icon_2x.scss
+++ b/app/assets/stylesheets/components/common/_icon_2x.scss
@@ -131,13 +131,15 @@
   }
 
   .icon--plus--blue {
-    @extend .icon--plus;
+    width: 16px;
+    height: 20px;
     background-position: -157px -224px;
   }
 
   .icon--minus--blue {
-    @extend .icon--minus;
     background-position: -182px -224px;
+    width: 16px;
+    height: 16px;
   }
 
   .icon--home {

--- a/app/assets/stylesheets/layout/page_specific/_article_page.scss
+++ b/app/assets/stylesheets/layout/page_specific/_article_page.scss
@@ -48,12 +48,8 @@
   }
 }
 
-%l-3col-side {
+.l-article-3col-left, .l-article-3col-right {
   @include column(12);
-
-  @include respond-to($mq-m) {
-    @include column(4);
-  }
 
   @include respond-to($mq-3col-layout) {
     @include column(3);
@@ -72,15 +68,10 @@
 
   @include respond-to($mq-3col-layout) {
     clear: none;
-    @extend %l-3col-side;
 
     .link-list-primary {
       @include column(12);
     }
-  }
-
-  @include respond-to($mq-l) {
-    margin-top: $baseline-unit*10;
   }
 
   .nav__strapline {
@@ -99,13 +90,13 @@
 }
 
 .l-article-3col-right {
-  @extend %l-3col-side;
-
   @include respond-to($mq-m) {
     position: relative;
+    @include column(4);
   }
 
   @include respond-to($mq-3col-layout) {
+    @include column(3);
     @include column-shift(3);
   }
 }


### PR DESCRIPTION
The below SCSS warnings occur whenever running Frontend. This PR fixes these, without any impact to the CSS that is generated:

```

15:10:37 web.1  | DEPRECATION WARNING on line 134 of /Users/mattsaywell/Repos/frontend/app/assets/stylesheets/components/common/_icon_2x.scss:
15:10:37 web.1  |   @extending an outer selector from within @media is deprecated.
15:10:37 web.1  |   You may only @extend selectors within the same directive.
15:10:37 web.1  |   This will be an error in Sass 3.3.
15:10:37 web.1  |   It can only work once @extend is supported natively in the browser.
15:10:37 web.1  |
15:10:37 web.1  |
15:10:37 web.1  | DEPRECATION WARNING on line 139 of /Users/mattsaywell/Repos/frontend/app/assets/stylesheets/components/common/_icon_2x.scss:
15:10:37 web.1  |   @extending an outer selector from within @media is deprecated.
15:10:37 web.1  |   You may only @extend selectors within the same directive.
15:10:37 web.1  |   This will be an error in Sass 3.3.
15:10:37 web.1  |   It can only work once @extend is supported natively in the browser.

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1634)
<!-- Reviewable:end -->
