### PR TITLE
7983 - Global nav - adding blog link

### DIFF
--- a/app/views/shared/_footer_primary.html.erb
+++ b/app/views/shared/_footer_primary.html.erb
@@ -90,7 +90,7 @@
         </ul>
 
         <div class="footer-primary__blog">
-          <a class="footer-primary__blog-link" href="<%= t('footer.blog_link') %>" target="_blank"><%= t('footer.blog') %></a>
+          <a class="footer-primary__blog-link" href="<%= t('blog_link') %>" target="_blank"><%= t('footer.blog') %></a>
         </div>
       </nav>
     </div>

--- a/app/views/shared/_global_nav.html.erb
+++ b/app/views/shared/_global_nav.html.erb
@@ -64,7 +64,7 @@
       <% end %>
 
       <li class="global-nav__blog" role="none">
-        <a href="#" class="global-nav__clump__blog-link" aria-haspopup="false" role="menuitem">
+        <a href="<%= t('blog_link') %>" class="global-nav__clump__blog-link" aria-haspopup="false" role="menuitem">
           Blog
         </a>
         <a data-dough-mobile-nav-close class="global-nav__close-button" href="#" role="button">  <%= t('mobile_nav.close') %>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -18,6 +18,8 @@ cy:
 
   back_to_top: Ewch i'r brig
 
+  blog_link: https://www.moneyadviceservice.org.uk/blog
+
   breadcrumbs:
    aria_label: briwsion bara
 
@@ -265,7 +267,6 @@ cy:
     news: Newyddion ac erthyglau
     news_link: /cy/news
     blog: Blog
-    blog_link: https://www.moneyadviceservice.org.uk/blog
     tools_and_resources: Offer a chyfrifianellau
     tools_and_resources_link: /cy/categories/tools-and-calculators
     site_map: Map safle

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,6 +16,8 @@ en:
 
   back_to_top: Back to top
 
+  blog_link: https://www.moneyadviceservice.org.uk/blog
+
   breadcrumbs:
    aria_label: breadcrumbs
 
@@ -266,7 +268,6 @@ en:
     news_link: /en/news
     partners_link: /en/corporate_categories/partners
     blog: Blog
-    blog_link: https://www.moneyadviceservice.org.uk/blog
     tools_and_resources: Tools & calculators
     tools_and_resources_link: /en/categories/tools-and-calculators
     site_map: Sitemap


### PR DESCRIPTION
We forgot to add the blog link to the Global nav. This PR adds the `href` to the link, and re-organises the yaml file that contains it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1680)
<!-- Reviewable:end -->
