### PR TITLE
[DEV APPROVED] Bumping UC/Money manager to 2.1.0 for tickets 8184 and 8186

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,7 @@ gem 'quiz', '~> 1.2.0', source: 'http://gems.dev.mas.local'
 gem 'rio', '1.18.0', source: 'http://gems.dev.mas.local'
 gem 'savings_calculator', '~> 1.8.1'
 gem 'timelines', '~> 1.4.0'
-gem 'universal_credit', '~> 2.0.1'
+gem 'universal_credit', '~> 2.1.0'
 
 # 1.0.2 has breaking changes as it adds japanese and turkish locales
 gem 'validate_url', '1.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -682,7 +682,7 @@ GEM
     unicorn-rails (2.2.1)
       rack
       unicorn
-    universal_credit (2.0.1)
+    universal_credit (2.1.0)
       autoprefixer-rails
       devise
       dough-ruby
@@ -807,7 +807,7 @@ DEPENDENCIES
   turnout
   uglifier
   unicorn-rails
-  universal_credit (~> 2.0.1)
+  universal_credit (~> 2.1.0)
   validate_url (= 1.0.0)
   vcr
   webmock


### PR DESCRIPTION
Bumping Unversal Credit to 2.1.0

This PR bumps the version of universal credit to version 2.0.2, the new version contains the following tickets:

[8186 - UC - Expand/Collapse Behaviour on 'to read'](https://github.com/moneyadviceservice/universal_credit/pull/128/files)
[8184 - Money Manager - Display Issues](https://github.com/moneyadviceservice/universal_credit/pull/129)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1738)
<!-- Reviewable:end -->
