### PR TITLE
[DEV APPROVED] - 8814 Add nofollow to voting buttons

### DIFF
--- a/app/views/shared/_on_page_feedback.html.erb
+++ b/app/views/shared/_on_page_feedback.html.erb
@@ -1,7 +1,7 @@
 <div class="on-page-feedback" aria-live="polite" data-dough-component="OnPageFeedback" data-dough-on-page-feedback-post="<%= article_page_feedbacks_path(article.id) %>">
   <div data-dough-feedback-page="start">
     <h2 class="on-page-feedback__title"><%= t('articles.on_page_feedback.prompt') %></h2>
-    <button class="on-page-feedback__thumb-button-up" data-dough-feedback="positive">
+    <button class="on-page-feedback__thumb-button-up" rel="nofollow" data-dough-feedback="positive">
       <span class="visually-hidden"><%= t('articles.on_page_feedback.positive') %></span>
       <svg xmlns="http://www.w3.org/2000/svg"
            class="svg-icon svg-icon--thumb-button"
@@ -10,7 +10,7 @@
       </svg>
       <span class="icon icon--thumb-icon-up"></span>
     </button>
-    <button class="on-page-feedback__thumb-button-down" data-dough-feedback="negative">
+    <button class="on-page-feedback__thumb-button-down" rel="nofollow" data-dough-feedback="negative">
       <span class="visually-hidden"><%= t('articles.on_page_feedback.negative') %></span>
       <svg xmlns="http://www.w3.org/2000/svg"
            class="svg-icon svg-icon--thumb-button"


### PR DESCRIPTION
**Target Process ticket**
[TP 8814](https://moneyadviceservice.tpondemand.com/entity/8814-add-no-follow-to-the-vote)

**Summary**
The adds no follow to page feedback are on articles. This will hopefully stop clicks from non human traffic.