### PR TITLE
[DEV APPROVED]8057 Related Links nav bug

### DIFF
--- a/app/assets/javascripts/components/StickyColumn.js
+++ b/app/assets/javascripts/components/StickyColumn.js
@@ -105,7 +105,6 @@ define(['jquery', 'DoughBaseComponent', 'eventsWithPromises'], function($, Dough
   StickyColumn.prototype._showInSidebar = function() {
     this.$parent.css('height', this.contentHeight - this.topMargin);
     this.$el.css('width', this.$parent.width());
-    this.$el.css('left', this.$parent.offset().left);
   };
 
   /**


### PR DESCRIPTION
There was a fix for IE 8 that caused the sticky nav to flow off the screen to the right. I checked and the fix is not required anymore and removed. I fixed the bug by removing the left positioning call in the js file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1692)
<!-- Reviewable:end -->
