### PR TITLE
[DEV APPROVED] 8464 Fix Canonical Link

### DIFF
--- a/config/locales/retirements.en.yml
+++ b/config/locales/retirements.en.yml
@@ -261,7 +261,7 @@ en:
     meta:
       title: Retirement budget planning
       description: ''
-      canonical: https://www.moneyadviceservice.org.uk/en/pensions-and-retirement/budgeting'
+      canonical: https://www.moneyadviceservice.org.uk/en/pensions-and-retirement/budgeting
     section1:
       title: Retirement budget planning
       video_caption_html: "Watch this short video of financial journalist Paul Lewis explaining budgeting in retirement. <a href=\"https://masjumpprdstorage.blob.core.windows.net/video-transcripts/budgeting_landing_page_transcript.en.pdf\" class=\"download-link--pdf\" download=\"budgeting_landing_page_transcript\">Download the video transcript</a>"


### PR DESCRIPTION
[TP Story](https://moneyadviceservice.tpondemand.com/entity/8464)

Tiny fix to remove an erroneous `'` from the end of a canonical link that caused issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1793)
<!-- Reviewable:end -->
