### PR TITLE
[DEV APPROVED] Change bower registry

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,4 @@
 {
-  "directory": "vendor/assets/bower_components"
+  "directory": "vendor/assets/bower_components",
+  "registry": "https://registry.bower.io"
 }


### PR DESCRIPTION
## Problem

When our [GO CI](https://go.dev.mas.local/go/tab/build/detail/responsive_commit_uat/256/test_and_build/1/test)
 runs `bower install` the following error is raised:

`Request to https://bower.herokuapp.com/packages/angular failed with 410`

This is because the bower registry: `http://bower.herokuapp.com` is not working anymore.

## Short-term Solution

And you can see here we need to update the bower registry to the new one: https://gist.github.com/sheerun/c04d856a7a368bad2896ff0c4958cb00

More of the issue you can follow here: https://github.com/bower/bower/issues/2484

See the build passed for this: https://go.dev.mas.local/go/tab/build/detail/responsive_commit_uat/257/test_and_build/1/test
## This is not over

So we need to update *ALL* of our tools on bower registry if we continue to use bower. This requires a further discussion with the team along side with updating Rails 5 and replaces bower with yarn/webpack.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1820)
<!-- Reviewable:end -->
