### PR TITLE
[DEV APPROVED] Moves the inclusion of JQuery higher in layout template

### DIFF
--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -9,6 +9,8 @@
 <head>
   <meta property="fb:pages" content="160564360681471" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+  <%= javascript_include_tag 'jquery/dist/jquery', async: 'async' %>
   <%= optimizely_include_tag if (Rails.env.production? || is_environment_on_uat?) %>
 
   <% if hide_elements_irrelevant_for_third_parties? %>
@@ -213,7 +215,7 @@
           j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : '';
       j.async = true;
       j.src = '//www.googletagmanager.com/gtm.js?id=' + i + dl;
-      f.parentNode.insertBefore(j, f);
+      f.parentNode.insertBefore(j, f.nextSibling);
     })(window, document, 'script', 'dataLayer', '<%= Rails.application.config.google_tag_manager_id %>');
   </script>
 <% end %>


### PR DESCRIPTION
# Moving JQuery higher in layout

There currently an issue with tracking and optimizely where JQuery is being loaded after both scripts, and optimizely requires JQuery, this is resulting in around a 40% of target users not seeing the A/B tests.

This PR moves the inclusion of JQuery to before the optimizely include tag.

## ASYNC

You'll notice that I have include an ``async`` attribute to the JQuery include tag, this will ensure that the script in non-blocking, and will allow the DOM content to be loaded while script is executed.  After a quick test I found the following performance impact:

| | DOMLOAD (Page is readable) | FULL LOAD (All images, scripts are complete) |
|-------|-------|-------|
| Current | 1.24s | 2s |
| ASYNC | 1.60s | 1.97s |

The DOM load is slightly impacted because the scripts are being executed at the same time as the DOM is being loaded.

While the full page load is slightly lower because the execution of jquery had already began earlier on in the loading of the page.

This will be tested in UAT and the impact on performance made clearer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1804)
<!-- Reviewable:end -->
