### PR TITLE
[DEV APPROVED] - Add a environment variable for all http requests timeout

### DIFF
--- a/.env
+++ b/.env
@@ -2,6 +2,7 @@ MAS_PUBLIC_WEBSITE_URL=https://www.moneyadviceservice.org.uk/:locale/
 MAS_CMS_URL=http://cms.qa.dev.mas.local
 MAS_CMS_API_TOKEN=mytoken
 MAS_CONTENT_SERVICE_URL=http://localhost:8080/content-service/
+FRONTEND_HTTP_REQUEST_TIMEOUT=10
 GOOGLE_API_KEY=AIzaSyCydfZlpTZlIUUUSbtab5t0oOE-y1GzHy0
 GOOGLE_API_CX_EN=011931388747222259444:razn90vopwc
 GOOGLE_API_CX_CY=011931388747222259444:4thmbtghtbq

--- a/lib/core/connection_factory/http.rb
+++ b/lib/core/connection_factory/http.rb
@@ -5,7 +5,9 @@ require 'faraday/conductivity'
 module Core
   module ConnectionFactory
     class Http
-      def self.build(url, timeout: 5, open_timeout: 5, retries: 2)
+      TIMEOUT = ENV.fetch('FRONTEND_HTTP_REQUEST_TIMEOUT').to_i
+
+      def self.build(url, timeout: TIMEOUT, open_timeout: TIMEOUT, retries: 2)
         options    = { url: url, request: { timeout: timeout, open_timeout: open_timeout } }
         connection = Faraday.new(options) do |faraday|
           faraday.request :json

--- a/spec/lib/core/connection_factory/http_spec.rb
+++ b/spec/lib/core/connection_factory/http_spec.rb
@@ -5,12 +5,12 @@ RSpec.describe Core::ConnectionFactory::Http, '.build' do
     expect(factory).to be_a(Core::Connection::Http)
   end
 
-  it 'has a default timeout of 5 seconds' do
-    expect(factory.options[:timeout]).to eq(5)
+  it 'has a timeout between 5 and 12 seconds' do
+    expect(factory.options[:timeout]).to be_within(5).of(12)
   end
 
-  it 'has a default open timeout of 5 seconds' do
-    expect(factory.options[:open_timeout]).to eq(5)
+  it 'has a open timeout between 5 and 12 seconds' do
+    expect(factory.options[:open_timeout]).to be_within(5).of(12)
   end
 
   it 'defaults to encoding JSON requests' do


### PR DESCRIPTION
The TL; DR we are living on the edge for one request to return 500 every hour on the site or when someone deploys the site.
 
## Context 
 
QA homepage was returning 500 internal server error. The logs shown the site returns 500 but CMS returns 200. Investigating more see it is *exceeding the timeout.*
 
The site makes the request to the CMS and CMS (on QA) takes more than 5 seconds to respond to the categories url (details here: https://cms.qa.dev.mas.local/api/en/categories.json).

Since we have 5 seconds as timeout on the site I decided to "measure" (gross way to measure I would say) how long it is taking *in production*.
It is taking between 4.600 sec to 4.800sec on my machine.
You can run `time curl -XGET https://cms.moneyadviceservice.org.uk/api/en/categories.json` to confirm it what I said. Or use curl with w option that gives the time_total almost look like mentioned above.
 
This PR and https://github.com/moneyadviceservice/scripts/pull/918 addresses the solution.
 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1688)
<!-- Reviewable:end -->
