### PR TITLE
[DEV APPROVED] TP: 7944, Comment: Disables click event on clump headings

### DIFF
--- a/app/assets/javascripts/components/GlobalNav.js
+++ b/app/assets/javascripts/components/GlobalNav.js
@@ -219,8 +219,10 @@ define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities', 'common'], 
     });
 
     this.$globalNavClumpHeading.click(function(e) {
-      e.preventDefault();
-      self._toggleMobileSubNav(this);
+      if (mediaQueries.atSmallViewport()) {
+        e.preventDefault();
+        self._toggleMobileSubNav(this);
+      }
     });
 
     this.$globalSubNavHeading.click(function(e) {


### PR DESCRIPTION
This disables the click event on the clump headings on desktop view only, which are not links to another area of the site and also have hover events attached to them. It has been added because it is confusing for the user to have both click and hover events on these elements, which cancel each other out.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1673)
<!-- Reviewable:end -->
