### PR TITLE
[DEV APPROVED] 7916 - Fixing share icons

### DIFF
--- a/app/assets/stylesheets/components/common/_icon_svg.scss
+++ b/app/assets/stylesheets/components/common/_icon_svg.scss
@@ -133,11 +133,4 @@ html.svg {
   .icon--email {
     display: none;
   }
- 
-  .svg-icon--twitter,
-  .svg-icon--facebook,
-  .svg-icon--youtube,
-  .svg-icon--email {
-    display: block;
-  }
 }

--- a/app/assets/stylesheets/components/common/_icon_svg.scss
+++ b/app/assets/stylesheets/components/common/_icon_svg.scss
@@ -125,3 +125,19 @@ html.svg {
 .icon--thumb-icon-down {
   background-position: -935px -436px;
 }
+
+.svg {
+  .icon--twitter,
+  .icon--facebook,
+  .icon--youtube,
+  .icon--email {
+    display: none;
+  }
+ 
+  .svg-icon--twitter,
+  .svg-icon--facebook,
+  .svg-icon--youtube,
+  .svg-icon--email {
+    display: block;
+  }
+}


### PR DESCRIPTION
## Frontend Social Share Icon Bug

In a previous PR to optimise the icons on the mas frontend site the piece of logic which hides the fallback icons if SVG's are supported was removed, this PR put that logic back in.

| Current Live | After |
|--------|------|
|![image](https://cloud.githubusercontent.com/assets/13165846/22057438/921821e4-dd5c-11e6-8700-966c7eaed90f.png)|![image](https://cloud.githubusercontent.com/assets/13165846/22057404/69bf6d6a-dd5c-11e6-9f51-acac4aeb5635.png)|

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1658)
<!-- Reviewable:end -->
