### PR TITLE
#8388 add newrelic_ignore_enduser to amp articles controller

### DIFF
--- a/app/controllers/amp_articles_controller.rb
+++ b/app/controllers/amp_articles_controller.rb
@@ -3,6 +3,8 @@ class AmpArticlesController < ActionController::Base
 
   include NotFound
 
+  newrelic_ignore_enduser
+
   decorates_assigned :article, with: AmpArticleDecorator
   before_action :retrieve_article
 


### PR DESCRIPTION
TP #8388

https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx?acid=5D6AC326B4D272C23E446C28586BAF51#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&searchPopup=Bug/8388

**Summary**
add new relic_ignore_enduser call to amp_articles_controller to prevent new relic js script being injected into AMP pages

**Testing**
Tested on UAT

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1762)
<!-- Reviewable:end -->
