### PR TITLE
[DEV APPROVED] TP: 8028, Comment: Set Talkback/VoiceOver to reflect state of nav

### DIFF
--- a/app/assets/javascripts/components/GlobalNav.js
+++ b/app/assets/javascripts/components/GlobalNav.js
@@ -299,12 +299,15 @@ define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities', 'common'], 
     this.$globalNav.toggleClass('is-active');
     this.$mobileNavOverlay.toggleClass('is-active');
 
-    // If we just closed the nav, reset all subnavs
+    // Reset all subnavs and aria-expanded attribute when the nav is closed
     if (!this.$globalNav.hasClass('is-active')) {
+      this.$mobileNavButton.attr('aria-expanded', 'false');
       this.$globalNav.removeClass('is-active');
       this.$mobileNavOverlay.removeClass('is-active');
       this.$globalNavClumps.removeClass('is-active');
       this.$globalNavClump.removeClass('is-active');
+    } else {
+      this.$mobileNavButton.attr('aria-expanded', 'true');
     }
   };
 

--- a/app/views/shared/_mobile_nav.html.erb
+++ b/app/views/shared/_mobile_nav.html.erb
@@ -1,7 +1,12 @@
 <ul class="mobile-nav">
   <% unless hide_elements_irrelevant_for_third_parties? %>
     <li class="mobile-nav__item">
-      <a data-dough-mobile-nav-button class="mobile-nav__link mobile-nav__link--menu" href="#" role="button"><%= t('mobile_nav.menu') %></a>
+      <a
+        data-dough-mobile-nav-button class="mobile-nav__link mobile-nav__link--menu"
+        href="#"
+        role="button"
+        aria-expanded="false"
+      ><%= t('mobile_nav.menu') %></a>
     </li>
   <% end %>
   <% if display_search_box_in_header? %>


### PR DESCRIPTION
This updates the nav so that TalkBack (on Android) and Voiceover (on iOS) read the changed state of the menu when activated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1694)
<!-- Reviewable:end -->
