### PR TITLE
[DEV APPROVED] 8274 - Webchat not working in IE8

### DIFF
--- a/app/views/shared/_contact_panels.html.erb
+++ b/app/views/shared/_contact_panels.html.erb
@@ -75,7 +75,7 @@
 <% end %>
 
 <% if show_floating_chat? %>
-<a href="#" aria-hidden="true" class="chat-box__container chat-box__container--hidden t__floating-web-chat">
+<a href="#" aria-hidden="true" id="js-chat-popup" class="chat-box__container chat-box__container--hidden t__floating-web-chat">
   <div class="chat-box__heading">Web Chat</div>
     <span class="icon icon--web-chat"></span>
 </a>
@@ -96,7 +96,7 @@
             chatContent = document.getElementById('js-chat-content');
 
         <% if show_floating_chat? %>
-          var chatPopup = document.getElementsByClassName('chat-box__container')[0];
+          var chatPopup = document.getElementById('js-chat-popup');
         <% end %>
 
 


### PR DESCRIPTION
**Target Process ticket**

https://moneyadviceservice.tpondemand.com/entity/8274

**Summary**
Currently on the production site the webchat fails to load in IE8 and throws an error.  This PR addresses this error by changing the JS selector from ``document.getElementsByClassName()`` <- Not supported by IE8, to ``document.getElementById()`` and adding an ID to the chat popup.

**Examples**

| Before | After |
|-------|------|
|![screen shot 2017-06-12 at 13 13 21 2](https://user-images.githubusercontent.com/13165846/27033933-624c49a2-4f73-11e7-8e22-aac506681357.png)|![screen shot 2017-06-12 at 13 31 36 2](https://user-images.githubusercontent.com/13165846/27033960-803eb666-4f73-11e7-9c3b-a7470b56b6b4.png)|


**Checklist**

+ [x] Tests passed.
+ [x] Code Climate passed for this PR.
+ [x] Commit history reviewed (clear commit messages).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1746)
<!-- Reviewable:end -->
