### PR TITLE
[DEV APPROVED] - TP: 7993, Comment: Fixes fallback for non-FlexBox browsers

### DIFF
--- a/app/assets/stylesheets/components/common/_global_nav.scss
+++ b/app/assets/stylesheets/components/common/_global_nav.scss
@@ -105,7 +105,6 @@ $global-nav-transition-duration: 300ms;
 
     /* non-FlexBox compliant -- */
     display: table-cell;
-    width: (100% / 8);
     vertical-align: bottom;
     /* -- non-FlexBox compliant */
 
@@ -160,8 +159,18 @@ $global-nav-transition-duration: 300ms;
   margin-bottom: 0;
   min-width: 5.5em;
 
-  @include respond-to($mq-m, $mq-m-max) {
+  @include respond-to($mq-m) {
     display: none;
+
+    /* non-FlexBox compliant -- */
+    vertical-align: middle;
+    /* -- non-FlexBox compliant */
+  }
+
+  @include respond-to($mq-m-max) {
+    /* non-FlexBox compliant -- */
+    display: table-cell;
+    /* -- non-FlexBox compliant */
   }
 }
 
@@ -251,11 +260,13 @@ $global-nav-transition-duration: 300ms;
   &:focus {
     background: $color-mas-blog-blue;
     text-decoration: none;
+    color: $color-white;
   }
 
   &:hover {
     background: $color-mas-blog-blue-hover;
     text-decoration: none;
+    color: $color-white;
   }
 
   .global-nav__arrow {
@@ -324,11 +335,20 @@ a.global-nav__close-button {
       justify-content: center;
     }
 
-    .global-nav__clump {
-      display: inline-block;
-      width: auto;
+    .global-nav__clump,
+    .global-nav__blog {
       flex-grow: 1;
       flex-shrink: 1;   // IE10 fix
+    }
+
+    .global-nav__clump {
+      display: inline-block;
+    }
+  }
+
+  @include respond-to($mq-m-max) {
+    .global-nav__blog {
+      display: inline-block;
     }
   }
 }


### PR DESCRIPTION
- blog link given same property as other clumps to fix issue where this element breaks layout by being forced onto a second line
- also fixes hover/focus states of this link to be consistent with the footer blog link

Blog link forced onto second line breaks layout: 

![image](https://cloud.githubusercontent.com/assets/6080548/22880510/59475898-f1da-11e6-8c3f-d98489eb8be8.png)

Blog link brought into line: 

![image](https://cloud.githubusercontent.com/assets/6080548/22880536/7564c358-f1da-11e6-85dd-09e2e49c4a89.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1684)
<!-- Reviewable:end -->
