### PR TITLE
[WIP] - Runs Rubocop on all files which has been changed

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -23,3 +23,4 @@ bowndler update --production --config.interactive=false
 RAILS_ENV=development rake karma:install karma:run_once
 bundle exec rspec spec --format html --out tmp/spec.html --format RspecJunitFormatter --profile --format progress --deprecation-out log/rspec_deprecations.txt
 bundle exec cucumber
+bundle exec rubocop `git diff --name-only $(git merge-base master HEAD)`


### PR DESCRIPTION
**Summary**
This move is to ensure that the quality of our _Frontend_ repository does not continue to suffer due to negligence. This PR will ensure that all other PRs to this repository will only pass if they have ddressed Ruby-related code issues flagged by Rubocop before they can be deployed.

**Examples**
## Modified Files
```
[jonesagyemang:~/Projects/MAS/frontend] lint_code_per_PR(+1/-0)+* 35m4s ± git status
On branch lint_code_per_PR
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

	modified:   Gemfile
```

## Linting Modified Files
```
[jonesagyemang:~/Projects/MAS/frontend] lint_code_per_PR(+1/-0)+* 35m4s ± ./test.sh
Inspecting 1 file
C

Offenses:

Gemfile:13:1: C: Extra blank line detected.
Gemfile:39:1: C: Gems should be sorted in an alphabetical order within their section of the Gemfile. Gem recaptcha should appear before redcarpet.
gem 'recaptcha', require: 'recaptcha/rails'
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Gemfile:44:1: C: Gems should be sorted in an alphabetical order within their section of the Gemfile. Gem postcode_anywhere-email_validation should appear before statsd-ruby.
gem 'postcode_anywhere-email_validation'
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Gemfile:46:1: C: Gems should be sorted in an alphabetical order within their section of the Gemfile. Gem mas-cms-client should appear before turnout.
gem 'mas-cms-client', '1.5.0'
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Gemfile:102:3: C: Gems should be sorted in an alphabetical order within their section of the Gemfile. Gem rspec-html-matchers should appear before rspec_junit_formatter.
  gem 'rspec-html-matchers'
  ^^^^^^^^^^^^^^^^^^^^^^^^^

1 file inspected, 5 offenses detected
```

**QA / Testing**
Change any file which is not excluded from code linting within the Rubocopp configuration file then run the test script `./test.sh`. This should run Rubocop on the changed file only rather than to all other files which are legitimate candidates for linting.

**Checklist**
+ [x] Tests passed.
+ [x] Rubocop is passing for this PR (or any other lint like JShint).
+ [x] Code Climate passed for this PR.
+ [x] Commit history reviewed (clear commit messages).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1881)
<!-- Reviewable:end -->
