### PR TITLE
[DEV APPROVED]Removes dead-end email button from home buying checklist

### DIFF
--- a/app/assets/stylesheets/components/page_specific/_home_buying_checklist.scss
+++ b/app/assets/stylesheets/components/page_specific/_home_buying_checklist.scss
@@ -201,13 +201,6 @@ input.home-buying-checklist__form-input {
 .home-buying-checklist__buttons {
   padding: 1.25rem;
 }
-.home-buying-checklist__button-email{
-  margin: 0 1.25rem 1.25rem 0;
-}
-.home-buying-checklist__button-inline-group {
-  position: relative;
-  float: left;
-}
 
 .home-buying-checklist__button-mobile {
   display: inline;

--- a/app/views/home_buying_checklist/show.html.erb
+++ b/app/views/home_buying_checklist/show.html.erb
@@ -149,26 +149,6 @@
   </form>
   <div class="l-1col">
     <div class="home-buying-checklist__buttons">
-
-      <div class="home-buying-checklist__button-inline-group" data-dough-component="PopupTip">
-        <button data-dough-popup-trigger class="button button--primary home-buying-checklist__button-email">
-          Email me my checklist
-        </button>
-
-        <div data-dough-popup-container class="popup-tip__container">
-          <p data-dough-popup-content>Coming Soon!</p>
-          <button data-dough-popup-close type="button" class="popup-tip__close">
-            <span aria-hidden="true">
-              <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--mobile-close-box">
-                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--mobile-close-box"></use>
-              </svg>
-            </span>
-            <span class="visually-hidden">Close</span>
-          </button>
-        </div>
-
-      </div>
-
       <button class="button button--primary" onclick="window.print()">
         Print my checklist
       </button>


### PR DESCRIPTION
# Removed Email me my checklist button

TP Ticket: https://moneyadviceservice.tpondemand.com/entity/8324

This PR removes the unnecessary button on the home buying checklist which suggests there is an option to email the checklist.  However on closer inspection this button actually triggers a popup tip with the content "Coming Soon":

<img src="https://user-images.githubusercontent.com/13165846/29711430-a5e09616-898c-11e7-8731-7a16dc69b866.png" width="400" />

Not only is this bad practice but a misuse of the popup tip component, it is being used out of scope and context.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1797)
<!-- Reviewable:end -->
