### PR TITLE
[DEV APPROVED] 8685 information guides

### DIFF
--- a/app/assets/stylesheets/components/page_specific/home_beta/_information_guides.scss
+++ b/app/assets/stylesheets/components/page_specific/home_beta/_information_guides.scss
@@ -1,0 +1,66 @@
+.information-guides {
+  @include column(12);
+}
+
+.information-guides__title {
+  @include body(20, 24);
+  font-weight: normal;
+  background-color: $color-teal-dark;
+  color: $color-white;
+  margin: 0;
+  padding: $baseline-unit $baseline-unit*2;
+}
+
+.information-guides__list {
+  @extend %clearfix;
+  margin: 0;
+  padding: $baseline-unit*2 0;
+  background-color: $color-grey-pale;
+  list-style: none;
+  border-bottom: 2px solid $color-teal-dark;
+
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.information-guides__list-item {
+  @include column(12);
+  @include body(16, 24);
+  position: relative;
+  background-color: $color-grey-palest;
+  border-bottom: 2px solid $color-teal-dark;
+  padding: $baseline-unit*2;
+
+  @include respond-to($mq-s) {
+    @include column(6);
+  }
+
+  @include respond-to($mq-m) {
+    @include column(3);
+  }
+}
+
+.information-guides__list-title {
+  @include body(18, 24);
+  color: $color-black;
+  font-weight: normal;
+  margin: 0;
+  padding: 0;
+}
+
+a.information-guides__list-link {
+  display: block;
+  padding-right: $baseline-unit;
+  color: $color-black;
+
+  @include respond-to($mq-m) {
+    text-align: right;
+  }
+}
+
+.information-guides__list-arrow {
+  fill: $color-teal-dark;
+  height: 34px;
+  width: 30px;
+  float: right;
+}

--- a/app/assets/stylesheets/components/page_specific/home_beta/_information_guides.scss
+++ b/app/assets/stylesheets/components/page_specific/home_beta/_information_guides.scss
@@ -37,6 +37,7 @@
 
   @include respond-to($mq-m) {
     @include column(3);
+    margin-top: $baseline-unit*2;
   }
 }
 

--- a/app/assets/stylesheets/components/page_specific/home_beta/_information_guides.scss
+++ b/app/assets/stylesheets/components/page_specific/home_beta/_information_guides.scss
@@ -49,13 +49,22 @@
   padding: 0;
 }
 
+.information-guides__list-text {
+  @include respond-to($mq-m) {
+    margin-bottom: $baseline-unit*6;
+  }
+}
+
 a.information-guides__list-link {
   display: block;
   padding-right: $baseline-unit;
   color: $color-black;
+  text-align: right;
 
   @include respond-to($mq-m) {
-    text-align: right;
+    position: absolute;
+    right: 0;
+    bottom: 0;
   }
 }
 

--- a/app/assets/stylesheets/components/page_specific/home_beta/_information_guides.scss
+++ b/app/assets/stylesheets/components/page_specific/home_beta/_information_guides.scss
@@ -57,20 +57,21 @@
 
 a.information-guides__list-link {
   display: block;
-  padding-right: $baseline-unit;
   color: $color-black;
   text-align: right;
 
   @include respond-to($mq-m) {
     position: absolute;
-    right: 0;
-    bottom: 0;
+    right: $baseline-unit;
+    bottom: $baseline-unit;
   }
 }
 
 .information-guides__list-arrow {
+  display: inline-block;
   fill: $color-teal-dark;
-  height: 34px;
-  width: 30px;
+  margin-left: $baseline-unit;
   float: right;
+  height: 25px;
+  width: 25px;
 }

--- a/app/views/home_beta/show.html.erb
+++ b/app/views/home_beta/show.html.erb
@@ -27,8 +27,7 @@
   <%= render 'shared/home_beta/seasonal_spotlight', item: @resource %>
 </div>
 
-<%= render 'shared/home_beta/most_read', items_with_image: @resource.tiles, items_without_image: @resource.text_tiles %>
 <%= render 'shared/home_beta/information_guides', item: @resource %>
-<%= render 'shared/article_promos', items_with_image: @resource.tiles, items_without_image: @resource.text_tiles %>
+<%= render 'shared/home_beta/most_read', items_with_image: @resource.tiles, items_without_image: @resource.text_tiles %>
 
 <%= render 'shared/stripe_banner', item: @resource %>

--- a/app/views/home_beta/show.html.erb
+++ b/app/views/home_beta/show.html.erb
@@ -28,5 +28,7 @@
 </div>
 
 <%= render 'shared/home_beta/most_read', items_with_image: @resource.tiles, items_without_image: @resource.text_tiles %>
+<%= render 'shared/home_beta/information_guides', item: @resource %>
+<%= render 'shared/article_promos', items_with_image: @resource.tiles, items_without_image: @resource.text_tiles %>
 
 <%= render 'shared/stripe_banner', item: @resource %>

--- a/app/views/shared/home_beta/_information_guides.html.erb
+++ b/app/views/shared/home_beta/_information_guides.html.erb
@@ -1,0 +1,22 @@
+<div class="information-guides">
+  <h2 class="information-guides__title">
+    <%= t('home_beta.information_guides.title') %>
+  </h2>
+  <ul class="information-guides__list">
+      <% t('home_beta.information_guides.item').each do |item| %>
+      <li class="information-guides__list-item">
+        <h3 class="information-guides__list-title">
+          <%= item[:title] %>
+        </h3>
+        <p><%= item[:description] %></p>
+        <%= link_to item[:link_url], html_options = {class: 'information-guides__list-link'} do %>
+          <%= item[:link_text] %>
+          <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--arrow-right-ball information-guides__list-arrow" focusable="false">
+            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--arrow-right-ball"></use>
+          </svg>
+          <span class="icon icon--arrow-right"></span>
+        <% end %>
+      </li>
+      <% end %>
+  </ul>
+</div>

--- a/app/views/shared/home_beta/_information_guides.html.erb
+++ b/app/views/shared/home_beta/_information_guides.html.erb
@@ -8,7 +8,7 @@
         <h3 class="information-guides__list-title">
           <%= item[:title] %>
         </h3>
-        <p><%= item[:description] %></p>
+        <p class="information-guides__list-text"><%= item[:description] %></p>
         <%= link_to item[:link_url], html_options = {class: 'information-guides__list-link'} do %>
           <%= item[:link_text] %>
           <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--arrow-right-ball information-guides__list-arrow" focusable="false">

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -238,6 +238,27 @@ cy:
       blog_title: Eich blog Cyngor Ariannol
       blog_description: Awgrymiadau, newyddion a safbwyntiau ar bopeth sydd ynghlwm ag arian, o forgeisi a chynilion i gyllido a budd-daliadau.
 
+  home_beta:
+    information_guides:
+      title: Canllawiau gwybodaeth ar ein safle
+      item:
+        - title: Benthyciadau diwrnod tâl
+          description: Chwiliwch am ddewisiadau rhatach, gyda llai o risg
+          link_url: /cy/benthyciadau-diwrnod-cyflog
+          link_text: Darllenwch fwy
+        - title: Credyd Cynhwysol
+          description: Dysgwch am y system dalu budd-daliadau newydd
+          link_url: /cy/articles/credyd-cyffredinol-cyflwyniad
+          link_text: Darllenwch fwy
+        - title: Cyfrifon banc am ddim
+          description: Dysgwch fwy am y cyfrifon sylfaenol hyn a sut i gael un
+          link_url: /cy/articles/cyfrifon-banc-sylfaenol
+          link_text: Darllenwch fwy
+        - title: Gwasanaethau cyngor am ddim ar ddyledion
+          description: Ydych chi’n pryderu am ddyledion? Gweld pa help sydd ar gael yn agos atoch chi.
+          link_url: /cy/tools/canfyddwr-cyngor-ar-ddyledion/organisations
+          link_text: Darllenwch fwy
+
   opt_out:
     title: Edrychwch ar hyn ar ein gwefan flaenorol
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -238,6 +238,27 @@ en:
       blog_title: Your Money Advice blog
       blog_description: Tips, news and views on all things money from mortgages and savings to budgeting and benefits
 
+  home_beta:
+    information_guides:
+      title: Information guides on our site
+      item:
+        - title: Pay day loans
+          description: Find cheaper, less risky alternatives.
+          link_url: /en/payday-loans
+          link_text: Read more
+        - title: Universal credit
+          description: Learn about the new benefits payment system
+          link_url: /en/articles/universal-credit-an-introduction
+          link_text: Read more
+        - title: Free bank accounts
+          description: Learn more about these basic accounts and how to get one
+          link_url: /en/articles/basic-bank-accounts
+          link_text: Read more
+        - title: Free debt advice services
+          description: Worried about debt? Se what help is available near you.
+          link_url: /en/tools/debt-advice-locator
+          link_text: Read more
+
   opt_out:
     title: View on our previous website
 

--- a/features/home_beta_page.feature
+++ b/features/home_beta_page.feature
@@ -18,6 +18,7 @@ Feature: Home page beta
       | language |
       | English  |
       | Welsh    |
+<<<<<<< 1723bb895fca26a46a84eed9ace25b76d0eb1e65
 
   Scenario Outline: Most Read
     Given I view the beta home page in <language>
@@ -27,3 +28,15 @@ Feature: Home page beta
       | language |
       | English  |
       | Welsh    |
+||||||| merged common ancestors
+=======
+
+  Scenario Outline: Information guides
+    Given I view the beta home page in <language>
+    Then I should be presented with the information guides in <language>
+
+    Examples:
+      | language |
+      | English  |
+      | Welsh    |
+>>>>>>> Adds core markup and UI

--- a/features/home_beta_page.feature
+++ b/features/home_beta_page.feature
@@ -18,7 +18,6 @@ Feature: Home page beta
       | language |
       | English  |
       | Welsh    |
-<<<<<<< 1723bb895fca26a46a84eed9ace25b76d0eb1e65
 
   Scenario Outline: Most Read
     Given I view the beta home page in <language>
@@ -28,8 +27,6 @@ Feature: Home page beta
       | language |
       | English  |
       | Welsh    |
-||||||| merged common ancestors
-=======
 
   Scenario Outline: Information guides
     Given I view the beta home page in <language>
@@ -39,4 +36,3 @@ Feature: Home page beta
       | language |
       | English  |
       | Welsh    |
->>>>>>> Adds core markup and UI

--- a/features/step_definitions/home_beta_page_steps.rb
+++ b/features/step_definitions/home_beta_page_steps.rb
@@ -24,3 +24,13 @@ Then(/^I should be presented with a Most Read section$/) do
   expect(home_beta_page.most_read)
     .to have_content(I18n.t('home.show.most_read_heading'))
 end
+
+Then(/^I should be presented with the information guides in English$/) do
+  expect(home_beta_page.information_guides)
+    .to have_content('Information guides on our site')
+end
+
+Then(/^I should be presented with the information guides in Welsh$/) do
+  expect(home_beta_page.information_guides)
+    .to have_content('Canllawiau gwybodaeth ar ein safle')
+end

--- a/features/support/ui/pages/home_beta.rb
+++ b/features/support/ui/pages/home_beta.rb
@@ -8,5 +8,6 @@ module UI::Pages
     element :popular_tools, '.tool_promo-beta'
     element :seasonal_spotlight, '.seasonal-spotlight'
     element :most_read, '.most-read'
+    element :information_guides, '.information-guides'
   end
 end


### PR DESCRIPTION
# 8685 information guides

This ticket is to create the 'information guides on our site' element for the homepage.
These spotlights are to highlight guides/content that we know a lot of users, who land on our homepage, require.

[TP Ticket 8685](https://moneyadviceservice.tpondemand.com/entity/8685-homepage-create-information-guides-on-our)

![image](https://user-images.githubusercontent.com/13165846/35214656-cf21aeb4-ff59-11e7-80b5-04df9f48da74.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/frontend/1887)
<!-- Reviewable:end -->
