### PR TITLE
[DEV APPROVED] 8836: Resolve issue with missing paths for tools pages

### DIFF
--- a/app/decorators/category_content_decorator.rb
+++ b/app/decorators/category_content_decorator.rb
@@ -18,8 +18,10 @@ class CategoryContentDecorator < Draper::Decorator
   def path
     case object
     when Core::Article, Core::Category, Mas::Cms::Article, Mas::Cms::Category
-      h.send("#{object.class.to_s.demodulize.underscore}_path", object.id, locale: I18n.locale)
-    when Core::Other, Mas::Cms::Video
+      h.send("#{object.class.to_s.demodulize.underscore}_path",
+             object.id,
+             locale: I18n.locale)
+    when Core::Other, Mas::Cms::Other, Mas::Cms::Video
       "/#{I18n.locale}/#{object.type.pluralize}/#{object.id}"
     end
   end

--- a/app/decorators/corporate_category_content_decorator.rb
+++ b/app/decorators/corporate_category_content_decorator.rb
@@ -2,10 +2,14 @@ class CorporateCategoryContentDecorator < CategoryContentDecorator
   def path
     case object
     when Core::Article, Mas::Cms::Article
-      h.send("#{object.class.to_s.demodulize.underscore}_path", object.id, locale: I18n.locale)
+      h.send("#{object.class.to_s.demodulize.underscore}_path",
+             object.id,
+             locale: I18n.locale)
     when Core::Category, Mas::Cms::Category
-      h.send("corporate_#{object.class.to_s.demodulize.underscore}_path", object.id, locale: I18n.locale)
-    when Core::Other, Mas::Cms::Video
+      h.send("corporate_#{object.class.to_s.demodulize.underscore}_path",
+             object.id,
+             locale: I18n.locale)
+    when Core::Other, Mas::Cms::Other, Mas::Cms::Video
       "/#{I18n.locale}/#{object.type.pluralize}/#{object.id}"
     end
   end

--- a/spec/decorators/category_content_decorator_spec.rb
+++ b/spec/decorators/category_content_decorator_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CategoryContentDecorator do
   before { allow(I18n).to receive(:locale) { locale } }
 
   subject(:decorator) { described_class.decorate(item) }
- 
+
   it { is_expected.to respond_to(:id) }
   it { is_expected.to respond_to(:path) }
   it { is_expected.to respond_to(:label) }
@@ -63,7 +63,7 @@ RSpec.describe CategoryContentDecorator do
   describe '#label' do
     let(:item) { double(type: 'foo_bar-baz') }
 
-    it "returns a capitalised representation of the object type with a ` - ' suffix" do
+    it 'returns capitalised string of the object type with - suffix' do
       expect(subject.label).to eq('Foo Bar Baz - ')
     end
   end
@@ -91,16 +91,18 @@ RSpec.describe CategoryContentDecorator do
       let(:item) { build :action_plan }
 
       it 'calls the correct path helper' do
-        expect(helpers).to receive(:action_plan_path).with(item.id, locale: locale)
+        expect(helpers)
+          .to receive(:action_plan_path)
+          .with(item.id, locale: locale)
         subject.path
       end
     end
 
     context 'with an Other' do
-      let(:item) { Core::Other.new('item-id') }
+      let(:item) { Mas::Cms::Other.new('item-id') }
 
       it 'returns the correct path' do
-        %w(campaign news tool video).each do |type|
+        %w[campaign news tool video].each do |type|
           allow(item).to receive_messages(type: type)
           expect(subject.path).to eq "/#{locale}/#{type.pluralize}/#{item.id}"
         end
@@ -111,7 +113,7 @@ RSpec.describe CategoryContentDecorator do
   describe '#icon_class' do
     let(:item) { double(type: 'foo_bar-baz') }
 
-    it "returns a dasherised representation of the object type prefixed with `icon--'" do
+    it 'returns dasherised string of object type with icon-- prefix' do
       expect(subject.icon_class).to eq('icon--foo-bar-baz')
     end
   end


### PR DESCRIPTION
**Target Process ticket**

[TP 8836](https://moneyadviceservice.tpondemand.com/entity/8836-all-of-the-more-in-links)
[TP 8876](https://moneyadviceservice.tpondemand.com/entity/8876-tools-links-on-category-pages-do)

**Summary**
Some of the links to tool pages are broken, and are redirecting to the current page rather than the correct tool.

##### Findings
Some of the tool page objects are now coming through as `Mas::Cms::Other` rather than `Core::Other`. 
When the `CategoryContentDecorator` tries to add the `path` to pages, they are getting missed as the `Mas::Cms::Other` type isn't listed.
The paths therefore aren't available when we create the links in the `_more_in` partial. 

**QA / Testing**
Test that the links which were previously broken (redirecting back to the same page) on these two pages are now linking to the right pages.
https://www.moneyadviceservice.org.uk/en/categories/tools-and-calculators
https://www.moneyadviceservice.org.uk/en/articles/how-to-prioritise-your-debts

**Checklist**

+ [ ] Tests passed.
+ [ ] Rubocop is passing for this PR (or any other lint like JShint).
+ [ ] Code Climate passed for this PR.
+ [ ] Commit history reviewed (clear commit messages).
