### PR TITLE
[DEV APPROVED] TP: 7975, Comment: Adds Breadcrumb component + bumps version number for Yeast

### DIFF
--- a/app/assets/javascripts/components/Breadcrumbs.js
+++ b/app/assets/javascripts/components/Breadcrumbs.js
@@ -1,0 +1,58 @@
+define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities'], function($, DoughBaseComponent, mediaQueries, utilities) {
+  'use strict';
+
+  var Breadcrumbs;
+
+  Breadcrumbs = function($el, config) {
+    Breadcrumbs.baseConstructor.call(this, $el, config);
+
+    this.$breadcrumbs = this.$el;
+  };
+
+  /**
+  * Inherit from base module, for shared methods and interface
+   */
+  DoughBaseComponent.extend(Breadcrumbs);
+  Breadcrumbs.componentName = 'Breadcrumbs';
+
+  /**
+  * Initialize the component
+   */
+  Breadcrumbs.prototype.init = function(initialised) {
+    console.log('init!');
+
+    this._initialisedSuccess(initialised);
+    this._bindEvents();
+    this._setVisibility();
+
+    return this;
+  };
+
+  /**
+   * Set up events
+   */
+  Breadcrumbs.prototype._bindEvents = function() {
+    $(window).on('resize', utilities.debounce($.proxy(this._setVisibility, this), 100));
+  }
+
+  /**
+   * Set aria-hidden to be true for small screenwidth
+   * Set HTML5 hidden property to be 'hidden' for small screenwidth
+   */
+  Breadcrumbs.prototype._setVisibility = function() {
+    console.log('_setUpAria!');
+
+    if (mediaQueries.atSmallViewport()) {
+      this.$breadcrumbs
+        .attr('aria-hidden', true)
+        .prop('hidden', 'hidden');
+    } else {
+      this.$breadcrumbs
+        .attr('aria-hidden', false)
+        .removeProp('hidden');
+    }
+  }
+
+  return Breadcrumbs;
+});
+

--- a/app/assets/javascripts/require_config.js.erb
+++ b/app/assets/javascripts/require_config.js.erb
@@ -23,6 +23,7 @@
 //= depend_on_asset components/GlobalNav
 //= depend_on_asset components/Glossary
 //= depend_on_asset components/HomeBuyingChecklist
+//= depend_on_asset components/Breadcrumbs
 //= depend_on_asset dough/assets/js/lib/featureDetect
 //= depend_on_asset dough/assets/js/lib/componentLoader
 //= depend_on_asset dough/assets/js/components/SearchFocus
@@ -80,6 +81,7 @@
       StickyColumn: requirejs_path('components/StickyColumn'),
       GlobalNav: requirejs_path('components/GlobalNav'),
       HomeBuyingChecklist: requirejs_path('components/HomeBuyingChecklist'),
+      Breadcrumbs: requirejs_path('components/Breadcrumbs'),
 
       # Engines
       carCostToolConfig: requirejs_path('car_cost_tool/require_config'),

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -1,4 +1,4 @@
-<nav class="breadcrumbs" role="navigation" aria-label="<%= t('breadcrumbs.aria_label') %>">
+<nav class="breadcrumbs" role="navigation" aria-label="<%= t('breadcrumbs.aria_label') %>" data-dough-component="Breadcrumbs">
   <ul class="unstyled-list">
     <% breadcrumbs.each_with_index do |breadcrumb, index| %>
       <li class="breadcrumbs__item" itemscope itemtype="http://data-vocabulary.org/Breadcrumb">

--- a/bower.json.erb
+++ b/bower.json.erb
@@ -11,7 +11,7 @@
     "jquery-waypoints": "2.0.*",
     "jquery-ujs": "*",
     "bind-polyfill": "^1.0.0",
-    "yeast": "1.6.0",
+    "yeast": "1.6.1",
     "advice_plans": "<%= gem_path('advice_plans') %>",
     "car_cost_tool": "<%= gem_path('car_cost_tool') %>",
     "debt_advice_locator": "<%= gem_path('debt_advice_locator') %>",


### PR DESCRIPTION
**Target Process ticket**
[TP7975](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&searchPopup=userstory/7975)

This PR relates to [PR42](https://github.com/moneyadviceservice/yeast/pull/42) on Yeast and bumps the version number to 1.6.1 to deploy that change to frontend.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1835)
<!-- Reviewable:end -->
