### PR TITLE
8149 icons display issue no js

### DIFF
--- a/app/assets/stylesheets/components/common/_icon_svg.scss
+++ b/app/assets/stylesheets/components/common/_icon_svg.scss
@@ -15,6 +15,7 @@
 // .svg-icon--email - Email
 // .svg-icon--stripe-banner-arrow - ARROW
 // .svg-icon--thumb-icon - Thumb
+// .svg-icon--clear-english - Clear English icon
 //
 // Styleguide svg-icons
 
@@ -141,6 +142,37 @@ html.svg {
 }
 
 // Clear English Standard
+#svg-icon--clear-english {
+  .st0 {
+    fill: none;
+  }
+
+  .st1 {
+    fill: #959CA1;
+  }
+
+  .st2 {
+    stroke: #FFFFFF;
+    stroke-width: 1.25;
+  }
+
+  .st3 {
+    fill: #FFFFFF;
+  }
+
+  .st4 {
+    fill: #FFFFFF;
+    stroke: #FFFFFF;
+    stroke-width: 3.4213;
+  }
+
+  .st5 {
+    fill-rule: evenodd;
+    clip-rule: evenodd;
+    fill: #004896;
+  }
+}
+
 .icon--clear-english,
 .svg-icon--clear-english {
   width: 100px;

--- a/app/assets/stylesheets/components/common/_icon_svg.scss
+++ b/app/assets/stylesheets/components/common/_icon_svg.scss
@@ -93,9 +93,23 @@ html.svg {
 .svg-icon--email {
   vertical-align: middle;
   fill: #fff;
-  display: block;
+  display: none;
+
+  .svg & {
+    display: block;
+  }
 }
 
+.icon--twitter,
+.icon--facebook,
+.icon--youtube,
+.icon--email {
+  display: block;
+
+  .svg & {
+    display: none;
+  }
+}
 
 // On-page feedback icons
 
@@ -124,15 +138,6 @@ html.svg {
 
 .icon--thumb-icon-down {
   background-position: -935px -436px;
-}
-
-.svg {
-  .icon--twitter,
-  .icon--facebook,
-  .icon--youtube,
-  .icon--email {
-    display: none;
-  }
 }
 
 // Clear English Standard

--- a/app/assets/stylesheets/components/common/_social_sharing.scss
+++ b/app/assets/stylesheets/components/common/_social_sharing.scss
@@ -37,6 +37,10 @@
     height: 33px;
     margin: 0 auto;
   }
+
+  .icon--facebook {
+    background-position: -456px -436px;
+  }
 }
 
 .social-sharing__item--twitter {
@@ -52,6 +56,10 @@
     height: 33px;
     margin: 0 auto;
   }
+
+  .icon--twitter {
+    background-position: -484px -437px;
+  }
 }
 
 .social-sharing__item--email {
@@ -66,5 +74,9 @@
   .icon--email {
     height: 33px;
     margin: 0 auto;
+  }
+
+  .icon--email {
+    background-position: -664px -444px;
   }
 }

--- a/app/assets/stylesheets/components/page_specific/_stripe_banner.scss
+++ b/app/assets/stylesheets/components/page_specific/_stripe_banner.scss
@@ -56,7 +56,6 @@
 .icon--stripe-banner-arrow {
   width: 64px;
   height: 64px;
-  display: block;
   margin: $baseline-unit auto 0 auto;
 
   @include respond-to($mq-s) {
@@ -68,6 +67,22 @@
   @include respond-to($mq-l) {
     top: 15%;
     right: 7%;
+  }
+}
+
+.svg-icon--stripe-banner-arrow {
+  display: none;
+
+  .svg & {
+    display: block;
+  }
+}
+
+.icon--stripe-banner-arrow {
+  display: block;
+
+  .svg & {
+    display: none;
   }
 }
 

--- a/app/views/shared/svg/_icon_sprite.html.erb
+++ b/app/views/shared/svg/_icon_sprite.html.erb
@@ -56,14 +56,6 @@
 
   <!-- Clear English Standard -->
   <symbol id="svg-icon--clear-english" viewBox="184.2 200.2 215.6 215.6">
-    <style>
-      .st0{fill:none;}
-      .st1{fill:#959CA1;}
-      .st2{stroke:#FFFFFF;stroke-width:1.25;}
-      .st3{fill:#FFFFFF;}
-      .st4{fill:#FFFFFF;stroke:#FFFFFF;stroke-width:3.4213;}
-      .st5{fill-rule:evenodd;clip-rule:evenodd;fill:#004896;}
-    </style>
     <circle class="st0" cx="292" cy="308" r="107.8"/>
     <circle class="st1" cx="292" cy="308" r="104.7"/>
     <circle class="st2" cx="292" cy="309.5" r="78.2"/>


### PR DESCRIPTION
There area a number of instances where icons are displaying incorrectly in non-JavaScript environments, specifically:  

**Social Sharing icons in the footer**

![image](https://cloud.githubusercontent.com/assets/6080548/24949793/c8f48cb0-1f66-11e7-9ec5-f5a8e63a1ce8.png)

**The arrow in the striped banner on the homepage**

![image](https://cloud.githubusercontent.com/assets/6080548/24949827/dc11068e-1f66-11e7-8b23-712c7ee024cb.png)

**The Social Sharing icons on articles pages**

![image](https://cloud.githubusercontent.com/assets/6080548/24949851/ec0d8788-1f66-11e7-8761-1accb0baf344.png)

This PR fixes these issues and additionally adds consistency to the way the SVG icon for the Clear Language section of the footer is coded: 
- Adds this to the comments
- Moves the currently styles to the CSS

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1716)
<!-- Reviewable:end -->
