### PR TITLE
[DEV APPROVED] 8556 - Sets a flexible width for syndicating debt advice locator tool (f2f)

### DIFF
--- a/app/assets/javascripts/syndication/tools.js.coffee
+++ b/app/assets/javascripts/syndication/tools.js.coffee
@@ -291,6 +291,7 @@
       cy:
         path: "cy/tools/canfyddwr-cyngor-ar-ddyledion/f2f"
       title: "Debt advice locator - face to face"
+      width: "100%"
 
     car_cost_tool:
       en:


### PR DESCRIPTION
# Debt advice locator (f2f) tool width

Ticket https://moneyadviceservice.tpondemand.com/entity/8566

Currently when the debt advice locator (f2f) tool is mounted using the syndication script, the tool appears very narrow, around 300px.

This needs to be adjusted so that the tool expands to the width of its parent container (iframe needs to have 100% width).  This gives partners control over how wide the tool appears once mounted as it will always be the full width of the container they put it in.

| Before | After |
|-------|------|
|![image](https://user-images.githubusercontent.com/13165846/30277169-e310c4d2-96fe-11e7-9833-a54bb60a7117.png)|![image](https://user-images.githubusercontent.com/13165846/30277185-ed097b8c-96fe-11e7-96bd-137157cd4e8f.png)|

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1805)
<!-- Reviewable:end -->
