### PR TITLE
[DEV APPROVED] 7923 global nav add tests

### DIFF
--- a/app/assets/javascripts/components/GlobalNav.js
+++ b/app/assets/javascripts/components/GlobalNav.js
@@ -33,11 +33,17 @@ define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities', 'common'], 
     this._setUpDesktopInteraction();
     this._setUpMobileAnimation();
     this._setUpKeyboardEvents();
-    this.$globalNav.removeClass('uninitialised');
-
-    $(window).on('resize', utilities.debounce($.proxy(this._setUpMobileAnimation, this), 100));
+    this._bindEvents();
 
     return this;
+  };
+
+  /**
+   * Set up component
+   */
+  GlobalNav.prototype._bindEvents = function() {
+    this.$globalNav.removeClass('uninitialised');
+    $(window).on('resize', utilities.debounce($.proxy(this._setUpMobileAnimation, this), 100));
   };
 
   /**

--- a/spec/javascripts/fixtures/GlobalNav.html
+++ b/spec/javascripts/fixtures/GlobalNav.html
@@ -1,0 +1,52 @@
+<div>
+  <a data-dough-mobile-nav-button></a>
+  <nav data-dough-component="GlobalNav" class="uninitialised no-transition">
+    <ul data-dough-nav-clumps>
+      <li data-dough-nav-clump id="clump-1">
+        <a data-dough-nav-clump-heading tabindex="0">
+          <span class="global-nav__clump__heading__text">First clump</span>
+        </a>
+        <div data-dough-subnav>
+          <div>
+            <a data-dough-subnav-heading></a>
+            <ul data-dough-subcategories>
+              <li>
+                <a tabindex="0">First link</a>
+                <ul>
+                  <li>
+                    <a tabindex="0">Second link</a>
+                  </li>
+                </ul>
+              </li>
+            </ul>
+          </div>
+          <a data-dough-mobile-nav-close></a>
+        </div>
+      </li>
+
+      <li data-dough-nav-clump id="clump-2">
+        <a data-dough-nav-clump-heading tabindex="0">
+          <span class="global-nav__clump__heading__text">Second clump</span>
+        </a>
+        <div data-dough-subnav>
+          <div>
+            <a data-dough-subnav-heading></a>
+            <ul data-dough-subcategories>
+              <li>
+                <a tabindex="0">First link</a>
+                <ul>
+                  <li>
+                    <a tabindex="0">Second link</a>
+                  </li>
+                </ul>
+              </li>
+            </ul>
+          </div>
+          <a data-dough-mobile-nav-close></a>
+        </div>
+      </li>
+    </ul>
+    <div data-dough-mobile-nav-overlay></div>
+  </nav>
+  <div id="main">
+</div>

--- a/spec/javascripts/test-main.js
+++ b/spec/javascripts/test-main.js
@@ -14,6 +14,7 @@ require.config({
     ujs: 'vendor/assets/bower_components/jquery-ujs/src/rails',
     eventsWithPromises: 'vendor/assets/bower_components/eventsWithPromises/src/eventsWithPromises',
     typeahead: 'vendor/assets/javascripts/typeahead.jquery',
+    jqueryThrottleDebounce: 'vendor/assets/bower_components/jqueryThrottleDebounce/jquery.ba-throttle-debounce',
 
     // Internal modules
     DoughBaseComponent: 'vendor/assets/bower_components/dough/assets/js/components/DoughBaseComponent',
@@ -35,11 +36,13 @@ require.config({
     EmbedCodeGenerator: 'app/assets/javascripts/components/EmbedCodeGenerator',
     OnPageFeedback: 'app/assets/javascripts/components/OnPageFeedback',
     ViewAll: 'app/assets/javascripts/components/ViewAll',
+    GlobalNav: 'app/assets/javascripts/components/GlobalNav',
 
     rsvp: 'vendor/assets/bower_components/rsvp/rsvp',
 
     utilities: 'vendor/assets/bower_components/dough/assets/js/lib/utilities',
     componentLoader: 'vendor/assets/bower_components/dough/assets/js/lib/componentLoader',
+    mediaQueries: 'vendor/assets/bower_components/dough/assets/js/lib/mediaQueries',
     RangeInput: 'vendor/assets/bower_components/dough/assets/js/components/RangeInput',
     TabSelector: 'vendor/assets/bower_components/dough/assets/js/components/TabSelector',
 

--- a/spec/javascripts/tests/GlobalNav_spec.js
+++ b/spec/javascripts/tests/GlobalNav_spec.js
@@ -1,0 +1,304 @@
+describe('GlobalNav', function() {
+  'use strict';
+
+  beforeEach(function(done) {
+    var self = this;
+
+    requirejs(
+        ['jquery', 'GlobalNav', 'mediaQueries', 'utilities', 'common'],
+        function($, GlobalNav, mediaQueries, utilities, common) {
+          self.$html = $(window.__html__['spec/javascripts/fixtures/GlobalNav.html']).appendTo('body');
+          self.component = self.$html.find('[data-dough-component="GlobalNav"]');
+          self.globalNav = GlobalNav;
+          self.mainContent = self.$html.find('#main');
+          self.mobileNavButton = (self.$html).find('[data-dough-mobile-nav-button]');
+          self.clumps = self.component.find('[data-dough-nav-clumps]');
+          self.subNavHeading = self.component.find('[data-dough-subnav-heading]');
+          self.mobileNavCloseButton = self.component.find('[data-dough-mobile-nav-close]');
+          self.mobileNavOverlay = self.component.find('[data-dough-mobile-nav-overlay]');
+          self.obj = new self.globalNav(self.component, self.component.data('dough-global-nav-config'));
+          self.delay = 250;
+
+          done();
+        }, done);
+  });
+
+  afterEach(function() {
+    this.$html.remove();
+  });
+
+  describe('Initialise component', function() {
+    it('calls the right methods when initialising', function() {
+      var setUpMobileInteractionStub = sinon.stub(this.obj, "_setUpMobileInteraction"),
+          setUpDesktopInteractionStub = sinon.stub(this.obj, "_setUpDesktopInteraction"),
+          setUpMobileAnimationStub = sinon.stub(this.obj, "_setUpMobileAnimation"),
+          setUpKeyboardEventsStub = sinon.stub(this.obj, "_setUpKeyboardEvents"),
+          bindEventsStub = sinon.stub(this.obj, "_bindEvents");
+
+      this.obj.init();
+
+      expect(setUpMobileInteractionStub.callCount).to.be.equal(1);
+      expect(setUpDesktopInteractionStub.callCount).to.be.equal(1);
+      expect(setUpMobileAnimationStub.callCount).to.be.equal(1);
+      expect(setUpKeyboardEventsStub.callCount).to.be.equal(1);
+      expect(bindEventsStub.callCount).to.be.equal(1);
+    });
+  });
+
+  describe('Bind Events', function() {
+    beforeEach(function() {
+      this.obj.init();
+    });
+
+    it('removes the uninialised class when component is loaded', function() {
+      expect(this.component.hasClass('uninitialised')).to.be.false;
+    });
+  });
+
+  describe('Mobile animation', function() {
+    beforeEach(function() {
+      this.obj.init();
+    });
+
+    it('toggles the no-transition class when viewport size changes', function() {
+      // This is not functional because I have been unable to simulate the resize event - DT
+    });
+  });
+
+  describe('Mobile interaction', function() {
+    beforeEach(function() {
+      this.obj.init();
+    });
+
+    it('toggles nav visibility when menu button is clicked', function() {
+      this.mobileNavButton.trigger('click');
+      expect(this.component.hasClass('is-active')).to.be.true;
+
+      this.mobileNavButton.trigger('click');
+      expect(this.component.hasClass('is-active')).to.be.false;
+    });
+
+    it('toggles subnav visibility when clump heading is clicked', function() {
+      $('#clump-1').find('[data-dough-subnav-heading]').trigger('click');
+
+      expect($('#clump-1').hasClass('is-active')).to.be.true;
+      expect(this.clumps.hasClass('is-active')).to.be.true;
+
+      $('#clump-1').find('[data-dough-subnav-heading]').trigger('click');
+
+      expect($('#clump-1').hasClass('is-active')).to.be.false;
+      expect(this.clumps.hasClass('is-active')).to.be.false;
+    });
+
+    it('toggles subnav visibility when subnav heading is clicked', function() {
+      // open the subnav and nav before the test is run
+      $('#clump-1').addClass('is-active');
+      this.clumps.addClass('is-active');
+
+      $('#clump-1').find('[data-dough-subnav-heading]').trigger('click');
+      expect($('#clump-1').hasClass('is-active')).to.be.false;
+      expect(this.clumps.hasClass('is-active')).to.be.false;
+
+      $('#clump-1').find('[data-dough-subnav-heading]').trigger('click');
+      expect($('#clump-1').hasClass('is-active')).to.be.true;
+      expect(this.clumps.hasClass('is-active')).to.be.true;
+    });
+
+    it('closes nav when close button is clicked', function() {
+      // open the nav before the test is run
+      this.component.addClass('is-active');
+
+      $('#clump-1').find('[data-dough-mobile-nav-close]').trigger('click');
+      expect(this.component.hasClass('is-active')).to.be.false;
+    });
+
+    it('closes nav when overlay is clicked', function() {
+      // the nav needs to be open before the test is run
+      this.component.addClass('is-active');
+
+      this.mobileNavOverlay.trigger('click');
+      expect(this.component.hasClass('is-active')).to.be.false;
+    });
+  });
+
+  describe('Desktop interaction', function() {
+    var clock;
+
+    beforeEach(function() {
+      clock = sinon.useFakeTimers();
+      this.obj.init();
+    });
+
+    afterEach(function() {
+      clock.restore();
+    });
+
+    it('closes subnav on a touch event outside of global nav', function() {
+      // the subnav needs to be open before test is run
+      $('#clump-1').addClass('is-active');
+      this.mainContent.trigger('touchstart');
+      expect($('#clump-1').hasClass('is-active')).to.be.false;
+    });
+
+    it('closes subnav when user moves mouse outside of global nav', function() {
+      // the subnav needs to be open before test is run
+      $('#clump-1').addClass('is-active');
+      this.component.trigger('mouseleave');
+      clock.tick(this.delay);
+      expect($('#clump-1').hasClass('is-active')).to.be.false;
+    });
+
+    it('opens subnav when user hovers on clump heading', function() {
+      $('#clump-1').find('.global-nav__clump__heading__text').trigger('mouseenter');
+      clock.tick(this.delay);
+      expect($('#clump-1').hasClass('is-active')).to.be.true;
+    });
+
+    it('toggles subnav when user touches clump heading', function() {
+      // opens subnav
+      $('#clump-1').find('.global-nav__clump__heading__text').trigger('touchend');
+      clock.tick(this.delay);
+      expect($('#clump-1').hasClass('is-active')).to.be.true;
+
+      // closes subnav
+      $('#clump-1').find('.global-nav__clump__heading__text').trigger('touchend');
+      expect($('#clump-1').hasClass('is-active')).to.be.false;
+    });
+  });
+
+  describe('Keyboard Events', function() {
+    var triggerKeyUp = function(element, keyCode) {
+      var e = $.Event('keyup');
+      e.which = keyCode;
+      element.trigger(e);
+    };
+
+    beforeEach(function() {
+      this.obj.init();
+    });
+
+    it('when at top level the enter key opens dropdown and moves focus into this', function() {
+      var index = $('#clump-1').find('[data-dough-nav-clump-heading]');
+
+      triggerKeyUp(index, 13);
+
+      expect(index.parents('[data-dough-nav-clump]').hasClass('is-active')).to.be.true;
+      expect(index.attr('aria-expanded')).to.eq('true');
+      expect($(index).siblings('[data-dough-subnav]').find('[data-dough-subcategories]').find('a').get(0) === document.activeElement).to.be.true;
+    });
+
+    it('when at top level the spacebar key opens dropdown', function() {
+      var index = $('#clump-1').find('[data-dough-nav-clump-heading]');
+
+      triggerKeyUp(index, 32);
+
+      expect(index.parents('[data-dough-nav-clump]').hasClass('is-active')).to.be.true;
+      expect(index.attr('aria-expanded')).to.eq('true');
+    });
+
+    it('when at top level the left arrow key moves focus to the previous element or wraps if on the first element', function() {
+      var index = $('#clump-2').find('[data-dough-nav-clump-heading]');
+
+      triggerKeyUp(index, 37);
+
+      expect($('#clump-1').find('[data-dough-nav-clump-heading]').get(0) === document.activeElement).to.be.true;
+    });
+
+    it('when at top level the right arrow key moves focus to the next element or wraps if on the last element', function() {
+      var index = $('#clump-1').find('[data-dough-nav-clump-heading]');
+
+      triggerKeyUp(index, 39);
+
+      expect($('#clump-2').find('[data-dough-nav-clump-heading]').get(0) === document.activeElement).to.be.true;
+    });
+
+    it('when at top level the down arrow key opens the dropdown', function() {
+      var index = $('#clump-1').find('[data-dough-nav-clump-heading]');
+
+      triggerKeyUp(index, 40);
+
+      expect(index.parents('[data-dough-nav-clump]').hasClass('is-active')).to.be.true;
+    });
+
+    it('when at secondary level the escape key closes dropdown and moves focus back to top level', function() {
+      var index = $('#clump-1').find('[data-dough-subcategories]');
+
+      triggerKeyUp(index, 27);
+
+      expect(index.parents('[data-dough-nav-clump]').hasClass('is-active')).to.be.false;
+      expect($('#clump-1').find('[data-dough-nav-clump-heading]').get(0) === document.activeElement).to.be.true;
+    });
+
+    it('when at secondary level the up arrow key moves focus to previous element or wraps to the last element if on the first', function() {
+      var links = $('#clump-1').find('[data-dough-subcategories]').find('a');
+
+      triggerKeyUp(links.last(), 38);
+
+      expect(links.get(0) === document.activeElement).to.be.true;
+
+      triggerKeyUp(links.first(), 38);
+
+      expect(links.get(1) === document.activeElement).to.be.true;
+    });
+
+    it('when at secondary level the down arrow key moves focus to the next element or wraps to the first element if on the last', function() {
+      var links = $('#clump-1').find('[data-dough-subcategories]').find('a');
+
+      triggerKeyUp(links.first(), 40);
+
+      expect(links.get(1) === document.activeElement).to.be.true;
+
+      triggerKeyUp(links.last(), 40);
+
+      expect(links.get(0) === document.activeElement).to.be.true;
+    });
+
+    it('when at secondary level the left arrow key closes the dropdown and moves focus to the previous top level element or the last element if already on the first', function() {
+      var links;
+
+      // open dropdown before running test
+      $('#clump-2').addClass('is-active');
+
+      links = $('#clump-2').find('[data-dough-subcategories]').find('a');
+
+      triggerKeyUp(links.last(), 37);
+
+      expect($('#clump-2').hasClass('is-active')).to.be.false;
+      expect($('#clump-1').find('[data-dough-nav-clump-heading]').get(0) === document.activeElement).to.be.true;
+
+      // open dropdown before running test
+      $('#clump-1').addClass('is-active');
+
+      links = $('#clump-1').find('[data-dough-subcategories]').find('a');
+
+      triggerKeyUp(links.last(), 37);
+
+      expect($('#clump-1').hasClass('is-active')).to.be.false;
+      expect($('#clump-2').find('[data-dough-nav-clump-heading]').get(0) === document.activeElement).to.be.true;
+    });
+
+    it('when at secondary level the right arrow key closes the dropdown and moves focus to the next top level element or the first element if already on the last', function() {
+      var links;
+
+      // open dropdown before running test
+      $('#clump-1').addClass('is-active');
+
+      links = $('#clump-1').find('[data-dough-subcategories]').find('a');
+
+      triggerKeyUp(links.last(), 39);
+
+      expect($('#clump-1').hasClass('is-active')).to.be.false;
+      expect($('#clump-2').find('[data-dough-nav-clump-heading]').get(0) === document.activeElement).to.be.true;
+
+      // open dropdown before running test
+      $('#clump-2').addClass('is-active');
+
+      links = $('#clump-2').find('[data-dough-subcategories]').find('a');
+
+      triggerKeyUp(links.last(), 39);
+
+      expect($('#clump-2').hasClass('is-active')).to.be.false;
+      expect($('#clump-1').find('[data-dough-nav-clump-heading]').get(0) === document.activeElement).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
This PR adds Karma tests for the Global Nav in the following areas: 

* Test for initialisation of component: check init is calling the appropriate methods. This also slightly refactors GlobalNav.js to put the two one-liners into a separate method. It's is a bit neater I think and helps test the init as a single unit which is probably better practice.
* Tests for binding events. In fact this just tests that the uninitialised class is removed when the component loads
* Test for mobile animation. This should test that the no-transition class is added/removed when the window is resized. I have so far been unable to simulate the resize event in this test so this is left as an empty test (i.e. it passes but only because it isn’t doing anything but can serve as a reminder to work on it at a later date).
* Tests for mobile interaction. This tests: 
    * the nav visibility toggles when the menu button is clicked
    * the dropdown visibility toggles when the clump heading is clicked
    * the dropdown visibility toggles when the subnav heading is clicked
    * the nav is closed when the close button is clicked
    * the nav is closed when the overlay is clicked
* Tests for desktop interaction This tests: 
    * the dropdown is closed on a touch event outside of global nav
    * the dropdown is closed when the user moves the mouse outside of the global nav
    * the dropdown is closed when the user hovers on a clump heading
    * the dropdown is opened when the user touches a clump heading
* Tests for keyboard interactions. This tests: 
    * the enter key opens the dropdown and moves focus into this
    * the spacebar key opens dropdown
    * when at the top level the left arrow key moves focus to the previous element on the top level or wraps if on the first element
    * when at the top level the right arrow key moves focus to the next element on top level or wraps if on the last element
    * when at the top level the down arrow key opens the dropdown
    * the escape key closes dropdown and moves focus back to top level
    * the up arrow key moves focus to the previous element or wraps to the last element if on the first
    * when at the secondary level the down arrow key moves focus to the next element or wraps to the first element if on the last
    * when at the secondary level the left arrow key closes the dropdown and moves focus to the previous top level element or the last element if already on the first
    * when at the secondary level the right arrow key closes the dropdown and moves focus to the next top level element or the first element if already on the last

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1719)
<!-- Reviewable:end -->
