### PR TITLE
[DEV APPROVED] Added cost calculator builder migration

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170914164504) do
+ActiveRecord::Schema.define(version: 20171011163826) do
 
   create_table "action_plans_expense_items", force: :cascade do |t|
     t.string  "kind",       limit: 256,             null: false
@@ -263,6 +263,7 @@ ActiveRecord::Schema.define(version: 20170914164504) do
     t.datetime "updated_at"
     t.integer  "index",               limit: 4
     t.boolean  "allow_user_duration"
+    t.string   "image_url",           limit: 255
   end
 
   add_index "cost_calculator_builder_expense_pages", ["calculator_id"], name: "index_cost_calculator_builder_expense_pages_on_calculator_id", using: :btree


### PR DESCRIPTION
Cost calculator builder is returning an [error](https://app.bugsnag.com/money-advice-service/responsive-site/errors/57f8a21e9a8502cbc9b7ae45?filters%5Bevent.since%5D%5B%5D=30d&filters%5Berror.status%5D%5B%5D=open).

This is because the field was not included on the db migrate. Adding on db migrate solves the issue

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1825)
<!-- Reviewable:end -->
