### PR TITLE
[DEV APPROVED] 8391 - Broken page should show 404 error

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -15,6 +15,8 @@ class CategoriesController < ApplicationController
     @breadcrumbs = BreadcrumbTrail.build(@category, category_tree)
 
     assign_active_categories(@category)
+  rescue Core::Repository::Base::RequestError
+    not_found
   end
 
   private

--- a/features/cassettes/CMS/get/api/en/categories/nonexistent-category_json.yml
+++ b/features/cassettes/CMS/get/api/en/categories/nonexistent-category_json.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3000/api/en/categories/nonexistent-category.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mas-Responsive/1.0 (Eriks-MacBook-Pro.local; erik; 31425) ruby/2.2.5 (319;
+        x86_64-darwin16)
+      X-Request-Id:
+      - 86d2c978-991d-4b03-be97-c965e3a19dab
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 21 Aug 2017 13:15:08 GMT
+      Status:
+      - 200 OK
+      Connection:
+      - close
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - '"37a6259cc0c1dae299a7866489dff0bd"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 86d2c978-991d-4b03-be97-c965e3a19dab
+      X-Runtime:
+      - '0.224416'
+    body:
+      encoding: UTF-8
+      string: 'null'
+    http_version: 
+  recorded_at: Mon, 21 Aug 2017 13:15:08 GMT
+recorded_with: VCR 3.0.3

--- a/features/categories.feature
+++ b/features/categories.feature
@@ -13,3 +13,8 @@ Feature: Categories
     Then I should see the category name and description
     And I should see the child categories
     And I should see the child category content items
+
+  @allow-rescue
+  Scenario: View a nonexistent category
+    When I view a category that does not exist
+    Then I should see a 404 error

--- a/features/step_definitions/category_steps.rb
+++ b/features/step_definitions/category_steps.rb
@@ -16,6 +16,10 @@ When(/^I view a category containing child categories in (.*)$/) do |language|
   browse_to_category(category_containing_child_categories, locale)
 end
 
+When(/^I view a category that does not exist$/) do
+  category_page.load(locale: 'en', id: 'nonexistent-category')
+end
+
 Then(/^I should see the category name and description$/) do
   expect(category_page.heading).to have_content(current_category.title)
   expect(category_page.description).to have_content(current_category.description)
@@ -65,4 +69,8 @@ Then(/^the category page should have alternate tags for the supported locales$/)
     expect(expected_hreflangs).to include(alternate_tag[:hreflang])
     expect(expected_hrefs).to include(alternate_tag[:href])
   end
+end
+
+Then(/^I should see a 404 error$/) do
+  expect(page.status_code).to eq(404)
 end

--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -38,7 +38,12 @@ RSpec.describe CategoriesController, type: :controller do
     end
 
     context 'when the category does not exist' do
-      before { allow_any_instance_of(Core::CategoryReader).to receive(:call).and_yield(category) }
+      before do
+        allow_any_instance_of(Core::CategoryReader).to receive(:call).and_raise(
+          Core::Repository::Base::RequestError,
+          'Unable to fetch Category JSON from Contento'
+        )
+      end
 
       it 'raises an ActionController RoutingError' do
         expect { get :show, id: category.id, locale: I18n.locale }


### PR DESCRIPTION
[TP link](https://moneyadviceservice.tpondemand.com/entity/8391)

**Summary**
Visiting https://www.moneyadviceservice.org.uk/en/corporate_categories/blah (where 'blah' can be by any nonexistent category) returns a 500 error (`Core::Repository::Base::RequestError 'Unable to fetch Category JSON from Contento'` is raised). A 404 should be returned instead.

This is ultimately because `Core::Repository::Categories::CMS` errors when a category doesn't exist in the CMS, and this error is never caught. Changing this behaviour deeper in the system could potentially impact on other code that depends on it, so we just rescue it in the controller and show a 404.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1789)
<!-- Reviewable:end -->
