### PR TITLE
[DEV APPROVED] TP: 8149, Comment: Fixes display issue with Social Sharing icons

### DIFF
--- a/app/assets/stylesheets/components/common/_icon_svg.scss
+++ b/app/assets/stylesheets/components/common/_icon_svg.scss
@@ -93,9 +93,31 @@ html.svg {
 .svg-icon--email {
   vertical-align: middle;
   fill: #fff;
+  display: none;
+}
+
+.icon--twitter,
+.icon--facebook,
+.icon--youtube,
+.icon--email {
   display: block;
 }
 
+.svg {
+  .icon--twitter,
+  .icon--facebook,
+  .icon--youtube,
+  .icon--email {
+    display: none;
+  }
+
+  .svg-icon--twitter,
+  .svg-icon--facebook,
+  .svg-icon--youtube,
+  .svg-icon--email {
+    display: block;
+  }
+}
 
 // On-page feedback icons
 
@@ -124,15 +146,6 @@ html.svg {
 
 .icon--thumb-icon-down {
   background-position: -935px -436px;
-}
-
-.svg {
-  .icon--twitter,
-  .icon--facebook,
-  .icon--youtube,
-  .icon--email {
-    display: none;
-  }
 }
 
 // Clear English Standard


### PR DESCRIPTION
This PR is related to PR https://github.com/moneyadviceservice/frontend/pull/1713 and adds to that to deal with an issue with the Social Sharing icons. 

These icons display wrongly in non-JavaScript environments: 

![image](https://cloud.githubusercontent.com/assets/6080548/24871064/512c0688-1e10-11e7-94d3-3ce09a0f20a2.png)

This PR refactors the CSS to fix this, which is caused by the SVG and PNG versions of the icons both displaying in this instance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1714)
<!-- Reviewable:end -->
