### PR TITLE
[DEV APPROVED] TP: 7978, Comment: Removes focus from clump headings for mouse events

### DIFF
--- a/app/assets/javascripts/components/GlobalNav.js
+++ b/app/assets/javascripts/components/GlobalNav.js
@@ -255,6 +255,9 @@ define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities', 'common'], 
           self._sendHoverAnalytics($(e.target).text());
           self._openDesktopSubNav($(e.target).parents('[data-dough-nav-clump-heading]'));
         }, self.delay);
+      })
+      .mousedown(function(e) {
+        e.preventDefault();
       });
 
     this.$globalNav


### PR DESCRIPTION
This disables focus on the global nav top level menu when clicked. This is to avoid confusing behaviour for the user whereby mouse events serve no other purpose (there is no link to follow and the sub-menu is opened by the hover event). 

Focus is retained when the user is navigating by keyboard (tab or left/right arrow) which is necessary because another keyboard action (enter or down arrow) is then required to open the sub-menu.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1675)
<!-- Reviewable:end -->
