### PR TITLE
[DEV APPROVED]7876 - Adding callout styles

### DIFF
--- a/app/assets/stylesheets/amp_styles.css.scss
+++ b/app/assets/stylesheets/amp_styles.css.scss
@@ -1,5 +1,6 @@
 $responsive: true;
 @import 'dough/assets/stylesheets/lib/variables';
+@import 'yeast/assets/lib/variables';
 
 @font-face {
   font-family: Museo Sans;
@@ -123,23 +124,6 @@ strong {
   font-weight: 700;
 }
 
-.callout {
-  padding: 1.25rem 0 0.5rem 0;
-  margin: 1.5rem 0;
-  border-radius: 5px;
-  background-color: $color-green-pale;
-  clear: right;
-}
-
-.callout p {
-  margin: 0 1.125rem 1.125rem 1.125rem;
-}
-
-.callout h3 {
-  margin: 0 1.125rem 0.375rem;
-  text-transform: capitalize;
-}
-
 .add-action {
   position: relative;
   background-color: $color-blue-light;
@@ -161,3 +145,58 @@ strong {
   overflow: hidden;
   position: absolute;
 }
+
+.callout {
+  position: relative;
+  margin: $baseline-unit*2 0;
+  border-radius: 5px;
+  background-color: $color-callout-background;
+
+  h3 {
+    @extend %heading-small;
+    padding: $baseline-unit;
+  }
+
+  p {
+    @extend %type-callout;
+    margin: $baseline-unit*2;
+  }
+}
+
+%callout--editorial {
+  border-radius: 0;
+  background: none;
+
+  h3 {
+    color: white;
+    font-size: 1.1rem;
+    margin: 0;
+  }
+}
+
+.callout--tip {
+  @extend %callout--editorial;
+  border: 2px solid $color-turquoise;
+  h3 {
+    background: $color-turquoise;
+  }
+}
+
+.callout--tool {
+  @extend %callout--editorial;
+  border: 2px solid $color-orange-medium;
+  h3 {
+    background: $color-orange-medium;
+  }
+}
+
+.callout__icon,
+.callout__tool-icon {
+  display: none;
+}
+
+.callout--instructional {
+  border: none;
+  background-color: $color-panel-background;
+}
+


### PR DESCRIPTION
## 7876 - AMP Callout updates

The callout styles on the Google AMP pages needed to be brought inline with the new ones on the MAS site articles.

Google AMP supports some pseudo selectors (:not, :first-of-type, :last-of-type), but not :before or :after.  Because of this it was decided to remove the icons and go with a simpler approach for these mobile pages:

**Without a title**
<img width="620" alt="screen shot 2017-01-05 at 12 36 40" src="https://cloud.githubusercontent.com/assets/13165846/21680929/89f0097c-d344-11e6-8214-0eac6194a5fd.png">

**With a title**
<img width="605" alt="screen shot 2017-01-05 at 12 36 36" src="https://cloud.githubusercontent.com/assets/13165846/21680932/8bba3fca-d344-11e6-8486-e0377d949976.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1647)
<!-- Reviewable:end -->
