### PR TITLE
[DEV APPROVED] 7944 - CSS fallback for JS behaviour whilst JS is downloading

### DIFF
--- a/app/assets/javascripts/components/GlobalNav.js
+++ b/app/assets/javascripts/components/GlobalNav.js
@@ -33,6 +33,7 @@ define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities', 'common'], 
     this._setUpDesktopInteraction();
     this._setUpMobileAnimation();
     this._setUpKeyboardEvents();
+    this.$globalNav.removeClass('uninitialised');
 
     $(window).on('resize', utilities.debounce($.proxy(this._setUpMobileAnimation, this), 100));
 

--- a/app/assets/stylesheets/components/common/_global_subnav.scss
+++ b/app/assets/stylesheets/components/common/_global_subnav.scss
@@ -42,7 +42,7 @@ $gutter: $default-gutter / 2; // the space between category columns
 }
 
 // no-js fallback --
-.no-js {
+.uninitialised {
   @include respond-to($mq-m) {
     .global-nav__clump__heading {
       &:hover {

--- a/app/views/shared/_global_nav.html.erb
+++ b/app/views/shared/_global_nav.html.erb
@@ -1,4 +1,4 @@
-<nav class="global-nav" role="navigation" aria-label="main" id="global-nav" tabindex="-1" data-dough-component="GlobalNav">
+<nav class="global-nav uninitialised" role="navigation" aria-label="main" id="global-nav" tabindex="-1" data-dough-component="GlobalNav">
   <div class="l-constrained">
     <ul data-dough-nav-clumps class="global-nav__clumps" role="menubar" aria-label="main site navigation">
       <% clumps.each do |clump| %>


### PR DESCRIPTION
At the moment there is a brief delay (whilst JS is downloading) where the Global Nav is unusable - hovering on the clump headings does nothing. 

This PR leverages the work already done by @davidtrussler on the no-JS / CSS-hover only code, and makes this behaviour apply until the JS component has downloaded and executed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1667)
<!-- Reviewable:end -->
