### PR TITLE
[DEV APPROVED] TP 8783: Creates amp-img tag converter

### DIFF
--- a/app/assets/stylesheets/amp_styles.css.scss
+++ b/app/assets/stylesheets/amp_styles.css.scss
@@ -39,6 +39,16 @@ $responsive: true;
   background-size: cover;
 }
 
+.amp-img-container {
+  position: relative;
+  width: 100%;
+  height: 20rem;
+}
+
+amp-img.contain img {
+  object-fit: contain;
+}
+
 // AMP element and class styles (that come from contento)
 .amp-body {
   max-width: 36rem;

--- a/app/decorators/amp_article_decorator.rb
+++ b/app/decorators/amp_article_decorator.rb
@@ -1,7 +1,6 @@
 require 'html_processor'
 
 class AmpArticleDecorator < Draper::Decorator
-
   def initialize(object, options = {})
     super
   end
@@ -20,8 +19,9 @@ class AmpArticleDecorator < Draper::Decorator
 
   def html_processors
     [
-      [HTMLProcessor::AmpVideo, [HTMLProcessor::VIDEO_IFRAME]],
-      [HTMLProcessor::AmpImg,   [HTMLProcessor::IMG]]
+      [HTMLProcessor::AmpVideo,  [HTMLProcessor::VIDEO_IFRAME]],
+      [HTMLProcessor::AmpImg,    [HTMLProcessor::IMG]],
+      [HTMLProcessor::AmpIframe, [HTMLProcessor::NON_VIDEO_IFRAME]]
     ]
   end
 end

--- a/app/decorators/amp_article_decorator.rb
+++ b/app/decorators/amp_article_decorator.rb
@@ -20,7 +20,8 @@ class AmpArticleDecorator < Draper::Decorator
 
   def html_processors
     [
-      [HTMLProcessor::AmpVideo, [HTMLProcessor::VIDEO_IFRAME]]
+      [HTMLProcessor::AmpVideo, [HTMLProcessor::VIDEO_IFRAME]],
+      [HTMLProcessor::AmpImg,   [HTMLProcessor::IMG]]
     ]
   end
 end

--- a/app/decorators/amp_article_decorator.rb
+++ b/app/decorators/amp_article_decorator.rb
@@ -1,6 +1,7 @@
 require 'html_processor'
 
 class AmpArticleDecorator < Draper::Decorator
+  include ActionView::Helpers::OutputSafetyHelper
   def initialize(object, options = {})
     super
   end
@@ -12,7 +13,7 @@ class AmpArticleDecorator < Draper::Decorator
       body = processor.new(body).process(*xpaths)
     end
 
-    body.html_safe
+    safe_join([body.html_safe])
   end
 
   private

--- a/app/views/amp_articles/show.html.erb
+++ b/app/views/amp_articles/show.html.erb
@@ -8,6 +8,7 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
   <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+  <script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>
 
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
 

--- a/lib/html_processor.rb
+++ b/lib/html_processor.rb
@@ -5,6 +5,7 @@ require 'html_processor/node_replacer'
 require 'html_processor/table_wrapper'
 require 'html_processor/video_wrapper'
 require 'html_processor/amp_video'
+require 'html_processor/amp_img'
 require 'html_processor/heading_attributes'
 
 module HTMLProcessor
@@ -15,6 +16,7 @@ module HTMLProcessor
   INTRO_PARAGRAPH   = '//p[@class="intro"]'.freeze
   IMAGE_AUTHOR      = '//p/em/text()[contains(., "Photo:")]'.freeze
   VIDEO_IFRAME      = '//iframe[starts-with(@src, "https://www.youtube.com/embed")]'.freeze
+  IMG               = '//img'.freeze
   COLLAPSIBLE_SPAN  = '//span[@class="collapse"]'.freeze
 
   TABLE_WRAPPER     = '<div class="table-wrapper"/>'.freeze

--- a/lib/html_processor.rb
+++ b/lib/html_processor.rb
@@ -6,6 +6,7 @@ require 'html_processor/table_wrapper'
 require 'html_processor/video_wrapper'
 require 'html_processor/amp_video'
 require 'html_processor/amp_img'
+require 'html_processor/amp_iframe'
 require 'html_processor/heading_attributes'
 
 module HTMLProcessor
@@ -17,6 +18,7 @@ module HTMLProcessor
   IMAGE_AUTHOR      = '//p/em/text()[contains(., "Photo:")]'.freeze
   VIDEO_IFRAME      = '//iframe[starts-with(@src, "https://www.youtube.com/embed")]'.freeze
   IMG               = '//img'.freeze
+  NON_VIDEO_IFRAME  = '//iframe[not(starts-with(@src, "https://www.youtube.com/embed"))]'.freeze
   COLLAPSIBLE_SPAN  = '//span[@class="collapse"]'.freeze
 
   TABLE_WRAPPER     = '<div class="table-wrapper"/>'.freeze

--- a/lib/html_processor.rb
+++ b/lib/html_processor.rb
@@ -1,3 +1,5 @@
+# rubocop:disable Metrics/LineLength,
+
 require 'html_processor/base'
 require 'html_processor/node_contents'
 require 'html_processor/node_remover'

--- a/lib/html_processor/amp_iframe.rb
+++ b/lib/html_processor/amp_iframe.rb
@@ -1,0 +1,38 @@
+require_dependency 'html_processor/base'
+
+module HTMLProcessor
+  class AmpIframe < Base
+    PERMITTED_AMP_ATTRIBUTES = %w[src
+                                  alt
+                                  height
+                                  width
+                                  srcdoc
+                                  frameborder
+                                  allowfullscreen
+                                  allowpaymentrequest
+                                  allowtransparency
+                                  referrerpolicy
+                                  sandbox].freeze
+
+    def process(*xpaths)
+      doc.xpath(*xpaths).each do |node|
+        amp_iframe = Nokogiri::XML::Node.new 'amp-iframe', doc
+        copy_attributes!(node, amp_iframe)
+        node.replace amp_iframe
+      end
+      super
+    end
+
+    private
+
+    def attributes_to_copy(original_iframe)
+      PERMITTED_AMP_ATTRIBUTES & original_iframe.attributes.keys
+    end
+
+    def copy_attributes!(original_iframe, amp_iframe)
+      attributes_to_copy(original_iframe).each do |field|
+        amp_iframe[field] = original_iframe.attribute(field)
+      end
+    end
+  end
+end

--- a/lib/html_processor/amp_iframe.rb
+++ b/lib/html_processor/amp_iframe.rb
@@ -16,9 +16,13 @@ module HTMLProcessor
 
     def process(*xpaths)
       doc.xpath(*xpaths).each do |node|
-        amp_iframe = Nokogiri::XML::Node.new 'amp-iframe', doc
-        copy_attributes!(node, amp_iframe)
-        node.replace amp_iframe
+        if https?(node.attribute('src'))
+          amp_iframe = Nokogiri::XML::Node.new 'amp-iframe', doc
+          copy_attributes!(node, amp_iframe)
+          node.replace amp_iframe
+        else
+          node.remove
+        end
       end
       super
     end
@@ -33,6 +37,10 @@ module HTMLProcessor
       attributes_to_copy(original_iframe).each do |field|
         amp_iframe[field] = original_iframe.attribute(field)
       end
+    end
+
+    def https?(url)
+      url && URI.parse(url).scheme == 'https'
     end
   end
 end

--- a/lib/html_processor/amp_iframe.rb
+++ b/lib/html_processor/amp_iframe.rb
@@ -17,10 +17,7 @@ module HTMLProcessor
     def process(*xpaths)
       doc.xpath(*xpaths).each do |node|
         if https?(node.attribute('src'))
-          amp_iframe = Nokogiri::XML::Node.new 'amp-iframe', doc
-          amp_iframe['layout'] = 'responsive'
-          copy_attributes!(node, amp_iframe)
-          node.replace amp_iframe
+          replace_original_iframe(node)
         else
           node.remove
         end
@@ -29,6 +26,13 @@ module HTMLProcessor
     end
 
     private
+
+    def replace_original_iframe(original_iframe)
+      amp_iframe = Nokogiri::XML::Node.new('amp-iframe', doc)
+      amp_iframe['layout'] = 'responsive'
+      copy_attributes!(original_iframe, amp_iframe)
+      original_iframe.replace(amp_iframe)
+    end
 
     def attributes_to_copy(original_iframe)
       PERMITTED_AMP_ATTRIBUTES & original_iframe.attributes.keys

--- a/lib/html_processor/amp_iframe.rb
+++ b/lib/html_processor/amp_iframe.rb
@@ -18,6 +18,7 @@ module HTMLProcessor
       doc.xpath(*xpaths).each do |node|
         if https?(node.attribute('src'))
           amp_iframe = Nokogiri::XML::Node.new 'amp-iframe', doc
+          amp_iframe['layout'] = 'responsive'
           copy_attributes!(node, amp_iframe)
           node.replace amp_iframe
         else

--- a/lib/html_processor/amp_img.rb
+++ b/lib/html_processor/amp_img.rb
@@ -16,6 +16,7 @@ module HTMLProcessor
       doc.xpath(*xpaths).each do |node|
         if node.attributes.include? 'src'
           amp_img = Nokogiri::XML::Node.new 'amp-img', doc
+          amp_img['layout'] = 'responsive'
           copy_attributes!(node, amp_img)
           append_noscript_fallback(node, amp_img)
           node.replace amp_img

--- a/lib/html_processor/amp_img.rb
+++ b/lib/html_processor/amp_img.rb
@@ -1,0 +1,47 @@
+require_dependency 'html_processor/base'
+
+module HTMLProcessor
+  class AmpImg < Base
+    PERMITTED_AMP_ATTRIBUTES = %w[
+      src
+      srcset
+      sizes
+      alt
+      attribution
+      height
+      width
+    ].freeze
+
+    def process(*xpaths)
+      doc.xpath(*xpaths).each do |node|
+        if node.attributes.include? 'src'
+          amp_img = Nokogiri::XML::Node.new 'amp-img', doc
+          copy_attributes!(node, amp_img)
+          append_noscript_fallback(node, amp_img)
+          node.replace amp_img
+        else
+          node.remove
+        end
+      end
+      super
+    end
+
+    private
+
+    def attributes_to_copy(original_image)
+      PERMITTED_AMP_ATTRIBUTES & original_image.attributes.keys
+    end
+
+    def copy_attributes!(original_image, amp_img)
+      attributes_to_copy(original_image).each do |field|
+        amp_img[field] = original_image.attribute(field)
+      end
+    end
+
+    def append_noscript_fallback(original_image, amp_img)
+      noscript_node = Nokogiri::XML::Node.new 'noscript', doc
+      noscript_node.add_child(original_image)
+      amp_img.add_child(noscript_node)
+    end
+  end
+end

--- a/lib/html_processor/amp_img.rb
+++ b/lib/html_processor/amp_img.rb
@@ -40,7 +40,7 @@ module HTMLProcessor
 
     def append_noscript_fallback(original_image, amp_img)
       noscript_node = Nokogiri::XML::Node.new 'noscript', doc
-      noscript_node.add_child(original_image)
+      noscript_node.add_child(original_image.clone)
       amp_img.add_child(noscript_node)
     end
   end

--- a/lib/html_processor/amp_img.rb
+++ b/lib/html_processor/amp_img.rb
@@ -14,11 +14,8 @@ module HTMLProcessor
 
     def process(*xpaths)
       doc.xpath(*xpaths).each do |original_img|
-        if original_img.attributes.include? 'src'
-          container = create_container
-          amp_img = create_amp_img(original_img)
-          container.add_child(amp_img)
-          original_img.replace container
+        if original_img.attributes.include?('src')
+          replace_original_img(original_img)
         else
           original_img.remove
         end
@@ -28,14 +25,21 @@ module HTMLProcessor
 
     private
 
+    def replace_original_img(original_img)
+      container = create_container
+      amp_img = create_amp_img(original_img)
+      container.add_child(amp_img)
+      original_img.replace(container)
+    end
+
     def create_container
-      node = Nokogiri::XML::Node.new 'div', doc
+      node = Nokogiri::XML::Node.new('div', doc)
       node['class'] = 'amp-img-container'
       node
     end
 
     def create_amp_img(original_img)
-      amp_img = Nokogiri::XML::Node.new 'amp-img', doc
+      amp_img = Nokogiri::XML::Node.new('amp-img', doc)
       amp_img['layout'] = 'fill'
       amp_img['class'] = 'contain'
       copy_attributes!(original_img, amp_img)
@@ -54,7 +58,7 @@ module HTMLProcessor
     end
 
     def append_noscript_fallback(original_image, amp_img)
-      noscript_node = Nokogiri::XML::Node.new 'noscript', doc
+      noscript_node = Nokogiri::XML::Node.new('noscript', doc)
       noscript_node.add_child(original_image.clone)
       amp_img.add_child(noscript_node)
     end

--- a/spec/lib/html_processors/amp_iframe_spec.rb
+++ b/spec/lib/html_processors/amp_iframe_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe HTMLProcessor::AmpIframe do
         EOHTML
       end
 
-      it 'copies the attributes across correctly from the original iframe' do
+      it 'copies original iframe attributes to the new iframe' do
         expect(attributes).to include(
           'src' => 'https://google.com',
           'alt' => 'test_alt',

--- a/spec/lib/html_processors/amp_iframe_spec.rb
+++ b/spec/lib/html_processors/amp_iframe_spec.rb
@@ -1,0 +1,76 @@
+require 'html_processor'
+require 'html_processor/amp_iframe'
+
+RSpec.describe HTMLProcessor::AmpIframe do
+  let(:processor) { described_class.new(html) }
+
+  describe '.process' do
+    subject { Nokogiri::XML(processed_html.strip).children.first }
+    let(:attributes) { subject.attributes.transform_values!(&:value) }
+
+    let(:processed_html) { processor.process(HTMLProcessor::NON_VIDEO_IFRAME) }
+
+    let(:xpath) do
+      '//iframe[not(starts-with(@src, "https://www.youtube.com/embed"))]'
+    end
+
+    context 'when attributes are present' do
+      let(:html) do
+        <<-EOHTML
+          <iframe
+            src="test_src"
+            alt="test_alt"
+            height="test_height"
+            width="test_width"
+            srcdoc="test_srcdoc"
+            frameborder="test_frameborder"
+            allowfullscreen="test_allowfullscreen"
+            allowpaymentrequest="test_allowpaymentrequest"
+            allowtransparency="test_allowtransparency"
+            referrerpolicy="test_referrerpolicy"
+            sandbox="test_sandbox" />
+        EOHTML
+      end
+
+      it 'copies the attributes across correctly from the original iframe' do
+        expect(attributes).to include(
+          'src' => 'test_src',
+          'alt' => 'test_alt',
+          'height' => 'test_height',
+          'width' => 'test_width',
+          'srcdoc' => 'test_srcdoc',
+          'frameborder' => 'test_frameborder',
+          'allowfullscreen' => 'test_allowfullscreen',
+          'allowpaymentrequest' => 'test_allowpaymentrequest',
+          'allowtransparency' => 'test_allowtransparency',
+          'referrerpolicy' => 'test_referrerpolicy',
+          'sandbox' => 'test_sandbox'
+        )
+      end
+    end
+
+    context 'when attributes are missing' do
+      let(:html) do
+        <<-EOHTML
+          <iframe />
+        EOHTML
+      end
+
+      it 'does not create those attributes on the amp-iframe' do
+        expect(attributes.keys).not_to include(
+          %w[src
+             alt
+             height
+             width
+             srcdoc
+             frameborder
+             allowfullscreen
+             allowpaymentrequest
+             allowtransparency
+             referrerpolicy
+             sandbox]
+        )
+      end
+    end
+  end
+end

--- a/spec/lib/html_processors/amp_iframe_spec.rb
+++ b/spec/lib/html_processors/amp_iframe_spec.rb
@@ -44,7 +44,8 @@ RSpec.describe HTMLProcessor::AmpIframe do
           'allowpaymentrequest' => 'test_allowpaymentrequest',
           'allowtransparency' => 'test_allowtransparency',
           'referrerpolicy' => 'test_referrerpolicy',
-          'sandbox' => 'test_sandbox'
+          'sandbox' => 'test_sandbox',
+          'layout' => 'responsive'
         )
       end
     end

--- a/spec/lib/html_processors/amp_iframe_spec.rb
+++ b/spec/lib/html_processors/amp_iframe_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe HTMLProcessor::AmpIframe do
       let(:html) do
         <<-EOHTML
           <iframe
-            src="test_src"
+            src="https://google.com"
             alt="test_alt"
             height="test_height"
             width="test_width"
@@ -34,7 +34,7 @@ RSpec.describe HTMLProcessor::AmpIframe do
 
       it 'copies the attributes across correctly from the original iframe' do
         expect(attributes).to include(
-          'src' => 'test_src',
+          'src' => 'https://google.com',
           'alt' => 'test_alt',
           'height' => 'test_height',
           'width' => 'test_width',
@@ -52,14 +52,13 @@ RSpec.describe HTMLProcessor::AmpIframe do
     context 'when attributes are missing' do
       let(:html) do
         <<-EOHTML
-          <iframe />
+          <iframe src="https://google.com" />
         EOHTML
       end
 
       it 'does not create those attributes on the amp-iframe' do
         expect(attributes.keys).not_to include(
-          %w[src
-             alt
+          %w[alt
              height
              width
              srcdoc
@@ -70,6 +69,19 @@ RSpec.describe HTMLProcessor::AmpIframe do
              referrerpolicy
              sandbox]
         )
+      end
+    end
+
+    context 'when the iframe src is not https' do
+      let(:html) do
+        <<-EOHTML
+          <iframe src="http://google.com"></iframe>
+        EOHTML
+      end
+      subject { processed_html.strip }
+
+      it 'does not create the amp-iframe tag' do
+        expect(subject).to eq('')
       end
     end
   end

--- a/spec/lib/html_processors/amp_img_spec.rb
+++ b/spec/lib/html_processors/amp_img_spec.rb
@@ -38,7 +38,8 @@ RSpec.describe HTMLProcessor::AmpImg do
         'alt' => 'test_alt',
         'attribution' => 'test_attribution',
         'height' => 'test_height',
-        'width' => 'test_width'
+        'width' => 'test_width',
+        'layout' => 'responsive'
       )
     end
 

--- a/spec/lib/html_processors/amp_img_spec.rb
+++ b/spec/lib/html_processors/amp_img_spec.rb
@@ -1,0 +1,93 @@
+require 'html_processor'
+require 'html_processor/amp_img'
+
+RSpec.describe HTMLProcessor::AmpImg do
+  let(:processor) { described_class.new(html) }
+
+  describe '.process' do
+    subject { Nokogiri::XML(processed_html.strip).children.first }
+    let(:attributes) { subject.attributes.transform_values!(&:value) }
+    let(:processed_html) { processor.process(HTMLProcessor::IMG) }
+
+    let(:xpath) do
+      '//img'
+    end
+
+    it 'creates an amp-img tag' do
+      expect(subject.name).to eq('amp-img')
+    end
+
+    let(:html) do
+      <<-EOHTML
+          <img
+              srcset="test_srcset"
+              src="test_src"
+              sizes="test_sizes"
+              alt="test_alt"
+              attribution="test_attribution"
+              height="test_height"
+              width="test_width" />
+        EOHTML
+    end
+
+    it 'copies the attributes across correctly from the original iframe' do
+      expect(attributes).to include(
+        'srcset' => 'test_srcset',
+        'src' => 'test_src',
+        'sizes' => 'test_sizes',
+        'alt' => 'test_alt',
+        'attribution' => 'test_attribution',
+        'height' => 'test_height',
+        'width' => 'test_width'
+      )
+    end
+
+    describe 'supporting javascript disabled' do
+      let(:amp_img_tag) { Nokogiri::XML(processed_html.strip).children.first }
+      subject { amp_img_tag.children.first }
+
+      it 'creates a noscript tag containing the original img tag' do
+        expect(subject.children.first.name).to eq('img')
+      end
+
+      it 'assigns the correct attributes to the inner img tag' do
+        expect(attributes).to include(
+          'srcset' => 'test_srcset',
+          'src' => 'test_src',
+          'sizes' => 'test_sizes',
+          'alt' => 'test_alt',
+          'attribution' => 'test_attribution',
+          'height' => 'test_height',
+          'width' => 'test_width'
+        )
+      end
+    end
+
+    context 'when attributes are missing' do
+      let(:html) do
+        <<-EOHTML
+          <img src="test_src" />
+        EOHTML
+      end
+
+      it 'does not create those attributes on the amp-iframe' do
+        expect(attributes.keys).not_to include(
+          %w[srcset sizes alt attribution height width]
+        )
+      end
+
+      context 'when src attribute is missing' do
+        let(:html) do
+          <<-EOHTML
+            <img />
+          EOHTML
+        end
+        subject { processed_html.strip }
+
+        it 'does not create the amp-img tag' do
+          expect(subject).to eq('')
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/html_processors/amp_img_spec.rb
+++ b/spec/lib/html_processors/amp_img_spec.rb
@@ -45,13 +45,15 @@ RSpec.describe HTMLProcessor::AmpImg do
     describe 'supporting javascript disabled' do
       let(:amp_img_tag) { Nokogiri::XML(processed_html.strip).children.first }
       subject { amp_img_tag.children.first }
+      let(:noscript_tag) { subject.children.first }
+      let(:img_attributes) { noscript_tag.attributes.transform_values(&:value) }
 
       it 'creates a noscript tag containing the original img tag' do
         expect(subject.children.first.name).to eq('img')
       end
 
       it 'assigns the correct attributes to the inner img tag' do
-        expect(attributes).to include(
+        expect(img_attributes).to include(
           'srcset' => 'test_srcset',
           'src' => 'test_src',
           'sizes' => 'test_sizes',

--- a/spec/lib/html_processors/amp_img_spec.rb
+++ b/spec/lib/html_processors/amp_img_spec.rb
@@ -5,10 +5,14 @@ RSpec.describe HTMLProcessor::AmpImg do
   let(:processor) { described_class.new(html) }
 
   describe '.process' do
-    let(:parent_container) { Nokogiri::XML(processed_html.strip).children.first }
+    let(:parent_container) do
+      Nokogiri::XML(processed_html.strip).children.first
+    end
     let(:amp_img_tag) { parent_container.children.first }
+    let(:amp_img_attrs) { amp_img_tag.attributes.transform_values(&:value) }
     let(:noscript_tag) { amp_img_tag.children.first }
-    let(:attributes) { subject.attributes.transform_values!(&:value) }
+    let(:inner_img_tag) { noscript_tag.children.first }
+    let(:img_attributes) { inner_img_tag.attributes.transform_values(&:value) }
     let(:processed_html) { processor.process(HTMLProcessor::IMG) }
 
     let(:xpath) do
@@ -28,66 +32,52 @@ RSpec.describe HTMLProcessor::AmpImg do
       EOHTML
     end
 
-    describe 'generated parent container' do
-      subject { parent_container }
-
-      it 'is a div' do
-        expect(subject.name).to eq('div')
-      end
-
-      it 'it has the correct styles for a dynamic width amp-img' do
-        expect(subject.attribute('class').value).to include('amp-img-container')
-      end
+    it 'the parent container is a div' do
+      expect(parent_container.name).to eq('div')
     end
 
-    describe 'generated amp-img tag' do
-      subject { amp_img_tag }
-
-      it 'is an amp-img' do
-        expect(subject.name).to eq('amp-img')
-      end
-
-      it 'copies the attributes across correctly from the original img' do
-        expect(attributes).to include(
-          'srcset' => 'test_srcset',
-          'src' => 'test_src',
-          'sizes' => 'test_sizes',
-          'alt' => 'test_alt',
-          'attribution' => 'test_attribution',
-          'height' => 'test_height',
-          'width' => 'test_width',
-          'layout' => 'fill',
-          'class' => 'contain'
-        )
-      end
+    it 'the parent container has the class amp-img-container' do
+      expect(parent_container.attribute('class').value)
+        .to include('amp-img-container')
     end
 
-    describe 'supporting javascript disabled' do
-      subject { noscript_tag }
-      let(:inner_img_tag) { noscript_tag.children.first }
-      let(:img_attributes) { inner_img_tag.attributes.transform_values(&:value) }
+    it 'the generated amp-img tag is an amp-img' do
+      expect(amp_img_tag.name).to eq('amp-img')
+    end
 
-      it 'creates a noscript tag containing the original img tag' do
-        expect(subject.name).to eq('noscript')
-        expect(inner_img_tag.name).to eq('img')
-      end
+    it 'copies the attributes across correctly from the original img' do
+      expect(amp_img_attrs).to include(
+        'srcset' => 'test_srcset',
+        'src' => 'test_src',
+        'sizes' => 'test_sizes',
+        'alt' => 'test_alt',
+        'attribution' => 'test_attribution',
+        'height' => 'test_height',
+        'width' => 'test_width',
+        'layout' => 'fill',
+        'class' => 'contain'
+      )
+    end
 
-      it 'assigns the correct attributes to the inner img tag' do
-        expect(img_attributes).to include(
-          'srcset' => 'test_srcset',
-          'src' => 'test_src',
-          'sizes' => 'test_sizes',
-          'alt' => 'test_alt',
-          'attribution' => 'test_attribution',
-          'height' => 'test_height',
-          'width' => 'test_width'
-        )
-      end
+
+    it 'creates a noscript tag containing the original img tag' do
+      expect(noscript_tag.name).to eq('noscript')
+      expect(inner_img_tag.name).to eq('img')
+    end
+
+    it 'assigns the correct attributes to the inner img tag' do
+      expect(img_attributes).to include(
+        'srcset' => 'test_srcset',
+        'src' => 'test_src',
+        'sizes' => 'test_sizes',
+        'alt' => 'test_alt',
+        'attribution' => 'test_attribution',
+        'height' => 'test_height',
+        'width' => 'test_width'
+      )
     end
 
     context 'when attributes are missing' do
-      subject { amp_img_tag }
-
       let(:html) do
         <<-EOHTML
           <img src="test_src" />
@@ -95,22 +85,21 @@ RSpec.describe HTMLProcessor::AmpImg do
       end
 
       it 'does not create those attributes on the amp-iframe' do
-        expect(attributes.keys).not_to include(
+        expect(amp_img_attrs.keys).not_to include(
           %w[srcset sizes alt attribution height width]
         )
       end
+    end
 
-      context 'when src attribute is missing' do
-        let(:html) do
-          <<-EOHTML
-            <img />
-          EOHTML
-        end
-        subject { processed_html.strip }
+    context 'when src attribute is missing' do
+      let(:html) do
+        <<-EOHTML
+          <img />
+        EOHTML
+      end
 
-        it 'does not create the amp-img tag' do
-          expect(subject).to eq('')
-        end
+      it 'does not create the amp-img tag' do
+        expect(processed_html.strip).to eq('')
       end
     end
   end

--- a/spec/lib/html_processors/amp_video_spec.rb
+++ b/spec/lib/html_processors/amp_video_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe HTMLProcessor::AmpVideo do
       '//div[@class="video-wrapper"]/*/iframe[starts-with(@src, "https://www.youtube.com/embed")]'
     end
 
-    it 'does not modify title attribute', focus: true do
+    it 'does not modify title attribute' do
       expect(processed_html.strip).to eq('<amp-youtube data-videoid="3ciEDiokPkw" layout="responsive" width="480" height="270"></amp-youtube>')
     end
   end

--- a/spec/lib/html_processors/amp_video_spec.rb
+++ b/spec/lib/html_processors/amp_video_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe HTMLProcessor::AmpVideo do
       expect(subject.name).to eq('amp-youtube')
     end
 
-    it 'assigns the correct attributes to the resulting tag' do
+    it 'assigns a height, width, video id and layout to the amp-youtube tag' do
       expect(attributes).to include(
         'height' => '270',
         'width' => '480',

--- a/spec/lib/html_processors/amp_video_spec.rb
+++ b/spec/lib/html_processors/amp_video_spec.rb
@@ -6,20 +6,35 @@ RSpec.describe HTMLProcessor::AmpVideo do
 
   let(:html) do
     <<-EOHTML
-      <iframe frameborder="0" height="413" width="680" src="https://www.youtube.com/embed/3ciEDiokPkw?rel=0">
+      <iframe
+        src="https://www.youtube.com/embed/3ciEDiokPkw?rel=0"
+        frameborder="0"
+        height="413"
+        width="680">
       </iframe>
     EOHTML
   end
 
   describe '.process' do
-    subject(:processed_html) { processor.process(HTMLProcessor::VIDEO_IFRAME) }
+    subject { Nokogiri::XML(processed_html.strip).children.first }
+    let(:processed_html) { processor.process(HTMLProcessor::VIDEO_IFRAME) }
+    let(:attributes) { subject.attributes.transform_values!(&:value) }
 
     let(:xpath) do
-      '//div[@class="video-wrapper"]/*/iframe[starts-with(@src, "https://www.youtube.com/embed")]'
+      '//div[@class="video-wrapper"]/*/iframe[starts-with(@src, "https://www.youtube.com/embed")]' # rubocop:disable Metrics/LineLength
     end
 
-    it 'does not modify title attribute' do
-      expect(processed_html.strip).to eq('<amp-youtube data-videoid="3ciEDiokPkw" layout="responsive" width="480" height="270"></amp-youtube>')
+    it 'creates an amp-youtube tag' do
+      expect(subject.name).to eq('amp-youtube')
+    end
+
+    it 'assigns the correct attributes to the resulting tag' do
+      expect(attributes).to include(
+        'height' => '270',
+        'width' => '480',
+        'data-videoid' => '3ciEDiokPkw',
+        'layout' => 'responsive'
+      )
     end
   end
 end


### PR DESCRIPTION
[TP ticket link](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=userstory/8783&appConfig=eyJhY2lkIjoiRjk1Qzc3Njg4REFDNTUyNTBGODhGNTE5MEM5M0JCN0UifQ==)

### Summary
This PR creates a converters for `img` and `iframe` tags when we render an amp article to convert them to their corresponding `amp-img` and `amp-iframe` tags.

The `src` attribute on an `img` tag is mandatory so I'm removing and not replacing with `amp-img` if it's not present.

### QA / Testing
Create an article that's enabled for amp
Add an img and an iframe
Verify that they are correctly converted to their corresponding `amp-img` and `amp-iframe` components
Disable javascript then load a converted `img` tag and verify that it still gets displayed

### Checklist

+ [x] Tests passed.
+ [x] Rubocop is passing for this PR (or any other lint like JShint).
+ [x] Code Climate passed for this PR.
+ [x] Commit history reviewed (clear commit messages).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1874)
<!-- Reviewable:end -->

  