### PR TITLE
8187::Bumps version of UC to 2-2-1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,7 @@ gem 'quiz', '~> 1.2.0', source: 'http://gems.dev.mas.local'
 gem 'rio', '1.18.0', source: 'http://gems.dev.mas.local'
 gem 'savings_calculator', '~> 1.8.1'
 gem 'timelines', '~> 1.4.0'
-gem 'universal_credit', '~> 2.1.5'
+gem 'universal_credit', '~> 2.2.1'
 
 # 1.0.2 has breaking changes as it adds japanese and turkish locales
 gem 'validate_url', '1.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -682,7 +682,7 @@ GEM
     unicorn-rails (2.2.1)
       rack
       unicorn
-    universal_credit (2.1.5)
+    universal_credit (2.2.1)
       autoprefixer-rails
       devise
       dough-ruby
@@ -807,7 +807,7 @@ DEPENDENCIES
   turnout
   uglifier
   unicorn-rails
-  universal_credit (~> 2.1.5)
+  universal_credit (~> 2.2.1)
   validate_url (= 1.0.0)
   vcr
   webmock


### PR DESCRIPTION
# Version Bump
This bumps the new version of UC to 2.2.1

This is in reference to ticket [#8187](https://moneyadviceservice.tpondemand.com/entity/8187) and PR [138](https://github.com/moneyadviceservice/universal_credit/pull/138) and [141](https://github.com/moneyadviceservice/universal_credit/pull/141).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1745)
<!-- Reviewable:end -->
