### PR TITLE
[DEV APPROVED] Fix `bundle install` issues with latest `bundler`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,7 +89,7 @@ end
 group :test do
   gem 'capybara'
   gem 'chronic'
-  gem 'codeclimate-test-reporter', require: false
+  gem 'codeclimate-test-reporter', '0.6.0', require: false
   gem 'cucumber-rails', require: false
   gem 'database_cleaner'
   gem 'email_spec', '< 2' # DelayedJob integration removed in 2.0.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,7 +140,7 @@ GEM
     cliver (0.3.2)
     cocoon (1.2.9)
     codeclimate-test-reporter (0.6.0)
-      simplecov (<= 0.13)
+      simplecov (>= 0.7.1, < 1.0.0)
     coderay (1.1.1)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -624,11 +624,11 @@ GEM
     sexp_processor (4.9.0)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
-    simplecov (0.13.0)
+    simplecov (0.15.0)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.0)
+    simplecov-html (0.10.2)
     site_prism (2.9)
       addressable (>= 2.3.3, < 3.0)
       capybara (>= 2.1, < 3.0)
@@ -735,7 +735,7 @@ DEPENDENCIES
   car_cost_tool (~> 1.1.2)
   chai-jquery-rails
   chronic
-  codeclimate-test-reporter
+  codeclimate-test-reporter (= 0.6.0)
   contribution_calculator (~> 0.1.0)
   cost_calculator_builder (~> 0.4.2)
   cream (~> 1.0.0)
@@ -818,4 +818,4 @@ DEPENDENCIES
   wpcc (= 1.5.1)
 
 BUNDLED WITH
-   1.15.1
+   1.15.4

--- a/README.md
+++ b/README.md
@@ -92,18 +92,6 @@ rm bower.json
 bowndler install
 ```
 
-#### Bundle install issues
-
-```
-Downloading codeclimate-test-reporter-0.6.0 revealed dependencies not in the API or the lockfile (simplecov (< 1.0.0,
->= 0.7.1)).
-Either installing with `--full-index` or running `bundle update codeclimate-test-reporter` should fix the problem.
-```
-
-(Bundling updating a single gem leads to a loop of having to update the previous gem.)
-
-Ensuring (for now) that the `bundler` gem is `1.14.6` works around this issue for now.
-
 ## Contributing
 
 1. Fork it


### PR DESCRIPTION
Currently, running `bundle install` for the first time with the latest version of `bundler` returns an error:

```
Downloading codeclimate-test-reporter-0.6.0 revealed dependencies not in the API or the lockfile (simplecov (< 1.0.0,
->= 0.7.1)).
Either installing with `--full-index` or running `bundle update codeclimate-test-reporter` should fix the problem.
```

There's a known workaround, which is to downgrade `bundler` to 1.14.6. Once the gems have been installed, `bundle install` works with no errors even with the latest `bundler` version, which is probably why this problem doesn't appear in Go builds or MAS dev environments.

The problem turned out to be an incorrectly specified dependency for `codeclimate-test-reporter` in the `Gemfile.lock` (similar problems are described [here](https://github.com/bundler/bundler/issues/5846), with suggestions that the cause is usually a corrupted lockfile).

To fix it, we locked `codeclimate-test-reporter` to the version currently used (since upgrading to the latest version would require code/configuration changes), and ran `bundle update codeclimate-test-reporter`, allowing bundler to correct the dependencies in the lockfile.

Since this fixes the problem, the workaround has been removed from the README.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1799)
<!-- Reviewable:end -->
