### PR TITLE
[DEV APPROVED] Update JavaScript dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,26 +2,27 @@
   "name": "frontend",
   "private": true,
   "devDependencies": {
-    "chai": "^1.9.1",
-    "chai-jquery": "^1.2.3",
-    "karma": "^0.12.23",
+    "chai": "^3.5.0",
+    "chai-jquery": "^2.0.0",
+    "karma": "^1.7.0",
     "karma-chai": "^0.1.0",
     "karma-chai-jquery": "^1.0.0",
-    "karma-coverage": "^0.2.6",
-    "karma-html2js-preprocessor": "^0.1.0",
-    "karma-jquery": "^0.1.0",
-    "karma-mocha": "^0.1.4",
-    "karma-phantomjs-launcher": "0.1.4",
-    "karma-requirejs": "~0.2.0",
-    "karma-sinon": "^1.0.3",
+    "karma-coverage": "^1.1.1",
+    "karma-html2js-preprocessor": "^1.1.0",
+    "karma-jquery": "^0.2.2",
+    "karma-mocha": "^1.3.0",
+    "karma-osx-reporter": "^0.2.1",
+    "karma-phantomjs-launcher": "^1.0.4",
+    "karma-requirejs": "^1.1.0",
+    "karma-sinon": "^1.0.5",
     "karma-sinon-chai": "^0.2.0",
-    "karma-spec-reporter": "0.0.13",
-    "karma-osx-reporter": "*",
+    "karma-spec-reporter": "^0.0.31",
     "mocha": "~1.15.1",
-    "phantomjs": ">= 1.9.7-1",
+    "phantomjs-prebuilt": "^2.1.15",
+    "requirejs": "^2.3.5",
     "sinon": "^1.9.0"
   },
-    "scripts": {
+  "scripts": {
     "test": "./node_modules/karma/bin/karma start spec/javascripts/karma.conf.js"
   }
 }


### PR DESCRIPTION
This PR is very similar to https://github.com/moneyadviceservice/budget_planner/pull/484, and done for similar reasons.

The currently specified versions of PhantomJS and a number of Karma packages are very old (many years). These are only used to run specs, and the specs run fine with the most recent versions, so this updates them. `karma-sinon-chai` had to be locked to a less recent version, since more recent ones cause individual tests to fail.

Since these packages are only used in development, deploying this change to production should not cause any issues.

Without some of these updates, it's often not possible to run the specs at all on systems with relatively recent versions of PhantomJS (>=2) installed, which causes issues for development.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1802)
<!-- Reviewable:end -->
