### PR TITLE
[DEV APPROVED] 8640 - Adds noindex to homebuying checklist

### DIFF
--- a/app/views/home_buying_checklist/show.html.erb
+++ b/app/views/home_buying_checklist/show.html.erb
@@ -1,3 +1,7 @@
+<% content_for(:head) do %>
+  <meta name="robots" content="noindex">
+<% end %>
+
 <div class="l-constrained">
   <div class="home-buying-checklist-top">
     <div class="l-1col">


### PR DESCRIPTION
**Target Process ticket**

[TP 8604](https://moneyadviceservice.tpondemand.com/entity/8640)

**Summary**
Currently Google is indexing the home buying checklist, this shouldn't happen as its part of an A/B test to test the demand for the tool.

**Checklist**

+ [x] Tests passed.
+ [x] Code Climate passed for this PR.
+ [x] Commit history reviewed (clear commit messages).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1836)
<!-- Reviewable:end -->
