### PR TITLE
Fix issue with global nav showing more than subcategories under each tab

### DIFF
--- a/app/views/shared/_global_nav.html.erb
+++ b/app/views/shared/_global_nav.html.erb
@@ -25,11 +25,11 @@
 
               <ul class="global-subnav__categories">
                 <% clump.categories.each do |category| %>
-                  <li class="global-subnav__category <%= 'global-subnav__category--double' if category.contents.count > 5 %>">
+                  <li class="global-subnav__category <%= 'global-subnav__category--double' if category.categories.count > 5 %>">
                     <%= link_to category.title, main_app.category_path(category.id), class: 'global-subnav__category__heading' %>
 
                     <ul class="global-subnav__subcategories">
-                      <% category.contents.each do |subcategory| %>
+                      <% category.categories.each do |subcategory| %>
                         <li class="global-subnav__subcategory">
                           <%= link_to subcategory.title, main_app.category_path(subcategory.id), class: 'global-subnav__subcategory__link' %>
                         </li>

--- a/lib/core/entity/category.rb
+++ b/lib/core/entity/category.rb
@@ -3,6 +3,10 @@ module Core
     attr_accessor :type, :parent_id, :title, :description, :contents, :third_level_navigation, :images, :links, :category_promos, :legacy_contents, :legacy
     validates_presence_of :title
 
+    def categories
+      contents.delete_if { |c| c.type != 'category' }
+    end
+
     def third_level_navigation?
       third_level_navigation
     end

--- a/spec/lib/core/entity/category_spec.rb
+++ b/spec/lib/core/entity/category_spec.rb
@@ -37,5 +37,17 @@ module Core
 
       specify { expect(category_with_legacy_contents.legacy?).to be true }
     end
+
+    describe "#categories" do
+      let(:category) { double(type: 'category') }
+      let(:another_category) { double(type: 'category') }
+      let(:article) { double(type: 'article') }
+
+      before { attributes[:contents] = [category, article, another_category] }
+
+      it 'only returns the catgories' do
+        expect(subject.categories).to eq [category, another_category]
+      end
+    end
   end
 end


### PR DESCRIPTION
`category.contents` returns everything in a category - subcategories, articles, guides, etc.

Added a method to the `Category` entity to return just the categories and updated the global nav to use that instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1653)
<!-- Reviewable:end -->
