### PR TITLE
[DEV APPROVED] 8549 - Adds links for tools on mobile nav

### DIFF
--- a/app/assets/javascripts/components/GlobalNav.js
+++ b/app/assets/javascripts/components/GlobalNav.js
@@ -233,7 +233,7 @@ define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities', 'common'], 
 
     this.$globalSubNavHeading.click(function(e) {
       e.preventDefault();
-      self._toggleMobileSubNav(this);
+      self._returnMobileNav(this);
     });
 
     this.$mobileNavClose.click(function(e){
@@ -304,6 +304,7 @@ define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities', 'common'], 
   GlobalNav.prototype._toggleMobileNav = function() {
     this.$globalNav.toggleClass('is-active');
     this.$mobileNavOverlay.toggleClass('is-active');
+    $('body').addClass('no-scroll');
 
     // If we just closed the nav, reset all subnavs
     if (!this.$globalNav.hasClass('is-active')) {
@@ -311,6 +312,7 @@ define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities', 'common'], 
       this.$mobileNavOverlay.removeClass('is-active');
       this.$globalNavClumps.removeClass('is-active');
       this.$globalNavClump.removeClass('is-active');
+      $('body').removeClass('no-scroll');
     }
   };
 
@@ -318,6 +320,15 @@ define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities', 'common'], 
     $(index)
       .parents('[data-dough-nav-clump]').toggleClass('is-active')
       .parents('[data-dough-nav-clumps]').toggleClass('is-active');
+      this.$globalSubNav.removeClass('is-hidden');
+
+  };
+
+  GlobalNav.prototype._returnMobileNav = function(index) {
+    $(index)
+      .parents('[data-dough-nav-clump]').toggleClass('is-active')
+      .parents('[data-dough-nav-clumps]').toggleClass('is-active');
+      this.$globalSubNav.addClass('is-hidden');
   };
 
   GlobalNav.prototype._openDesktopSubNav = function(index) {

--- a/app/assets/javascripts/components/GlobalNav.js
+++ b/app/assets/javascripts/components/GlobalNav.js
@@ -330,7 +330,9 @@ define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities', 'common'], 
     $(index)
       .parents('[data-dough-nav-clump]').toggleClass('is-active')
       .parents('[data-dough-nav-clumps]').toggleClass('is-active');
-      this.$globalSubNav.addClass('is-hidden');
+      setTimeout(function(){
+        $('[data-dough-subnav]').addClass('is-hidden');
+      }, 400);
   };
 
   GlobalNav.prototype._openDesktopSubNav = function(index) {

--- a/app/assets/javascripts/components/GlobalNav.js
+++ b/app/assets/javascripts/components/GlobalNav.js
@@ -317,11 +317,13 @@ define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities', 'common'], 
   };
 
   GlobalNav.prototype._toggleMobileSubNav = function(index) {
+    var siblingsNav = $(index).siblings().get(0);
+
     $(index)
       .parents('[data-dough-nav-clump]').toggleClass('is-active')
       .parents('[data-dough-nav-clumps]').toggleClass('is-active');
-      this.$globalSubNav.removeClass('is-hidden');
 
+    $(siblingsNav).removeClass('is-hidden');
   };
 
   GlobalNav.prototype._returnMobileNav = function(index) {

--- a/app/assets/stylesheets/components/common/_global_nav.scss
+++ b/app/assets/stylesheets/components/common/_global_nav.scss
@@ -154,6 +154,10 @@ $global-nav-transition-duration: 300ms;
   }
 }
 
+.no-scroll {
+  overflow: hidden;
+}
+
 .global-nav__clump:last-child {
   border-bottom: none;
 }

--- a/app/assets/stylesheets/components/common/_global_subnav.scss
+++ b/app/assets/stylesheets/components/common/_global_subnav.scss
@@ -41,6 +41,10 @@ $global-nav-transition-duration: 300ms !default; // Defined in _global_nav.scss
   }
 }
 
+.is-hidden {
+  display: none;
+}
+
 // no-js fallback --
 .uninitialised {
   @include respond-to($mq-m) {
@@ -152,11 +156,10 @@ $global-nav-transition-duration: 300ms !default; // Defined in _global_nav.scss
 }
 
 .global-subnav__tool-category {
-  display: none;
+  display: table-cell;
 
   @include respond-to($mq-m) {
     /* non-FlexBox compliant -- */
-    display: table-cell;
     vertical-align: top;
     /* -- non-FlexBox compliant */
   }

--- a/app/assets/stylesheets/components/common/_global_subnav.scss
+++ b/app/assets/stylesheets/components/common/_global_subnav.scss
@@ -156,10 +156,11 @@ $global-nav-transition-duration: 300ms !default; // Defined in _global_nav.scss
 }
 
 .global-subnav__tool-category {
-  display: table-cell;
+  display: block;
 
   @include respond-to($mq-m) {
     /* non-FlexBox compliant -- */
+    display: table-cell;
     vertical-align: top;
     /* -- non-FlexBox compliant */
   }

--- a/app/assets/stylesheets/components/common/_global_subnav.scss
+++ b/app/assets/stylesheets/components/common/_global_subnav.scss
@@ -14,7 +14,7 @@ $global-nav-transition-duration: 300ms !default; // Defined in _global_nav.scss
   top: 0;
   left: 0;
   transform: translateX(100%);
-  padding: $baseline-unit;
+  padding: $baseline-unit $baseline-unit $baseline-unit*10 $baseline-unit;
 
   @include respond-to($mq-m) {
     transition: none;

--- a/app/views/shared/_global_nav.html.erb
+++ b/app/views/shared/_global_nav.html.erb
@@ -11,7 +11,7 @@
             </svg>
           </a>
 
-          <div data-dough-subnav class="l-constrained global-subnav">
+          <div data-dough-subnav class="l-constrained global-subnav is-hidden">
             <div class="l-constrained">
               <p class="global-nav__clump__description" aria-role="category description"><%= clump.description %></p>
 

--- a/spec/javascripts/fixtures/GlobalNav.html
+++ b/spec/javascripts/fixtures/GlobalNav.html
@@ -6,7 +6,7 @@
         <a data-dough-nav-clump-heading tabindex="0">
           <span class="global-nav__clump__heading__text">First clump</span>
         </a>
-        <div data-dough-subnav>
+        <div data-dough-subnav class="is-hidden">
           <div>
             <a data-dough-subnav-heading></a>
             <ul data-dough-subcategories>
@@ -28,7 +28,7 @@
         <a data-dough-nav-clump-heading tabindex="0">
           <span class="global-nav__clump__heading__text">Second clump</span>
         </a>
-        <div data-dough-subnav>
+        <div data-dough-subnav class="is-hidden">
           <div>
             <a data-dough-subnav-heading></a>
             <ul data-dough-subcategories>

--- a/spec/javascripts/tests/GlobalNav_spec.js
+++ b/spec/javascripts/tests/GlobalNav_spec.js
@@ -1,4 +1,4 @@
-describe.only('GlobalNav', function() {
+describe('GlobalNav', function() {
   'use strict';
 
   beforeEach(function(done) {

--- a/spec/javascripts/tests/GlobalNav_spec.js
+++ b/spec/javascripts/tests/GlobalNav_spec.js
@@ -1,4 +1,4 @@
-describe('GlobalNav', function() {
+describe.only('GlobalNav', function() {
   'use strict';
 
   beforeEach(function(done) {
@@ -13,6 +13,8 @@ describe('GlobalNav', function() {
           self.mainContent = self.$html.find('#main');
           self.mobileNavButton = (self.$html).find('[data-dough-mobile-nav-button]');
           self.clumps = self.component.find('[data-dough-nav-clumps]');
+          self.clumpHeading = self.component.find('[data-dough-nav-clump-heading]');
+          self.mobileSubNav = self.component.find('[data-dough-subnav]');
           self.subNavHeading = self.component.find('[data-dough-subnav-heading]');
           self.mobileNavCloseButton = self.component.find('[data-dough-mobile-nav-close]');
           self.mobileNavOverlay = self.component.find('[data-dough-mobile-nav-overlay]');
@@ -68,7 +70,7 @@ describe('GlobalNav', function() {
   describe('Mobile interaction', function() {
     beforeEach(function() {
       this.obj.init();
-    });
+    }); 
 
     it('toggles nav visibility when menu button is clicked', function() {
       this.mobileNavButton.trigger('click');
@@ -76,7 +78,30 @@ describe('GlobalNav', function() {
 
       this.mobileNavButton.trigger('click');
       expect(this.component.hasClass('is-active')).to.be.false;
+
+      this.mobileNavButton.trigger('click');
+      expect(this.mobileSubNav.hasClass('is-hidden')).to.be.true;
+      expect($('body').hasClass('no-scroll')).to.be.true;
     });
+
+    it('When clump heading is clicked remove is-hidden class from subnav', function() {
+      // This test is prevented from being initiated by mediaQueries.atSmallViewport() if statement.
+      // This is called by the $globalNavClumpHeading click function within the GlobalNav.js component. 
+
+      /*
+      $('#clump-1').find('[data-dough-nav-clump-heading]').trigger('click');
+      var siblingsNav = $('#clump-1').find('[data-dough-subnav]').get(0);
+
+      expect($(siblingsNav).hasClass('is-hidden')).to.be.false;
+      */
+    }); 
+
+    it('Applys is-hidden class to sub nav and returns to main mobile nav', function() {
+      $('#clump-1').find('[data-dough-subnav-heading]').trigger('click');
+      var siblingsNav = $('#clump-1').find('[data-dough-subnav]').get(0);
+
+      expect($(siblingsNav).hasClass('is-hidden')).to.be.true;
+    }); 
 
     it('toggles subnav visibility when clump heading is clicked', function() {
       $('#clump-1').find('[data-dough-subnav-heading]').trigger('click');

--- a/spec/javascripts/tests/GlobalNav_spec.js
+++ b/spec/javascripts/tests/GlobalNav_spec.js
@@ -85,15 +85,7 @@ describe.only('GlobalNav', function() {
     });
 
     it('When clump heading is clicked remove is-hidden class from subnav', function() {
-      // This test is prevented from being initiated by mediaQueries.atSmallViewport() if statement.
-      // This is called by the $globalNavClumpHeading click function within the GlobalNav.js component. 
-
-      /*
-      $('#clump-1').find('[data-dough-nav-clump-heading]').trigger('click');
-      var siblingsNav = $('#clump-1').find('[data-dough-subnav]').get(0);
-
-      expect($(siblingsNav).hasClass('is-hidden')).to.be.false;
-      */
+      // This test is prevented from being initiated by mediaQueries.atSmallViewport() helper.
     }); 
 
     it('Applys is-hidden class to sub nav and returns to main mobile nav', function() {


### PR DESCRIPTION
# The Global Nav does not surface tool links on mobile

TP [8549](https://moneyadviceservice.tpondemand.com/entity/8549)

a) These tools are often interacted with on Desktop so it would be valuable to surface them on mobile as well.

b) Fix vertical scrolling issue introduced to mobile nav when tools are displayed.

**Bonus**
Fix body scrolling issue discovered while testing mobile nav.

## Solution:

Change tools in mobile nav visibility to `display: block;`
Add `'no-scroll` class to body when mobile nav is opened.
Update subnav view  by adding `is-hidden` class and remove class with javascript when subnav is triggered.
Increase bottom padding in `.global-subnav` to allow the close button to be displayed.

## Notes:
This work led to the discovery of some limitations to our Karma testing environment. 

**Specifically:**
Karma is not set up to compile SCSS and include these stylsheets in its fixtures. This means that javascript which modifies CSS properties can not be directly tested.

![screenshot_20170926-161115](https://user-images.githubusercontent.com/2187295/30868042-74b085d0-a2d5-11e7-9b35-a8be60585191.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1811)
<!-- Reviewable:end -->
