### PR TITLE
Add more emphasis on local CMS and include some common gotchas in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ The Money Advice Service's responsive website.
 ## Prerequisites
 
 * [Git]
-* [Ruby 2.1.2][Ruby]
-* [Rubygems 2.2.2][Rubygems]
+* [Ruby][Ruby] - see verstion specified in [.ruby-version](.ruby-version)
 * [Node.js][Node]
 * [Bundler]
 * [Bower]

--- a/README.md
+++ b/README.md
@@ -67,9 +67,42 @@ $ foreman s
 
 ### Change CMS URL Path
 
-In development, frontend will use the local CMS for convenience. You can change the MAS_CMS_URL on .env file. Use http://cms.moneyadviceservice.org.uk to point to LIVE content, https://cms.qa.dev.mas.local for testing Or http://localhost:PORT to point to a local running CMS.
+In development, frontend will use the local CMS for convenience. See [CMS repository README](https://github.com/moneyadviceservice/cms/blob/master/README.md) for instructions on setting up a local CMS instance.
+
+You can change the MAS_CMS_URL on .env file. Use http://cms.moneyadviceservice.org.uk to point to LIVE content, https://cms.qa.dev.mas.local for testing Or http://localhost:PORT to point to a local running CMS.
 
 Don't forget to restart the server after the modification.
+
+### Development setup gotchas
+
+#### Contento 404 error
+
+```
+Unable to fetch Footer JSON from Contento error: [#<Core::Connection::Http::ResourceNotFound: the server responded with status 404>] url_prefix: [#<URI::HTTP http://localhost:3000/>]
+```
+
+The CMS is setup but the database is empty. A solution is to copy the QA CMS database into the CMS, as detailed in the [CMS repository README](https://github.com/moneyadviceservice/cms/blob/master/README.md).
+
+#### Problems loading Dough or Yeast
+
+Assuming you have run `bowndler install`, you may have issues with previous `bower` installations.
+
+```
+rm -rf vendor/assets/bower_components
+bowndler install
+```
+
+#### Bundle install issues
+
+```
+Downloading codeclimate-test-reporter-0.6.0 revealed dependencies not in the API or the lockfile (simplecov (< 1.0.0,
+>= 0.7.1)).
+Either installing with `--full-index` or running `bundle update codeclimate-test-reporter` should fix the problem.
+```
+
+(Bundling updating a single gem leads to a loop of having to update the previous gem.)
+
+Ensuring (for now) that the `bundler` gem is `1.14.6` works around this issue for now.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ $ foreman s
 
 In development, frontend will use the local CMS for convenience. See [CMS repository README](https://github.com/moneyadviceservice/cms/blob/master/README.md) for instructions on setting up a local CMS instance.
 
-You can change the MAS_CMS_URL on .env file. Use http://cms.moneyadviceservice.org.uk to point to LIVE content, https://cms.qa.dev.mas.local for testing Or http://localhost:PORT to point to a local running CMS.
+You can change the MAS_CMS_URL on .env file. Use https://cms.qa.dev.mas.local for testing, or http://localhost:PORT to point to a local running CMS.
 
 Don't forget to restart the server after the modification.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Money Advice Service's responsive website.
 ## Prerequisites
 
 * [Git]
-* [Ruby][Ruby] - see verstion specified in [.ruby-version](.ruby-version)
+* [Ruby][Ruby] - see version specified in [.ruby-version](.ruby-version)
 * [Node.js][Node]
 * [Bundler]
 * [Bower]

--- a/README.md
+++ b/README.md
@@ -86,8 +86,9 @@ The CMS is setup but the database is empty. A solution is to copy the QA CMS dat
 
 Assuming you have run `bowndler install`, you may have issues with previous `bower` installations.
 
-```
+```sh
 rm -rf vendor/assets/bower_components
+rm bower.json
 bowndler install
 ```
 


### PR DESCRIPTION
Setting up for development documentation:

* Signpost setting up a local CMS a little more
* Adds a section for common gotchas and mitigations encountered while we Cultivars were getting set up on the 12 June 2017.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1748)
<!-- Reviewable:end -->
