### PR TITLE
[DEV APPROVED] 8120 - Fixing WebChat JS Error

### DIFF
--- a/app/assets/stylesheets/components/page_specific/_floating_chat.scss
+++ b/app/assets/stylesheets/components/page_specific/_floating_chat.scss
@@ -16,6 +16,10 @@
     text-decoration: none;
   }
 
+  &:focus {
+    background-color: $color-white;
+  }
+
   @include respond-to($mq-xs) {
     display: none;
   }

--- a/app/views/shared/_contact_panels.html.erb
+++ b/app/views/shared/_contact_panels.html.erb
@@ -93,8 +93,11 @@
 
         var chatCTA = document.getElementById('js-chat-cta'),
             chatDescription = document.getElementById('js-chat-description'),
-            chatContent = document.getElementById('js-chat-content'),
-            chatPopup = document.getElementsByClassName('chat-box__container')[0];
+            chatContent = document.getElementById('js-chat-content');
+
+        <% if show_floating_chat? %>
+          var chatPopup = document.getElementsByClassName('chat-box__container')[0];
+        <% end %>
 
 
         if (sWOImage.width == 1) {
@@ -113,8 +116,9 @@
           chatDescription.innerHTML += '&nbsp;*';
           <% end %>
 
-
-          chatPopup.className = "chat-box__container chat-box__container--hidden";
+          <% if show_floating_chat? %>
+            chatPopup.className = "chat-box__container chat-box__container--hidden";
+          <% end %>
 
           chatContent.className = "contact-panel__dynamic-content is-loaded";
 
@@ -145,15 +149,16 @@
           sWOChatElement.href = sWOChatstart;
           sWOChatElement.target = "_blank";
 
+          <% if show_floating_chat? %>
+            chatPopup.className = "chat-box__container";
+            chatPopup.href = sWOChatstart;
+            chatPopup.target = "_blank";
 
-          chatPopup.className = "chat-box__container";
-          chatPopup.href = sWOChatstart;
-          chatPopup.target = "_blank";
-
-          chatPopup.onclick = function() {
-            window.open(chatPopup.href, "Chat", "width=484,height=361,scrollbars=yes,resizable=yes");
-            return false;
-          };
+            chatPopup.onclick = function() {
+              window.open(chatPopup.href, "Chat", "width=484,height=361,scrollbars=yes,resizable=yes");
+              return false;
+            };
+          <% end %>
 
         }
 


### PR DESCRIPTION
There is currently a JS error on every page apart from the homepage, this is caused by the JS looking for a variable which is undefined as the element it refers to only exists on the homepage (Where the floating chat is restricted to).

| Screenshot of error |
|------------|
|<img width="541" alt="screen shot 2017-05-18 at 15 19 47" src="https://cloud.githubusercontent.com/assets/13165846/26206808/ae53327e-3bdd-11e7-9462-1b119403f8f8.png">|

This PR wraps the sections of the JS in the contact panels which refer to this element in the condition:

```
<% if show_floating_chat? %>
```

This way the errors do not appear on any of the other pages, the variable will only be required when the floating chat is active, and will work on every subsequent page we add it to.

**Screenshots of solution**

| Same page as above | Floating chat still appearing on homepage |
|-----|-----|
|<img width="501" alt="screen shot 2017-05-18 at 15 21 00" src="https://cloud.githubusercontent.com/assets/13165846/26206843/cab93878-3bdd-11e7-9ce6-c3b968fad693.png">|![image](https://cloud.githubusercontent.com/assets/13165846/26206872/de4f8efa-3bdd-11e7-9dce-d2a95701550b.png)|

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1737)
<!-- Reviewable:end -->
