### PR TITLE
Bumping frontend to 2.1.1 for ticket 8216

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,7 @@ gem 'quiz', '~> 1.2.0', source: 'http://gems.dev.mas.local'
 gem 'rio', '1.18.0', source: 'http://gems.dev.mas.local'
 gem 'savings_calculator', '~> 1.8.1'
 gem 'timelines', '~> 1.4.0'
-gem 'universal_credit', '~> 2.1.0'
+gem 'universal_credit', '~> 2.1.1'
 
 # 1.0.2 has breaking changes as it adds japanese and turkish locales
 gem 'validate_url', '1.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -682,7 +682,7 @@ GEM
     unicorn-rails (2.2.1)
       rack
       unicorn
-    universal_credit (2.1.0)
+    universal_credit (2.1.1)
       autoprefixer-rails
       devise
       dough-ruby
@@ -807,7 +807,7 @@ DEPENDENCIES
   turnout
   uglifier
   unicorn-rails
-  universal_credit (~> 2.1.0)
+  universal_credit (~> 2.1.1)
   validate_url (= 1.0.0)
   vcr
   webmock


### PR DESCRIPTION
Bumping UC/MM in frontend to version 2.1.1 for ticket [8216](https://github.com/moneyadviceservice/universal_credit/pull/130)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1739)
<!-- Reviewable:end -->
