### PR TITLE
[DEV APPROVED] 7847 - Fixing styleguide icons and adding SVGs

### DIFF
--- a/app/assets/stylesheets/components/common/_icon.scss
+++ b/app/assets/stylesheets/components/common/_icon.scss
@@ -27,12 +27,8 @@
 // .icon--account - green person icon
 // .icon--calculator - calculator icon
 // .icon--info - info icon
-// .icon--twitter - twitter icon
-// .icon--facebook - facebook
-// .icon--youtube - youtube
-// .icon--email - email
 //
-// Styleguide icons
+// Styleguide png-icons
 
 //= depend_on_asset icon-sprite.png
 
@@ -311,16 +307,6 @@
   width: 20px;
 }
 
-.svg {
-  .icon--stripe-banner-arrow {
-    display: none;
-  }
-
-  .svg-icon--stripe-banner-arrow {
-    display: block;
-  }
-}
-
 .icon--stripe-banner-arrow {
   background-position: -517px -426px;
   width:68px;
@@ -353,98 +339,17 @@
 }
 
 .icon--twitter {
-  display: block;
   background-position: -484px -445px;
 }
 
 .icon--facebook {
-  display: block;
   background-position: -456px -441px;
 }
 
 .icon--youtube {
-  display: block;
   background-position: -417px -443px;
 }
 
 .icon--email {
-  display: block;
   background-position: -664px -452px;
-}
-
-.svg-icon--twitter,
-.svg-icon--facebook,
-.svg-icon--youtube,
-.svg-icon--email {
-  display: none;
-}
-
-.svg-icon--twitter,
-.svg-icon--facebook,
-.svg-icon--youtube,
-.svg-icon--email {
-  vertical-align: middle;
-  fill: #fff;
-}
-
-.svg {
-  .icon--twitter,
-  .icon--facebook,
-  .icon--youtube,
-  .icon--email {
-    display: none;
-  }
-
-  .svg-icon--twitter,
-  .svg-icon--facebook,
-  .svg-icon--youtube,
-  .svg-icon--email {
-    display: block;
-  }
-}
-
-// In page feedback icons
-.svg-icon--thumb-icon,
-.svg-icon--thumb-button {
-  display: none;
-}
-
-.svg-icon--thumb-icon,
-.icon--thumb-icon-up,
-.icon--thumb-icon-down {
-  margin: 0 auto;
-  width: 40px;
-  height: 40px;
-}
-
-.svg-icon--thumb-button {
-  width: 35px;
-  height: 35px;
-}
-
-.icon--thumb-button {
-  margin: 0 auto;
-  width: 60px;
-  height: 60px;
-}
-
-.icon--thumb-icon-up {
-  background-position: -889px -440px;
-}
-
-.icon--thumb-icon-down {
-  background-position: -935px -436px;
-}
-
-.svg {
-  .icon--thumb-icon-up,
-  .icon--thumb-icon-down,
-  .icon--thumb-button {
-    display: none;
-  }
-
-  .svg-icon--thumb-icon,
-  .svg-icon--thumb-button {
-    display: block;
-  }
 }

--- a/app/assets/stylesheets/components/common/_icon.scss
+++ b/app/assets/stylesheets/components/common/_icon.scss
@@ -28,9 +28,9 @@
 // .icon--calculator - calculator icon
 // .icon--info - info icon
 // .icon--twitter - twitter icon
-// .icon--facebook - twitter facebook
-// .icon--youtube - twitter youtube
-// .icon--email - twitter email
+// .icon--facebook - facebook
+// .icon--youtube - youtube
+// .icon--email - email
 //
 // Styleguide icons
 
@@ -306,7 +306,7 @@
 }
 
 .icon--info {
-  background-position: -70px -260px;
+  background-position: -73px -102px;
   height: 25px;
   width: 20px;
 }

--- a/app/assets/stylesheets/components/common/_icon_2x.scss
+++ b/app/assets/stylesheets/components/common/_icon_2x.scss
@@ -168,7 +168,7 @@
     }
   }
 
-  .icon--email {
+  .icon--email, .icon--thumb-icon-up, .icon--thumb-icon-down  {
     background-size: auto; // hack because we don't have a double-density version
   }
 

--- a/app/assets/stylesheets/components/common/_icon_svg.scss
+++ b/app/assets/stylesheets/components/common/_icon_svg.scss
@@ -1,14 +1,64 @@
-// Styling for SVG icons, to be used instead of PNG sprite icons
+// We have an SVG element loaded at the top of each page containing a set of reusable SVG icons, which are referenced with the <use> tag from markup later in the page.
+// These are preferrable over PNG sprite icons. Where necessary there should be a PNG fallback for the same icon.
+// The advantages of using these is that we can alter colour and size with CSS, they offer support for all screen densities, as well as not requiring any extra HTTP requests to load.
+//
+// .svg-icon--plus - Plus icon
+// .svg-icon--minus - Minus icon
+// .svg-icon--arrow-right - Arrow
+// .svg-icon--arrow-left - Arrow left
+// .svg-icon--arrow-right - Arrow right
+// .svg-icon--desktop-close-box - Close box (desktop)
+// .svg-icon--mobile-close-box - Close box (mobile)
+// .svg-icon--facebook - Facebook
+// .svg-icon--twitter - Twitter
+// .svg-icon--youtube - Youtube
+// .svg-icon--email - Email
+// .svg-icon--stripe-banner-arrow - ARROW
+// .svg-icon--thumb-icon - Thumb
+//
+// Styleguide svg-icons
 
 .svg-icon {
+  display: block;
   html.no-svg & {
     display: none;
   }
 }
 
+// Normalise on the styleguide
+.styleguide-element .svg-icon {
+  fill: #000;
+  max-width: 40px;
+  max-height: 40px;
+  position: static;
+  margin: 0;
+}
+
 %small-svg-icon {
   width: 16px;
   height: 16px;
+}
+
+
+html.no-svg {
+
+  .no-svg-icon {
+    @extend .icon;
+  }
+
+  .no-svg-icon--default {
+    @extend %small-svg-icon;
+    background-color: #fff;
+    background-image: none;
+    border: 2px solid black;
+  }
+}
+
+html.svg {
+  // When browser supports SVG, hide any .icon siblings (PNG fallbacks) of the .svg-icon
+  .svg-icon + span.icon {
+    display: none;
+  }
 }
 
 // Plus
@@ -35,17 +85,43 @@
   fill: $color-blue-medium;
 }
 
-html.no-svg {
+// Social sharing
 
-  .no-svg-icon {
-    @extend .icon;
-  }
+.svg-icon--twitter,
+.svg-icon--facebook,
+.svg-icon--youtube,
+.svg-icon--email {
+  vertical-align: middle;
+  fill: #fff;
+  display: block;
+}
 
-  .no-svg-icon--default {
-    @extend %small-svg-icon;
-    background-color: #fff;
-    background-image: none;
-    border: 2px solid black;
-  }
 
+// On-page feedback icons
+
+.svg-icon--thumb-icon,
+.icon--thumb-icon-up,
+.icon--thumb-icon-down {
+  margin: 0 auto;
+  width: 40px;
+  height: 40px;
+}
+
+.svg-icon--thumb-button {
+  width: 35px;
+  height: 35px;
+}
+
+.icon--thumb-button {
+  margin: 0 auto;
+  width: 60px;
+  height: 60px;
+}
+
+.icon--thumb-icon-up {
+  background-position: -889px -440px;
+}
+
+.icon--thumb-icon-down {
+  background-position: -935px -436px;
 }

--- a/app/assets/stylesheets/styleguide/_example.scss
+++ b/app/assets/stylesheets/styleguide/_example.scss
@@ -109,7 +109,7 @@
 /* @lintingIgnoreBegin */
 
 // high contrast background for icons
-#section-icons .styleguide-element {
+#section-png-icons .styleguide-element, #section-svg-icons .styleguide-element {
   background-color: darken(#f9f9f9, 10%);
 }
 

--- a/app/views/styleguide/components_common.html.erb
+++ b/app/views/styleguide/components_common.html.erb
@@ -1,6 +1,12 @@
 <h1>Common Components</h1>
 
-<%= styleguide_section sections['icons'] do %>
+<%= styleguide_section sections['svg-icons'] do %>
+  <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon $modifier_class" focusable="false" data-di-res-id="474a5830-8911ba2c">
+    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#$modifier_class"></use>
+  </svg>
+<% end %>
+
+<%= styleguide_section sections['png-icons'] do %>
   <span class="icon $modifier_class"></span>
   <span class="visually-hidden">hidden text</span>
 <% end %>
@@ -37,8 +43,8 @@
         idea of how much a lender might offer for a mortgage, and if you could
         afford it. Actual amounts and affordability criteria will differ
         across lenders</p>
+      </div>
     </div>
-  </div>
 <% end %>
 
 <%= styleguide_section sections['validation-summary'] do %>


### PR DESCRIPTION
This PR:

- Fixes the missing `.icon--info` icon that is in the styleguide
- Adds a new styleguide section for SVG Icons, our preferred approach to spriting - see http://localhost:5000/en/styleguide/components/common for the new section
- Makes some of the display logic for SVG / PNG more generic rather than repeating the `display: none / block;` logic for each item
- Fixes the PNG fallback for the thumbs up / down icon on double-density screens

This relies upon this [Dough PR ](https://github.com/moneyadviceservice/dough/pull/281)

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1636)
<!-- Reviewable:end -->
