### PR TITLE
[DEV APPROVED] Remove new tax year warning

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+Rails:
+  Enabled: true
 Documentation:
   Enabled: false
 Metrics/LineLength:
@@ -27,7 +29,6 @@ Style/StringLiterals:
 Lint/ShadowingOuterLocalVariable:
   Enabled: false
 AllCops:
-  RunRailsCops: true
   Exclude:
   - 'app/helpers/application_helper.rb'
   - 'bin/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem 'statsd-ruby'
 gem 'postcode_anywhere-email_validation'
 gem 'turnout'
 
-gem 'action_plans', '~> 4.4.0'
+gem 'action_plans', '~> 4.5.0'
 gem 'advice_plans', '~> 3.3.1'
 gem 'agreements', '~> 2.1.0'
 gem 'baby_cost_calculator', '~> 0.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ GEM
   remote: https://rubygems.org/
   remote: http://gems.dev.mas.local/
   specs:
-    action_plans (4.4.0.339)
+    action_plans (4.5.0.349)
       autoprefixer-rails
       dough-ruby (~> 5.0)
       draper
@@ -689,7 +689,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  action_plans (~> 4.4.0)
+  action_plans (~> 4.5.0)
   activerecord-session_store
   advice_plans (~> 3.3.1)
   aes

--- a/app/helpers/budget_warning.rb
+++ b/app/helpers/budget_warning.rb
@@ -1,7 +1,8 @@
 module BudgetWarning
-    ANNOUNCEMENT_DAY   = 06
-    ANNOUNCEMENT_MONTH = 4
-    ANNOUNCEMENT_YEAR  = 2017
+  ANNOUNCEMENT_DAY   = 6
+  ANNOUNCEMENT_MONTH = 4
+  ANNOUNCEMENT_YEAR  = 2018
+  WHITELIST = YAML.load_file('config/budget_warning_tools.yml')
 
   class Announcement
     attr_reader :date
@@ -13,20 +14,16 @@ module BudgetWarning
     end
 
     def go_live?
-      (Date.today >= date) ? true : false
+      Time.zone.today >= date ? true : false
     end
   end
 
   def display_banner_warning?
-    BudgetWarning::Announcement.new.go_live?
+    BudgetWarning::Announcement.new.go_live? && whitelisted?
   end
   module_function :display_banner_warning?
 
   def whitelisted?
-    whitelist = ['/en/tools/redundancy-pay-calculator/',
-                 '/cy/tools/cyfrifiannell-tal-diswyddo/']
-
-    whitelist.include? request.url.gsub(request.base_url, '')
+    WHITELIST.include? request.url.gsub(request.base_url, '')
   end
-  module_function :whitelisted?
 end

--- a/app/views/layouts/_unconstrained.html.erb
+++ b/app/views/layouts/_unconstrained.html.erb
@@ -8,7 +8,7 @@
   <% end %>
 
   <div class="t-default-main-content" <%== 'id="main"' if default_main_content_location? %> tabindex="-1">
-    <% if display_banner_warning? && whitelisted? %>
+    <% if display_banner_warning? %>
       <div class="l-constrained">
         <%=  render 'shared/banner_alert' %>
       </div>

--- a/config/budget_warning_tools.yml
+++ b/config/budget_warning_tools.yml
@@ -1,0 +1,4 @@
+# Examples
+# - /en/tools/redundancy-pay-calculator/
+# - /cy/tools/cyfrifiannell-tal-diswyddo/
+--- []

--- a/spec/helpers/budget_warning_spec.rb
+++ b/spec/helpers/budget_warning_spec.rb
@@ -3,41 +3,54 @@ require_relative './shared_examples/displays_banner_warning.rb'
 RSpec.describe BudgetWarning, type: :helper do
   context '#before announcement day' do
     it 'should not display banner warning' do
-      Timecop.freeze(Chronic.parse('3rd March 2016')) do
-        expect(described_class.display_banner_warning?).to be(false)
+      Timecop.freeze(Chronic.parse('3rd March 2017')) do
+        expect(display_banner_warning?).to be(false)
       end
     end
   end
 
   context '#on announcement day' do
     it_behaves_like 'displays_warning_banner' do
-      let(:date) { '6th April 2017' }
+      let(:date) { '6th April 2018' }
     end
   end
 
   context '#after announcement day' do
     it_behaves_like 'displays_warning_banner' do
-      let(:date) { '24th April 2017' }
+      let(:date) { '24th April 2018' }
     end
   end
 
-  describe '#whitelisted page' do
-    context 'english pages' do
-      it 'displays banner for only the Redundancy Calculator' do
-        request = double('request', url: 'www.example.com/en/tools/redundancy-pay-calculator/',
-                                    base_url: 'www.example.com')
-        allow(BudgetWarning).to receive(:request).and_return(request)
+  describe '#whitelisted?' do
+    let(:request) do
+      double(
+        url: 'example.org/en/tools/redundancy-pay-calculator/',
+        base_url: 'example.org'
+      )
+    end
 
-        expect(described_class.whitelisted?).to be(true)
+    before do
+      stub_const('BudgetWarning::WHITELIST', whitelisted_tools)
+      allow(helper).to receive(:request).and_return(request)
+    end
+
+    context 'when request is whitelisted' do
+      let(:whitelisted_tools) do
+        ['/en/tools/redundancy-pay-calculator/']
+      end
+
+      it 'returns true' do
+        expect(helper).to be_whitelisted
       end
     end
-    context 'welsh pages' do
-      it 'displays banner for only the Redundancy Calculator' do
-        request = double('request', url: 'www.example.com/cy/tools/cyfrifiannell-tal-diswyddo/',
-                                    base_url: 'www.example.com')
-        allow(BudgetWarning).to receive(:request).and_return(request)
 
-        expect(described_class.whitelisted?).to be(true)
+    context 'when request is not whitelisted' do
+      let(:whitelisted_tools) do
+        ['/en/tools/budget-planner/']
+      end
+
+      it 'returns false' do
+        expect(helper).to_not be_whitelisted
       end
     end
   end

--- a/spec/helpers/shared_examples/displays_banner_warning.rb
+++ b/spec/helpers/shared_examples/displays_banner_warning.rb
@@ -1,5 +1,6 @@
 RSpec.shared_examples 'displays_warning_banner' do
   it 'shows warning banner for impending budget changes' do
+    expect(self).to receive(:whitelisted?).and_return(true)
     Timecop.freeze(Chronic.parse(date)) do
       expect(display_banner_warning?).to be(true)
     end


### PR DESCRIPTION
This pr removes the warning added in pr #1705.

Rather than delete the code which was added back in recently, changing the date ensures the warning is not displayed. There are several options to achieve this result, including setting the whitelist to an empty array.  This pr is to initiate _brief_ discussion on the preferred approach in terms of balancing effort, urgency and future proofing.

We decided to use a yaml file to configure which tools should show budget warnings. If the file is empty, no warning will be displayed. This approach will minimise the developer effort required to enable/disable the message each tax year.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1722)
<!-- Reviewable:end -->
