### PR TITLE
[DEV APPROVED]7979 - Global Nav - responsive homepage restyle

### DIFF
--- a/app/assets/stylesheets/components/page_specific/_home_top.scss
+++ b/app/assets/stylesheets/components/page_specific/_home_top.scss
@@ -3,7 +3,6 @@
 // Styleguide Home Top
 
 .home-top {
-  padding-bottom: 50%;
   position: relative;
   overflow: hidden;
 
@@ -11,53 +10,64 @@
     padding-bottom: 0;
   }
 
-  @include respond-to($mq-xl) {
-    .theme-cy & {
-      background: none;
-    }
+  @include respond-to($mq-l) {
+    display: flex;
   }
-
 }
 
 .home-top-left,
 .home-top-right {
-  @include column(12);
+  width: 100%;
+  overflow: hidden;
+  float: left;
+}
 
+.home-top-right {
+  position: relative;
+  @include respond-to($mq-s) {
+    padding: 0 $baseline-unit*2;
+  }
+  @include respond-to($mq-m) {
+    padding: 0;
+    width: 33%;
+  }
+  @include respond-to($mq-m, $mq-m-max) {
+    padding-top: $baseline-unit * 4;
+  }
   @include respond-to($mq-l) {
-    @include column(6);
+    display: flex;
+    width: 50%;
+  }
+}
+
+.home-top-left {
+  @include respond-to($mq-m) {
+    width: 66%;
+  }
+  @include respond-to($mq-l) {
+    display: flex;
+    width: 50%;
   }
 }
 
 .home-top-trust {
   position: relative;
-  margin-top: $baseline-unit*7;
-  margin-bottom: $baseline-unit*7;
+  margin-top: $baseline-unit*4;
+  margin-bottom: $baseline-unit*4;
 
   @include respond-to($mq-xl) {
+    margin-top: $baseline-unit*7;
+    margin-bottom: $baseline-unit*7;
     width: 1000px;
   }
 }
 
 .home-top__image {
   background-repeat: no-repeat;
-  background-size: contain;
+  background-size: cover;
   bottom: 0;
   padding-top: 55.64%;
-  position: absolute;
   width: 100%;
-
-  @include respond-to($mq-m) {
-    padding-top: 33%;
-    right: 0;
-    width: 50%;
-    position: relative;
-  }
-
-  @include respond-to($mq-l) {
-    background-position: right;
-    padding-top: 28%;
-    position: absolute;
-  }
 
   @if $responsive == false {
     display: none;
@@ -69,7 +79,7 @@
   @include body(36, 42);
   color: $color-heading-extra-small;
   margin: 0;
-  padding-bottom: $baseline-unit*7;
+  padding-bottom: $baseline-unit*4;
   padding-top: 0;
 
   @include respond-to($mq-small-tablet, $mq-small-tablet-end) {
@@ -77,27 +87,19 @@
   }
 
   @include respond-to($mq-m) {
-    @include body(42, 48);
-
-    .theme-cy & {
-      max-width: 600px;
-    }
+    @include body(36, 40);
   }
 
   @include respond-to($mq-l) {
+    @include body(40, 44);
+    padding-bottom: $baseline-unit*5;
     max-width: 530px;
-
-    .theme-cy & {
-      max-width: 500px;
-    }
   }
 
   @include respond-to($mq-xl) {
     max-width: 620px;
-
-    .theme-cy & {
-      max-width: 750px;
-    }
+    padding-bottom: $baseline-unit*7;
+    @include body(42, 48);
   }
 
   @if $responsive == false {
@@ -118,16 +120,6 @@
 
   @include respond-to($mq-l) {
     max-width: none;
-
-    .theme-cy & {
-      max-width: 570px;
-    }
-  }
-
-  @include respond-to($mq-l, $mq-xl) {
-    .theme-cy & {
-      max-width: 50%;
-    }
   }
 }
 
@@ -136,7 +128,13 @@
   clear: none;
   margin: 0;
   position: absolute;
-  right: 0;
+  @include respond-to($mq-m, $mq-m-max) {
+    position: static;
+    margin-bottom: $baseline-unit*4;
+  }
+  @include respond-to($mq-m) {
+    right: 0;
+  }
 }
 
 .home-top-promo__text {
@@ -146,18 +144,23 @@
   background: rgba(0,0,0,0.8);
   border-top-left-radius: 6px;
   border-top-right-radius: 6px;
-  margin: 0 $baseline-unit*3;
+  margin: 0 $baseline-unit;
   max-width: 400px;
   padding: $baseline-unit $baseline-unit*7 $baseline-unit $baseline-unit*4;
   position: relative;
 
+  @include respond-to($mq-m, $mq-m-max) {
+    border-radius: 0;
+    margin: 0;
+  }
+
   @include respond-to($mq-m) {
-    margin: $baseline-unit*2 0 0;
     padding: $baseline-unit*2 $baseline-unit*8 $baseline-unit*2 $baseline-unit*4;
   }
 
   @include respond-to($mq-l) {
-    width: 80%;
+    margin: $baseline-unit*2 0 0;
+    width: 90%;
   }
 }
 

--- a/app/assets/stylesheets/components/page_specific/_promo.scss
+++ b/app/assets/stylesheets/components/page_specific/_promo.scss
@@ -92,6 +92,6 @@
   width: 21px;
 
   @include respond-to($mq-l) {
-    top: 13%;
+    top: 15px;
   }
 }

--- a/app/assets/stylesheets/layout/page_specific/_homepage.scss
+++ b/app/assets/stylesheets/layout/page_specific/_homepage.scss
@@ -1,5 +1,4 @@
 .l-home-top {
-  @include column(12);
   width: 100%;
   margin: 0;
 

--- a/app/assets/stylesheets/layout/page_specific/_homepage.scss
+++ b/app/assets/stylesheets/layout/page_specific/_homepage.scss
@@ -16,14 +16,6 @@
       margin-bottom: $baseline-unit*9;
     }
   }
-
-  .home-top-promo {
-    @include column(12);
-
-    @include respond-to($mq-m) {
-      @include column(6);
-    }
-  }
 }
 
 .l-homepage-divider {

--- a/app/assets/stylesheets/layout/page_specific/_promos.scss
+++ b/app/assets/stylesheets/layout/page_specific/_promos.scss
@@ -1,35 +1,12 @@
 .l-tool-promos {
   @extend %clearfix;
   overflow: hidden;
+  background: $color-grey-pale;
+  padding-top: $baseline-unit*2;
+}
+
+.l-tool-promos__inner {
   position: relative;
-  margin-top: $baseline-unit*6;
-
-  .flexbox & {
-    display: flex;
-    flex-flow: column;
-
-    @include respond-to($mq-m) {
-      display: block;
-      flex-flow: row nowrap;
-      flex-wrap: nowrap;
-    }
-
-    @include respond-to($mq-l) {
-      display: flex;
-      flex-flow: row;
-      flex-wrap: wrap;
-
-      &:after {
-        @include column(12);
-        content: "";
-        display: block;
-        width: 100%;
-        border-bottom: 1px solid $color-grey-seven;
-        position: relative;
-        top: -1px;
-      }
-    }
-  }
 }
 
 .l-tool-promos__heading {
@@ -105,12 +82,6 @@
     @include column(3);
     border-top: 0;
     margin-bottom: 0;
-  }
-
-  .flexbox & {
-    @include respond-to($mq-l) {
-      flex-basis: 21.55%;
-    }
   }
 
   .l-promos--articles & {

--- a/app/views/shared/_home_top.html.erb
+++ b/app/views/shared/_home_top.html.erb
@@ -1,7 +1,6 @@
 <div class="l-home-top">
-  <div class="home-top">
-    <div class="l-constrained">
-      
+  <div class="l-constrained">
+    <div class="home-top">
       <div class="home-top-left">
         <div class="home-top-trust">
           <p class="home-top-trust__heading"><%= item.heading %></p>

--- a/app/views/shared/_tool_promos.html.erb
+++ b/app/views/shared/_tool_promos.html.erb
@@ -1,5 +1,5 @@
-<div class="l-constrained">
-  <section class="l-tool-promos">
+<section class="l-tool-promos">
+  <div class="l-constrained l-tool-promos__inner">
     <%= link_to(t('home.show.tools_view_all'), class: 'l-tool-promos__item promo__link') do %>
       <span class="icon icon--calculator l-tool-promos__calculator"></span>
       <%= heading_tag(level: 2, class: 'l-tool-promos__heading') do %>
@@ -20,5 +20,6 @@
         <%= render 'shared/svg/use_icon', icon: 'arrow-right', class_name: 'promo__arrow' %>
       <% end %>
     <% end %>
-  </section>
-</div>
+  </div>
+</section>
+

--- a/app/views/shared/_tool_promos.html.erb
+++ b/app/views/shared/_tool_promos.html.erb
@@ -22,4 +22,3 @@
     <% end %>
   </div>
 </section>
-


### PR DESCRIPTION
In PR #1674 we are removing the 'Category Directory' from the homepage. This leaves us with a few layout issues with components on the homepage.

This PR:

- Adds a grey background to the 'popular tools and calculators' section that now follows the hero slot
- Changes the way that the homepage handles 'medium' width viewports - see images below - the layout is significantly different. I have also changed some font-sizes and given the hero slot a new layout at medium width viewports.
- Slightly alters the way that the full-width layout appears - the right-hand-side hero image is now constrained within its container

**Screenshots are at around 800px width, but to get a feel for the changes I would recommend local testing / resizing browser window**

New version: 
![image](https://cloud.githubusercontent.com/assets/14920201/22657147/59d2e202-ec8d-11e6-9206-f10ede164532.png)

Production: 
![image](https://cloud.githubusercontent.com/assets/14920201/22657158/6635a8b8-ec8d-11e6-8cec-e090e11afffb.png)


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1676)
<!-- Reviewable:end -->
