### PR TITLE
[DEV APPROVED] TP: 7996, Comment: Adds alternative navigation for non-js users

### DIFF
--- a/app/assets/stylesheets/components/common/_global_nav.scss
+++ b/app/assets/stylesheets/components/common/_global_nav.scss
@@ -134,6 +134,14 @@ $global-nav-transition-duration: 300ms;
   }
 }
 
+// no-js fallback --
+.no-js {
+  .global-nav {
+    display: none;
+  }
+}
+// -- no-js fallback
+
 .touch {
   .global-nav__clump {
     &:hover {

--- a/app/assets/stylesheets/components/common/_mobile_nav.scss
+++ b/app/assets/stylesheets/components/common/_mobile_nav.scss
@@ -16,6 +16,10 @@
   @include respond-to($mq-m) {
     margin: $baseline-unit*1.5 $baseline-unit $baseline-unit*1.5 0;
   }
+
+  .no-js & {
+    display: none;
+  }
 }
 
 .mobile-nav__link {
@@ -106,12 +110,12 @@
   transition: opacity 0.4s;
   top: 0;
   left: 0;
-  
+
   &.is-active {
     opacity: 1;
     bottom: 0;
     right: 0;
-    
+
     @include respond-to($mq-m) {
       display: none;
     }

--- a/app/assets/stylesheets/components/common/_no-js_nav.scss
+++ b/app/assets/stylesheets/components/common/_no-js_nav.scss
@@ -1,0 +1,72 @@
+// Footer Navigation
+//
+// Styleguide Footer Navigation
+
+.no-js-nav {
+  display: none;
+  padding-top: $baseline-unit*14;
+
+  .no-js & {
+    display: block;
+  }
+
+  @include respond-to($mq-m) {
+    background: $color-yellow-light;
+    padding-top: 0;
+  }
+}
+
+.no-js-nav__categories {
+  @include column(12);
+
+  list-style: none;
+  padding: 0;
+  margin-top: $baseline-unit*2;
+  margin-bottom: $baseline-unit*2;
+  font-size: 1rem;
+}
+
+.no-js-nav__category {
+  float: left;
+  padding-right: $baseline-unit;
+  margin-right: $baseline-unit;
+  border-right: solid 1px;
+  line-height: 1rem;
+  margin-top: $baseline-unit;
+  margin-bottom: $baseline-unit;
+
+  @include respond-to($mq-s) {
+    padding-right: $baseline-unit*3;
+    margin-right: $baseline-unit*3;
+  }
+}
+
+.no-js-nav__category:last-child {
+  padding-right: 0;
+  margin-right: 0;
+  border-right: none;
+}
+
+.no-js-nav__link {
+  font-size: 0.875rem;
+  color: $color-black;
+
+  &:hover,
+  &:focus,
+  &:visited {
+    color: $color-black;
+  }
+
+  &:focus {
+    @include focus-outline;
+  }
+
+  @include respond-to($mq-m) {
+    font-weight: 700;
+
+    &:focus {
+      background: $color-grey-pale;
+      outline-color: $color-grey-pale;
+    }
+  }
+}

--- a/app/views/layouts/_application_shared.html.erb
+++ b/app/views/layouts/_application_shared.html.erb
@@ -9,6 +9,7 @@
 
   <%= render 'shared/alerts' if alerts? %>
   <%= render 'shared/header' %>
+  <%= render 'shared/no_js_nav' %>
   <%= render 'shared/global_nav' %>
 
   <%= yield %>

--- a/app/views/shared/_no_js_nav.html.erb
+++ b/app/views/shared/_no_js_nav.html.erb
@@ -1,0 +1,17 @@
+<nav class="no-js-nav" role="navigation" aria-label="main" tabindex="-1">
+  <div class="l-constrained">
+    <ul class="no-js-nav__categories" role="menubar" aria-label="main site navigation">
+      <% clumps.each do |clump| %>
+        <% clump.categories.each do |category| %>
+          <li class="no-js-nav__category" role="none">
+            <%= link_to category.title, main_app.category_path(category.id), role: 'menuitem', class: 'no-js-nav__link' %>
+          </li>
+        <% end %>
+      <% end %>
+
+      <li class="no-js-nav__category" role="none">
+        <a href="<%= t('blog_link') %>" class="no-js-nav__link" role="menuitem">Blog</a>
+      </li>
+    </ul>
+  <div>
+</nav>


### PR DESCRIPTION
It is not possible to navigate the current global nav via keyboard commands with JavaScript disabled or if JavaScript does not load. This PR adds an alternative navigation that displays in these circumstances and allows keyboard-only users to be able to navigate the site. 


**Alternate nav on desktop:** 

![image](https://cloud.githubusercontent.com/assets/6080548/24661137/7b079fec-1949-11e7-9f65-4547a6554aa0.png)


**Alternate nav on mobile:** 

![image](https://cloud.githubusercontent.com/assets/6080548/24661182/9df254f2-1949-11e7-87c7-54e68436d007.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1709)
<!-- Reviewable:end -->
