### PR TITLE
[DEV APPROVED] 8364 - Fix Welsh links

### DIFF
--- a/app/views/corporate/index.html.erb
+++ b/app/views/corporate/index.html.erb
@@ -8,46 +8,46 @@
 
       <div class="l-promo-corporate">
         <div class="l-promo-corporate__item">
-          <a class="promo__link" href="/en/corporate_categories/about-us">
+          <%= link_to corporate_article_path(t('corporate_home.about_us.link')), class: 'promo__link' do %>
             <%= image_tag('corporate/about_us_promo.jpg', class:'promo__img') %>
             <h2 aria-level="2" class="promo__heading" role="heading"><%= t('corporate_home.about_us.heading') %></h2>
             <p class="promo__content"><%= t('corporate_home.about_us.content') %></p>
-          </a>
+          <% end %>
         </div>
         <div class="l-promo-corporate__item">
-          <a class="promo__link" href="/en/corporate/media-centre">
+          <%= link_to corporate_article_path(t('corporate_home.media_centre.link')), class: 'promo__link' do %>
             <%= image_tag('corporate/media_centre_promo.jpg', class:'promo__img') %>
             <h2 aria-level="2" class="promo__heading" role="heading"><%= t('corporate_home.media_centre.heading') %></h2>
             <p class="promo__content"><%= t('corporate_home.media_centre.content') %></p>
-          </a>
+          <% end %>
         </div>
         <div class="l-promo-corporate__item">
-          <a class="promo__link" href="/en/corporate_categories/partners">
+          <%= link_to corporate_category_path(t('corporate_home.partners.link')), class: 'promo__link' do %>
             <%= image_tag('corporate/partners_promo.jpg', class:'promo__img') %>
             <h2 aria-level="2" class="promo__heading" role="heading"><%= t('corporate_home.partners.heading') %></h2>
             <p class="promo__content"><%= t('corporate_home.partners.content') %></p>
-          </a>
+          <% end %>
         </div>
         <div class="l-promo-corporate__item">
-          <a class="promo__link" href="/en/corporate_categories/our-debt-work">
+          <%= link_to corporate_category_path(t('corporate_home.our_debt_work.link')), class: 'promo__link' do %>
             <%= image_tag('corporate/our_debt_work_promo.jpg', class:'promo__img') %>
             <h2 aria-level="2" class="promo__heading" role="heading"><%= t('corporate_home.our_debt_work.heading') %></h2>
             <p class="promo__content"><%= t('corporate_home.our_debt_work.content') %></p>
-          </a>
+          <% end %>
         </div>
         <div class="l-promo-corporate__item">
-          <a class="promo__link" href="/en/corporate_categories/resources-for-professionals">
+          <%= link_to corporate_category_path(t('corporate_home.resources.link')), class: 'promo__link' do %>
             <%= image_tag('corporate/professional_resources_promo.jpg', class:'promo__img') %>
             <h2 aria-level="2" class="promo__heading" role="heading"><%= t('corporate_home.resources.heading') %></h2>
             <p class="promo__content"><%= t('corporate_home.resources.content') %></p>
-          </a>
+          <% end %>
         </div>
         <div class="l-promo-corporate__item">
-          <a class="promo__link" href="/en/corporate/research">
+          <%= link_to corporate_article_path(t('corporate_home.research.link')), class: 'promo__link' do %>
             <%= image_tag('corporate/research_promo.jpg', class:'promo__img') %>
             <h2 aria-level="2" class="promo__heading" role="heading"><%= t('corporate_home.research.heading') %></h2>
             <p class="promo__content"><%= t('corporate_home.research.content') %></p>
-          </a>
+          <% end %>
         </div>
       </div>
     </main>

--- a/app/views/corporate/index.html.erb
+++ b/app/views/corporate/index.html.erb
@@ -15,7 +15,7 @@
           </a>
         </div>
         <div class="l-promo-corporate__item">
-          <a class="promo__link" href="/en/corporate_categories/media-centre">
+          <a class="promo__link" href="/en/corporate/media-centre">
             <%= image_tag('corporate/media_centre_promo.jpg', class:'promo__img') %>
             <h2 aria-level="2" class="promo__heading" role="heading"><%= t('corporate_home.media_centre.heading') %></h2>
             <p class="promo__content"><%= t('corporate_home.media_centre.content') %></p>

--- a/config/locales/corporate/corporate_home.cy.yml
+++ b/config/locales/corporate/corporate_home.cy.yml
@@ -7,18 +7,24 @@ cy:
     about_us:
       heading: Amdanom ni
       content: Gwasanaeth diduedd a rhad ac am ddim i helpu pobl i reoli eu harian (Pwy ydym ni, a’r hyn a wnawn)
+      link: amdanom-ni
     media_centre:
       heading: Canolfan y cyfryngau
       content: Newyddion a’r datganiadau diweddaraf i’r wasg
+      link: canolfan-gyfryngau
     partners:
       heading: Partneriaid
       content: Ein canllawiau, newyddion, offerynnau a fideos ar ein gwefan
+      link: partners
     our_debt_work:
       heading: Ein Gwaith Dyled
       content: Ein gwasanaeth dyled, cyhoeddiadau a phecynnau gwerthuso cyngor
+      link: our-debt-work
     resources:
       heading: Adnoddau i Bobl broffesiynol
       content: Adnoddau ar gyfer pobl broffesiynol sy’n gweithio gyda phobl ifanc a rhieni
+      link: resources-for-professionals
     research:
       heading: Ymchwil
       content: Ein gwaith ymchwil a gwerthuso
+      link: research

--- a/config/locales/corporate/corporate_home.en.yml
+++ b/config/locales/corporate/corporate_home.en.yml
@@ -7,21 +7,27 @@ en:
     about_us:
       heading: About us
       content: A free and impartial advice service to help people manage their money (Who we are and what we do)
+      link: about-us
     media_centre:
       heading: Media centre
       content: The latest news and press releases
+      link: media-centre
     partners:
       heading: Partners
       content: Our guides, news, tools and videos on your website
+      link: partners
     our_debt_work:
       heading: Our debt work
       content: Our debt service, publications and advice evaluation toolkits
+      link: our-debt-work
     resources:
       heading: Resources for professionals
       content: Resources for professionals who work with young people and parents
+      link: resources-for-professionals
     research:
       heading: Research
       content: Our research and evaluation work
+      link: research
   corporate_tool_directory:
     popular_tools:
       heading: Our popular tools


### PR DESCRIPTION
[TP link](https://moneyadviceservice.tpondemand.com/entity/8364)

**Summary**
This fixes a number of incorrect/missing Welsh links on https://www.moneyadviceservice.org.uk/en/corporate/.

The ticket pointed out one of these - the "Media centre" URL that was used works in English, but has no corresponding Welsh page and thus caused an error when the "Welsh" link is clicked.

In the process of fixing this, I found that the view had hardwired English URLs for several links, even though Welsh versions exist. So this PR also addresses that by using path helpers, and moving the link slugs into translation files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1790)
<!-- Reviewable:end -->
