### PR TITLE
[DEV APPROVED] 8727 Remove Optimizely tag from syndicated tools

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,6 @@ class ApplicationController < ActionController::Base
   include Localisation
   include NotFound
   include AssetsHelper
-  include ApplicationHelper
 
   before_action :fetch_footer_content
   def fetch_footer_content
@@ -101,6 +100,10 @@ class ApplicationController < ActionController::Base
   helper_method :mas_optimizely_tag
 
   private
+
+  def is_environment_on_uat?
+    Rails.env == 'uat'
+  end
 
   def set_syndicated_x_frame
     response.headers['X-Frame-Options'] = 'ALLOWALL' if syndicated_tool_request?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,8 @@ class ApplicationController < ActionController::Base
   include Chat
   include Localisation
   include NotFound
+  include AssetsHelper
+  include ApplicationHelper
 
   before_action :fetch_footer_content
   def fetch_footer_content
@@ -89,6 +91,14 @@ class ApplicationController < ActionController::Base
 
   def set_tool_instance
   end
+
+  def mas_optimizely_tag
+    return if syndicated_tool_request?
+
+    optimizely_include_tag if Rails.env.production? || is_environment_on_uat?
+  end
+
+  helper_method :mas_optimizely_tag
 
   private
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -55,10 +55,6 @@ module ApplicationHelper
     (request.fullpath =~ /^\/(cy|en)\/(tools|retirement-income-options)/).present?
   end
 
-  def is_environment_on_uat?
-    ENV['MAS_ENVIRONMENT'] == 'uat'
-  end
-
   private
 
   def strip_leading_indentation_from_source(source)

--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -11,7 +11,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <%= javascript_include_tag 'jquery/dist/jquery', async: 'async' %>
-  <%= optimizely_include_tag if (Rails.env.production? || is_environment_on_uat?) %>
+  <%= mas_optimizely_tag %>
 
   <%= display_meta_tags(site: t('.title'), reverse: true, separator: '-') %>
   <%= csrf_meta_tags %>

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -19,12 +19,20 @@ RSpec.describe ApplicationController, type: :controller do
     it 'sets x frame options to ALLOWALL' do
       expect(subject.headers['X-Frame-Options']).to eql('ALLOWALL')
     end
+
+    it 'does not render Optimizely tag' do
+      expect(controller.mas_optimizely_tag).to be_nil
+    end
   end
 
   context 'when not a syndicated request' do
     controller do
       def syndicated_tool_request?
         false
+      end
+
+      def is_environment_on_uat?
+        true
       end
 
       def index
@@ -34,12 +42,24 @@ RSpec.describe ApplicationController, type: :controller do
 
     subject { get :index }
 
+    let(:digest) { '3094089b66468a09b6479fa0' }
+    let(:data) { { digest: digest } }
+
     it 'does not render syndicated layout' do
       expect(subject).to_not render_template('layouts/syndicated')
     end
 
     it 'sets x frame options to SAMEORIGIN' do
       expect(subject.headers['X-Frame-Options']).to eql('SAMEORIGIN')
+    end
+
+    it 'renders Optimizely tag' do
+      allow(File).to receive(:exist?).and_return(true)
+      allow(File).to receive(:open).and_return(
+        double('json_data', read: JSON[data], :sync= => true, puts: '')
+      )
+
+      expect(controller.mas_optimizely_tag).to include('optimizely')
     end
   end
 


### PR DESCRIPTION
**Target Process ticket**
[TP#8727](https://moneyadviceservice.tpondemand.com/entity/8727)

**Summary**
A developer from the charity Rethink reported seeing a potential JS error in Money Manager. This potentially impacting other tools. This error is common to all syndicated tools (e.g. https://partner-tools.moneyadviceservice.org.uk/en/tools/baby-money-timeline) and is because the Optimizely script isn’t available via the partner-tools domain. Periscopix are currently working to filter that domain via GTM. We will check again once that work is done ([as explained by](https://moneyadviceservice.tpondemand.com/entity/8727) @davidtrussler)

**QA / Testing**
The Optimizely script tags should only be rendered on the production and UAT environment for and non-syndicated tools.

**Checklist**

+ [x] Tests passed.
+ [x] Rubocop is passing for this PR (or any other lint like JShint).
+ [x] Code Climate passed for this PR.
+ [x] Commit history reviewed (clear commit messages).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1856)
<!-- Reviewable:end -->
