### PR TITLE
8464 - Remove extra single quote for canonical link in locale yml

### DIFF
--- a/config/locales/retirements.en.yml
+++ b/config/locales/retirements.en.yml
@@ -261,7 +261,7 @@ en:
     meta:
       title: Retirement budget planning
       description: ''
-      canonical: https://www.moneyadviceservice.org.uk/en/pensions-and-retirement/budgeting'
+      canonical: https://www.moneyadviceservice.org.uk/en/pensions-and-retirement/budgeting
     section1:
       title: Retirement budget planning
       video_caption_html: "Watch this short video of financial journalist Paul Lewis explaining budgeting in retirement. <a href=\"https://masjumpprdstorage.blob.core.windows.net/video-transcripts/budgeting_landing_page_transcript.en.pdf\" class=\"download-link--pdf\" download=\"budgeting_landing_page_transcript\">Download the video transcript</a>"


### PR DESCRIPTION
[TP Link](https://moneyadviceservice.tpondemand.com/entity/8464)

The `canonical` link in the [Retirement budget planning](https://www.moneyadviceservice.org.uk/en/pensions-and-retirement/budgeting) page gives you a 404:

```html
<link rel="canonical" href="https://www.moneyadviceservice.org.uk/en/pensions-and-retirement/budgeting&#39;" />
```

This was due to an extra single quote at the end of the link in the `en.yml` file. The welsh version works fine though.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1794)
<!-- Reviewable:end -->
