### PR TITLE
[DEV APPROVED] TP: 8606, Comment: Fixes dropdown display issue

### DIFF
--- a/app/assets/stylesheets/components/common/_global_subnav.scss
+++ b/app/assets/stylesheets/components/common/_global_subnav.scss
@@ -24,6 +24,7 @@ $global-nav-transition-duration: 300ms !default; // Defined in _global_nav.scss
     margin: 0;
     max-width: none;
     background: $color-white;
+    padding-bottom: $baseline-unit;
 
     /* non-FlexBox compliant -- */
     display: table-row;


### PR DESCRIPTION
**Target Process ticket**
[TP8606](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx?acid=6C17D8319C81AC3D36AFAD64CAE08A28#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&boardPopup=bug/8606)

**Summary**
After a recent deploy the nav drop-downs are displaying without the drop shadow at the bottom making this hard to distinguish from the general background.

The solution is to revert a change that was made for the mobile nav on desktop devices.

**Examples**
Before: 

![screen shot 2017-10-05 at 09 58 50](https://user-images.githubusercontent.com/6080548/31220990-1be359aa-a9ba-11e7-9fbd-21c824b85986.png)

After:

![screen shot 2017-10-05 at 10 45 40](https://user-images.githubusercontent.com/6080548/31221071-60315ec2-a9ba-11e7-8ba6-416c0973061e.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1817)
<!-- Reviewable:end -->
