### PR TITLE
#8476 remove GooglePlus link embedded in frontend app

### DIFF
--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -27,7 +27,6 @@
   <meta http-equiv="cleartype" content="on"><![endif]-->
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="HandheldFriendly" content="True">
-
   <meta name="application-name" content="Money Advice Service">
   <meta name="msapplication-starturl" content="https://www.moneyadviceservice.org.uk">
   <meta name="msapplication-square70x70logo" content="/favicon_ms_70x70.png">
@@ -47,7 +46,6 @@
   <%= tag 'link', rel: 'apple-touch-icon-precomposed', sizes: '180x180', href: '/favicon_180x180.png' %>
   <%= tag 'link', rel: 'manifest', href: '/manifest.json' %>
 
-  <%= tag 'link', rel: 'publisher', href: Rails.application.config.google_plus_mas_url %>
   <%# Basic styles for all devices, doesn't contain anything that could cause rendering issues
       such as positional info %>
   <%= stylesheet_link_tag 'dough/assets/stylesheets/basic' %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,7 +24,6 @@ module Frontend
     config.i18n.load_path    += Dir[Rails.root.join('config', 'locales', '**/*', '*.yml').to_s]
 
     config.crazy_egg_url         = '//dnn506yrbagrg.cloudfront.net/pages/scripts/0018/4438.js'
-    config.google_plus_mas_url   = '//plus.google.com/+MoneyadviceserviceOrgUkYourMoneyAdvice/'
     config.google_tag_manager_id = 'GTM-WVFLH9'
 
     config.time_zone = 'Europe/London'


### PR DESCRIPTION
Replace Broken GooglePlus link on Frontend application 
 
Old link is now broken because the admin account used to create has now been deleted.
 
https://plus.google.com/+MoneyadviceserviceOrgUkYourMoneyAdvice/
 
Needs to be replaced with the numerical url link below
 
https://plus.google.com/116645767000258814442


TP ticket link:-

https://moneyadviceservice.tpondemand.com/entity/8476

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1777)
<!-- Reviewable:end -->
