### PR TITLE
Add custom backtrace silencers to stop custom middlewares obscuring application backtraces

### DIFF
--- a/config/initializers/backtrace_silencers.rb
+++ b/config/initializers/backtrace_silencers.rb
@@ -1,0 +1,5 @@
+# You can add backtrace silencers for libraries that you're using but don't wish to see in your backtraces.
+Rails.backtrace_cleaner.add_silencer { |line| line =~ /^app\/middleware\// }
+
+# You can also remove all the silencers if you're trying to debug a problem that might stem from framework code.
+# Rails.backtrace_cleaner.remove_silencers!


### PR DESCRIPTION
This is something that's bugged me for some time on several projects and I only came across an explanation of what's going on the other day. Rails also nowadays includes a template initializer for this sort of thing in newly generated applications.

In short, when we have custom middlewares they produce entries upstream of our application backtrace and unless we tell Rails to ignore them, it won't know that that's not a relevant part to show us in the event of an exception.

**Example: problem with an unexpected nil in my UC engine conversion**

<img width="1005" alt="screen shot 2017-02-17 at 15 26 54" src="https://cloud.githubusercontent.com/assets/9943/23071356/fdde7622-f525-11e6-9a7f-8bf621ff43a5.png">

<img width="1345" alt="screen shot 2017-02-17 at 15 29 35" src="https://cloud.githubusercontent.com/assets/9943/23071360/01cf7380-f526-11e6-9897-8a07bbfdc5a6.png">

So if we tell the backtrace silencer to ignore those four custom middlewares:

<img width="1002" alt="screen shot 2017-02-17 at 15 26 23" src="https://cloud.githubusercontent.com/assets/9943/23071590/cec1d66c-f526-11e6-9eb5-ffe2c459f955.png">

<img width="1331" alt="screen shot 2017-02-17 at 15 29 21" src="https://cloud.githubusercontent.com/assets/9943/23071612/ddff4ce0-f526-11e6-99c8-096ac5455439.png">

Much more helpful!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1687)
<!-- Reviewable:end -->
