### PR TITLE
8684 - Seasonal Spotlight

### DIFF
--- a/app/assets/stylesheets/components/page_specific/home_beta/_seasonal_spotlight.scss
+++ b/app/assets/stylesheets/components/page_specific/home_beta/_seasonal_spotlight.scss
@@ -1,0 +1,36 @@
+.seasonal-spotlight {
+  @include column(12);
+  margin-top: $baseline-unit*2;
+  margin-bottom: $baseline-unit*2;
+  background-size: cover;
+  background-position: center;
+  position: relative;
+  height: 300px;
+
+  @include respond-to($mq-m) {
+    @include column(6);
+    display: flex;
+    height: auto;
+
+    .ie9 & {
+      height: 340px;
+    }
+  }
+}
+
+.seasonal-spotlight__cta {
+  position: absolute;
+  bottom: $baseline-unit*2;
+  right: $baseline-unit*2;
+  padding-right: $baseline-unit*5;
+  white-space: normal;
+  max-width: 80%;
+}
+
+.seasonal-spotlight__cta-arrow {
+  position: absolute;
+  right: $baseline-unit;
+  top: $baseline-unit*2;
+  height: 26px;
+  width: 26px;
+}

--- a/app/assets/stylesheets/layout/page_specific/_homepage_beta.scss
+++ b/app/assets/stylesheets/layout/page_specific/_homepage_beta.scss
@@ -1,0 +1,4 @@
+.l-home-promos {
+  display: flex;
+  flex-wrap: wrap;
+}

--- a/app/views/home_beta/show.html.erb
+++ b/app/views/home_beta/show.html.erb
@@ -22,7 +22,10 @@
 
 <%= render 'shared/home_top', item: @resource %>
 
-<%= render 'shared/home_beta/tool_promos', items: @resource.tools %>
+<div class="l-home-promos">
+  <%= render 'shared/home_beta/tool_promos', items: @resource.tools %>
+  <%= render 'shared/home_beta/seasonal_spotlight', item: @resource %>
+</div>
 
 <%= render 'shared/article_promos', items_with_image: @resource.tiles, items_without_image: @resource.text_tiles %>
 

--- a/app/views/shared/home_beta/_seasonal_spotlight.html.erb
+++ b/app/views/shared/home_beta/_seasonal_spotlight.html.erb
@@ -1,0 +1,6 @@
+<div class="seasonal-spotlight" style="background-image: url(<%= item.hero_image %>);">
+  <a href="<%= item.cta_link %>" class="seasonal-spotlight__cta button button--primary">
+    <%= item.cta_text %>
+    <%= render 'shared/svg/use_icon', icon: 'arrow-right', class_name: 'seasonal-spotlight__cta-arrow' %>
+  </a>
+</div>

--- a/features/home_beta_page.feature
+++ b/features/home_beta_page.feature
@@ -9,3 +9,12 @@ Feature: Home page beta
       | language |
       | English  |
       | Welsh    |
+
+  Scenario Outline: Seasonal spotlight
+    Given I view the beta home page in <language>
+    Then I should be presented with the seasonal spotlight in <language>
+
+    Examples:
+      | language |
+      | English  |
+      | Welsh    |

--- a/features/step_definitions/home_beta_page_steps.rb
+++ b/features/step_definitions/home_beta_page_steps.rb
@@ -9,3 +9,13 @@ Then(/^I should be presented with popular tools and calculators$/) do
   expect(home_beta_page.popular_tools)
     .to have_content(I18n.t('home.show.tools_heading'))
 end
+
+Then(/^I should be presented with the seasonal spotlight in English$/) do
+  expect(home_beta_page.seasonal_spotlight)
+    .to have_content('Easy ways to catch the saving habit')
+end
+
+Then(/^I should be presented with the seasonal spotlight in Welsh$/) do
+  expect(home_beta_page.seasonal_spotlight)
+    .to have_content('Ffyrdd hawdd i ddal y arferiad cynilo')
+end

--- a/features/support/ui/pages/home_beta.rb
+++ b/features/support/ui/pages/home_beta.rb
@@ -6,5 +6,6 @@ module UI::Pages
     set_url '/{locale}/home-beta'
 
     element :popular_tools, '.tool_promo-beta'
+    element :seasonal_spotlight, '.seasonal-spotlight'
   end
 end


### PR DESCRIPTION
# 8684 - Create Seasonal Spotlight box

| English | Welsh |
|--------|--------|
|![image](https://user-images.githubusercontent.com/13165846/34992738-03cfdcaa-fac6-11e7-9027-a8877e904955.png)|![image](https://user-images.githubusercontent.com/13165846/34992775-24e64820-fac6-11e7-9d43-f0dcd9294959.png)|

The heights use flexbox, IE9 fallback added (Screenshot below:)

![ie9](https://user-images.githubusercontent.com/13165846/35038451-c7803fbc-fb72-11e7-9337-6a4a8e016243.png)


[TP Ticket 8684](https://moneyadviceservice.tpondemand.com/entity/8684-create-seasonal-spotlight-box)

**Summary**
This is a ticket to create a Seasonal spotlight box for the homepage, highlighted below.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1884)
<!-- Reviewable:end -->
