### PR TITLE
Bump wpcc version to 2.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,7 @@ gem 'rio', '1.18.4', source: 'http://gems.dev.mas.local'
 gem 'savings_calculator', '~> 1.8.1'
 gem 'timelines', '~> 1.5.0'
 gem 'universal_credit', '3.1.0'
-gem 'wpcc', '1.14.0'
+gem 'wpcc', '2.0.0'
 
 # 1.0.2 has breaking changes as it adds japanese and turkish locales
 gem 'validate_url', '1.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -731,7 +731,7 @@ GEM
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
-    wpcc (1.14.0)
+    wpcc (2.0.0)
       dough-ruby
       meta-tags
       rails (>= 4, < 5)
@@ -841,7 +841,7 @@ DEPENDENCIES
   validate_url (= 1.0.0)
   vcr
   webmock
-  wpcc (= 1.14.0)
+  wpcc (= 2.0.0)
 
 BUNDLED WITH
    1.16.1


### PR DESCRIPTION
[TP card](https://moneyadviceservice.tpondemand.com/entity/9008-nty-18-wpcc-deploy-the-feature)

## Context

This PR includes the tax changes for the new financial year.
The wpcc 2.0.0 version includes the work done on this PR: https://github.com/moneyadviceservice/wpcc/pull/205