### PR TITLE
[DEV APPROVED] Creates feature spec for the show_all? flag on money manager/universal credit

### DIFF
--- a/features/money_manager.feature
+++ b/features/money_manager.feature
@@ -20,7 +20,7 @@ Scenario: Signing in after completing questionnaire saves answers
   And   I select a country
   And   I sign in
   Then  I get my results
-  
+
 Scenario: Signing in should overwrite old answers with new ones
   Given I am signed in
   And   I am on the Money Manager tool
@@ -30,3 +30,10 @@ Scenario: Signing in should overwrite old answers with new ones
   And   I answer the questions differently
   And   I sign in
   Then  I have the latest answers
+
+Scenario: Passing a special parameter in the url should show all content
+  Given I am signed in
+  And   I am on the Money Manager tool
+  And   I complete the series of questions
+  And   I visit the show all url
+  Then  I see all of the advice

--- a/features/money_manager.feature
+++ b/features/money_manager.feature
@@ -31,6 +31,7 @@ Scenario: Signing in should overwrite old answers with new ones
   And   I sign in
   Then  I have the latest answers
 
+@no-javascript
 Scenario: Passing a special parameter in the url should show all content
   Given I am signed in
   And   I am on the Money Manager tool

--- a/features/step_definitions/money_manager_steps.rb
+++ b/features/step_definitions/money_manager_steps.rb
@@ -29,6 +29,10 @@ Given(/^I get my results$/) do
   expect(page.current_path).to eql('/en/tools/money-manager/to-read')
 end
 
+When(/^I visit the show all url$/) do
+  money_manager_show_all_advice_page.load
+end
+
 Then(/^I should not see any hint of my details when I re-visit the tool$/) do
   step 'I select a country'
   expect(money_manager_questionnaire_page.received_first_payment_true).not_to be_checked
@@ -43,4 +47,11 @@ Then(/^I have the latest answers$/) do
   money_manager_circumstances_changed_page.load
   expect(money_manager_circumstances_changed_page.received_first_payment_false).to be_checked
   expect(money_manager_circumstances_changed_page.single_or_in_couple_couple).to be_checked
+end
+
+
+Then(/^I see all of the advice$/) do
+  all_advice_count = money_manager_show_all_advice_page.all_advice_list_items.length
+  visible_advice_count = money_manager_show_all_advice_page.active_advice_list_items.length
+  expect(all_advice_count).to eq(visible_advice_count)
 end

--- a/features/step_definitions/money_manager_steps.rb
+++ b/features/step_definitions/money_manager_steps.rb
@@ -35,8 +35,12 @@ end
 
 Then(/^I should not see any hint of my details when I re-visit the tool$/) do
   step 'I select a country'
-  expect(money_manager_questionnaire_page.received_first_payment_true).not_to be_checked
-  expect(money_manager_questionnaire_page.received_first_payment_false).not_to be_checked
+  expect(
+    money_manager_questionnaire_page.received_first_payment_true
+  ).not_to be_checked
+  expect(
+    money_manager_questionnaire_page.received_first_payment_false
+  ).not_to be_checked
 end
 
 Then(/^I should be at the Money Manager landing page$/) do
@@ -45,13 +49,18 @@ end
 
 Then(/^I have the latest answers$/) do
   money_manager_circumstances_changed_page.load
-  expect(money_manager_circumstances_changed_page.received_first_payment_false).to be_checked
-  expect(money_manager_circumstances_changed_page.single_or_in_couple_couple).to be_checked
+  expect(
+    money_manager_circumstances_changed_page.received_first_payment_false
+  ).to be_checked
+  expect(
+    money_manager_circumstances_changed_page.single_or_in_couple_couple
+  ).to be_checked
 end
 
-
 Then(/^I see all of the advice$/) do
-  all_advice_count = money_manager_show_all_advice_page.all_advice_list_items.length
-  visible_advice_count = money_manager_show_all_advice_page.active_advice_list_items.length
-  expect(all_advice_count).to eq(visible_advice_count)
+  expect(
+    money_manager_show_all_advice_page.all_advice_list_items.length
+  ).to eq(
+    money_manager_show_all_advice_page.active_advice_list_items.length
+  )
 end

--- a/features/support/ui/pages/money_manager_show_all_advice_page.rb
+++ b/features/support/ui/pages/money_manager_show_all_advice_page.rb
@@ -1,0 +1,12 @@
+require_relative '../page'
+
+module UI::Pages
+  class MoneyManagerShowAllAdvice < UI::Page
+    set_url '/en/tools/money-manager/to-read?show_all'
+
+    elements :active_advice_list_items,
+             'div.advice-list__item-content-text.is-active'
+    elements :all_advice_list_items,
+             'div.advice-list__item-content-text'
+  end
+end

--- a/features/support/world/pages.rb
+++ b/features/support/world/pages.rb
@@ -21,6 +21,9 @@ module World
       money_manager
       money_manager_circumstances_changed
       money_manager_questionnaire
+      money_manager_show_all_advice
+      news
+      news_article
       partners
       profile
       quiz_admin


### PR DESCRIPTION
[TP Link](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx#page=board/4771110243071511547&appConfig=eyJhY2lkIjoiRjk1Qzc3Njg4REFDNTUyNTBGODhGNTE5MEM5M0JCN0UiLCJhcHBDb250ZXh0Ijp7InByb2plY3RDb250ZXh0Ijp7Im5vIjpmYWxzZX0sInRlYW1Db250ZXh0Ijp7Im5vIjpmYWxzZX19fQ==)

**Summary**
This PR creates a feature spec for the TP Link card above. The logic is implemented in https://github.com/moneyadviceservice/universal_credit/pull/216.

**Checklist**

+ [ ] Tests passed.
+ [ ] Rubocop is passing for this PR (or any other lint like JShint).
+ [ ] Code Climate passed for this PR.
+ [ ] Commit history reviewed (clear commit messages).

**N.B.** The test is failing because the universal credit PR has not been merged and so we cannot bump the version of UC yet. Once that has been merged we will add that bump to this PR and the feature spec should pass.