### PR TITLE
[DEV APPROVED] 8343 - Employer Best Practice Typo

### DIFF
--- a/config/locales/employer_best_practices.en.yml
+++ b/config/locales/employer_best_practices.en.yml
@@ -125,7 +125,7 @@ en:
         figure_1_html: "<p class='margin-bottom'><strong>of employees are making uninformed financial decisions - they don't use advice or information when weighing up options about saving or spending</strong></p><p class='margin-top italic'>CIPD, 2017</p>"
         figure_2_html: '<p class="margin-bottom"><strong>of employees would appreciate their employer providing access to financial awareness programmes</strong></p><p class="margin-top italic">SMF, 2016</p>'
         figure_3_html: '<p class="margin-bottom"><strong>of employees would value employer facilitated support to help their financial well being </strong></p><p class="margin-top italic">Neyber, 2017</p>'
-        figure_4_html: '<p class="margin-bottom"><strong>of employees would point employees to useful information if they had access</strong></p><p class="margin-top italic">FCA, 2017</p>'
+        figure_4_html: '<p class="margin-bottom"><strong>of employers would point employees to useful information if they had access</strong></p><p class="margin-top italic">FCA, 2017</p>'
       help_link_html: Click <strong>here</strong> to help your employees
       help_link_url: /en/employer-best-practices/money-guide
       faq_tips_button_html: 'Other FAQs &amp; Tips'


### PR DESCRIPTION
## Corrects type in my business section of the employer best practice portal

TP Ticket:
https://moneyadviceservice.tpondemand.com/entity/8343

**Summary**
The Infographic on this page:
https://www.moneyadviceservice.org.uk/en/employer-best-practices/my-business

Contains a typo - The bottom left hand point says:
"70% of employees would point employees to useful information if they had access"
 
This should read:
"70% of employers would point employees to useful information if they had access"

This PR makes this change, please note this is for English only

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1757)
<!-- Reviewable:end -->
