### PR TITLE
Removing outdated steps on the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,6 @@ Clone the repository:
 $ git clone --recursive https://github.com/moneyadviceservice/frontend.git
 ```
 
-Make sure you've added the following line to your `/etc/hosts` file
-
-`10.50.6.148	gems.test.mas`
-
 Make sure all dependencies are available to the application:
 
 ```sh
@@ -54,15 +50,10 @@ Setup the database:
 bundle exec rake db:create && bundle exec rake db:schema:load
 ```
 
-Copy the features.yml.sample to the config dir:
-
+Make sure to copy the .env-example file:
 ```sh
-cp config/features.yml.sample config/features.yml
-```
-
-Make sure to copy the .env-example file:				
-```sh		
 cp .env-example .env
+```
 
 then set .env variables (i.e. GOOGLE API KEY) stored in KeepassX to run tests locally
 


### PR DESCRIPTION
We don't need to add the private gem server to /etc/hosts file
anymore and we are not using feature toggles anymore either.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1747)
<!-- Reviewable:end -->
