### PR TITLE
[DEV APPROVED] - Bumps dough to 5.26.2.302 for tooltip no-js update 8744

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -275,7 +275,7 @@ GEM
     dotenv-rails (2.1.1)
       dotenv (= 2.1.1)
       railties (>= 4.0, < 5.1)
-    dough-ruby (5.26.1.300)
+    dough-ruby (5.26.2.302)
       activemodel
       activesupport
       rails (>= 3.2, < 5)


### PR DESCRIPTION
# Bumps dough to new version 5.26.2

Bumps dough to latest version (5.26.2.302) for ticket 8744

[TP Ticket 8744](https://moneyadviceservice.tpondemand.com/entity/8744-tooltip-component-bug)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1873)
<!-- Reviewable:end -->
