### PR TITLE
Homepage Beta Search Component

### DIFF
--- a/app/assets/stylesheets/components/page_specific/home_beta/_central_search.scss
+++ b/app/assets/stylesheets/components/page_specific/home_beta/_central_search.scss
@@ -1,12 +1,12 @@
 .central_search-beta {
-	@extend %clearfix;
-	background-color: $color-green-primary;
+  @extend %clearfix;
+  background-color: $color-green-primary;
   margin-top: $baseline-unit*2;
   width:100%;
 }
 
 .central_search-beta__content {
-	padding: $baseline-unit*2;
+  padding: $baseline-unit*2;
   max-width: 90%;
   margin: auto;
 
@@ -22,7 +22,7 @@
 .central_search-beta__headline {
   @include body(24, 32);
   @extend %font-heading-medium;
-	color: $color-white;
+  color: $color-white;
   text-align: center;
   margin-bottom: $baseline-unit*2;
 

--- a/app/assets/stylesheets/components/page_specific/home_beta/_central_search.scss
+++ b/app/assets/stylesheets/components/page_specific/home_beta/_central_search.scss
@@ -65,4 +65,3 @@
     display: none;
   }
 }
-

--- a/app/assets/stylesheets/components/page_specific/home_beta/_central_search.scss
+++ b/app/assets/stylesheets/components/page_specific/home_beta/_central_search.scss
@@ -1,0 +1,68 @@
+.central_search-beta {
+	@extend %clearfix;
+	background-color: $color-green-primary;
+  margin-top: $baseline-unit*2;
+  width:100%;
+}
+
+.central_search-beta__content {
+	padding: $baseline-unit*2;
+  max-width: 90%;
+  margin: auto;
+
+  @include respond-to($mq-m) {
+    max-width: 80%;
+  }
+
+  @include respond-to($mq-xl) {
+    max-width: 60%;
+  }
+}
+
+.central_search-beta__headline {
+  @include body(24, 32);
+  @extend %font-heading-medium;
+	color: $color-white;
+  text-align: center;
+  margin-bottom: $baseline-unit*2;
+
+  @include respond-to($mq-l) {
+    @include body(26, 34);
+  }
+}
+
+.central_search-beta__search-box {
+  position: relative;
+  margin: 0 auto;
+  max-width: 100%;
+
+  @include respond-to($mq-m) {
+    max-width: 80%;
+  }
+
+  .search__input {
+    width: 100%;
+
+    @include respond-to($mq-m) {
+      @include column(9);
+      position: absolute;
+    }
+  }
+}
+
+.central_search-beta__search-box--desktop {
+  display: none;
+
+  @include respond-to($mq-m) {
+    display: block;
+  }
+}
+
+.central_search-beta__search-box--mobile {
+  display: block;
+
+  @include respond-to($mq-m) {
+    display: none;
+  }
+}
+

--- a/app/controllers/home_beta_controller.rb
+++ b/app/controllers/home_beta_controller.rb
@@ -1,4 +1,5 @@
 class HomeBetaController < ApplicationController
+  layout '_unconstrained'
 
   def show
     @resource = interactor.call

--- a/app/views/home_beta/show.html.erb
+++ b/app/views/home_beta/show.html.erb
@@ -22,10 +22,12 @@
 
 <%= render 'shared/home_beta/central_search' %>
 
-<div class="l-home-promos">
-  <%= render 'shared/home_beta/tool_promos', items: @resource.tools %>
-  <%= render 'shared/home_beta/seasonal_spotlight', item: @resource %>
-</div>
+<div class="l-constrained">
+  <div class="l-home-promos">
+    <%= render 'shared/home_beta/tool_promos', items: @resource.tools %>
+    <%= render 'shared/home_beta/seasonal_spotlight', item: @resource %>
+  </div>
 
-<%= render 'shared/home_beta/information_guides', item: @resource %>
-<%= render 'shared/home_beta/most_read', items_with_image: @resource.tiles, items_without_image: @resource.text_tiles %>
+  <%= render 'shared/home_beta/information_guides', item: @resource %>
+  <%= render 'shared/home_beta/most_read', items_with_image: @resource.tiles, items_without_image: @resource.text_tiles %>
+</div>

--- a/app/views/home_beta/show.html.erb
+++ b/app/views/home_beta/show.html.erb
@@ -20,7 +20,7 @@
 
 <%= heading_tag t('layouts.base.title'), class: 'visually-hidden' %>
 
-<%= render 'shared/home_top', item: @resource %>
+<%= render 'shared/home_beta/central_search' %>
 
 <div class="l-home-promos">
   <%= render 'shared/home_beta/tool_promos', items: @resource.tools %>
@@ -29,5 +29,3 @@
 
 <%= render 'shared/home_beta/information_guides', item: @resource %>
 <%= render 'shared/home_beta/most_read', items_with_image: @resource.tiles, items_without_image: @resource.text_tiles %>
-
-<%= render 'shared/stripe_banner', item: @resource %>

--- a/app/views/shared/home_beta/_central_search.html.erb
+++ b/app/views/shared/home_beta/_central_search.html.erb
@@ -1,7 +1,7 @@
 <div class="central_search-beta">
   <div class="central_search-beta__content">  
     <div class="central_search-beta__headline">
-      Free and impartial money advice, set up by government
+      <%= t('home.show.strapline') %>
     </div>
     <div class="central_search-beta__search-box">
       <%= render 'shared/home_beta/search_beta' %>

--- a/app/views/shared/home_beta/_central_search.html.erb
+++ b/app/views/shared/home_beta/_central_search.html.erb
@@ -1,0 +1,10 @@
+<div class="central_search-beta">
+  <div class="central_search-beta__content">  
+    <div class="central_search-beta__headline">
+      Free and impartial money advice, set up by government
+    </div>
+    <div class="central_search-beta__search-box">
+      <%= render 'shared/home_beta/search_beta' %>
+    </div> 
+  </div>
+</div>

--- a/app/views/shared/home_beta/_search_beta.html.erb
+++ b/app/views/shared/home_beta/_search_beta.html.erb
@@ -1,0 +1,18 @@
+<form data-dough-component="ClearInput" action="<%= main_app.search_results_path %>" method="get" role="search" class="search search--inpage" >
+  <label class="visually-hidden" for="search"><%= t('search_box.label') %></label>
+  <input data-dough-clear-input class="search__input" id="search" required type="search" name="query" value="<%= params[:query] %>" autocomplete="off" data-dough-search-input/>
+  <button data-dough-clear-input-button type="reset" class="search__clear">
+    <span class="icon icon--clear"></span>
+  </button>
+  <div class="central_search-beta__search-box--mobile">
+    <button class="search__submit search__submit--white" type="submit">
+      <span class="icon icon--search"></span>
+      <span class="visually-hidden"><%= t('search_box.button_text') %></span>
+    </button>
+  </div>
+  <div class="central_search-beta__search-box--desktop">
+    <button class="search__submit search__submit--inpage button button--primary" type="submit">
+      <%= t('search_box.button_text') %>
+    </button>
+  </div>  
+</form>


### PR DESCRIPTION
This PR creates the search component for the MAS  beta homepage. 

[TP](https://moneyadviceservice.tpondemand.com/entity/8680-homepage-create-central-search-box)

## Description
As a new user I want to start my journey on the Money Advice Service site using site search but I don't always see the top right search box.
 
**What needs to happen:**
Implement a UI element below the leader image that features site search, centred on the page.

|English | Welsh|
|-------|--------|
| <img width="1219" alt="screen shot 2018-01-26 at 11 08 27" src="https://user-images.githubusercontent.com/2187295/35437251-8277ee88-0289-11e8-8a8f-8ef1708c7393.png">| <img width="1216" alt="screen shot 2018-01-26 at 11 08 53" src="https://user-images.githubusercontent.com/2187295/35437278-916a80fe-0289-11e8-93d2-fa1e66228188.png">|

