### PR TITLE
Bumps UC version 2-16-0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ gem 'quiz', '~> 1.2.0', source: 'http://gems.dev.mas.local'
 gem 'rio', '1.18.4', source: 'http://gems.dev.mas.local'
 gem 'savings_calculator', '~> 1.8.1'
 gem 'timelines', '~> 1.4.0'
-gem 'universal_credit', '2.15.0'
+gem 'universal_credit', '2.16.0'
 gem 'wpcc', '1.11.8'
 
 # 1.0.2 has breaking changes as it adds japanese and turkish locales

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -681,7 +681,7 @@ GEM
     unicorn-rails (2.2.1)
       rack
       unicorn
-    universal_credit (2.15.0)
+    universal_credit (2.16.0)
       autoprefixer-rails
       devise
       dough-ruby
@@ -810,7 +810,7 @@ DEPENDENCIES
   turnout
   uglifier
   unicorn-rails
-  universal_credit (= 2.15.0)
+  universal_credit (= 2.16.0)
   validate_url (= 1.0.0)
   vcr
   webmock


### PR DESCRIPTION
Bumps UC tool to version 2.16.0 for [PR](https://github.com/moneyadviceservice/universal_credit/pull/195)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1823)
<!-- Reviewable:end -->
