### PR TITLE
8961 - Removes top margin from the central search box

### DIFF
--- a/app/assets/stylesheets/components/page_specific/home_beta/_central_search.scss
+++ b/app/assets/stylesheets/components/page_specific/home_beta/_central_search.scss
@@ -1,7 +1,6 @@
 .central_search-beta {
   @extend %clearfix;
   background-color: $color-green-primary;
-  margin-top: $baseline-unit*2;
   width:100%;
 }
 


### PR DESCRIPTION
# 8961 - Removes top margin from the central search box

TP Ticket [8961](https://moneyadviceservice.tpondemand.com/entity/8961-hp-main-image-should-rest-directly)

On the current implementation of the new homepage beta, there is a white space between the lead image and the next page element - the green search box.

This PR ensures that the image rests on top of the central search box.  By removing a top margin.

**Screenshots**

| Desktop |
|-----------|
|![image](https://user-images.githubusercontent.com/13165846/39294948-f28003ae-4934-11e8-97bc-82f41d85e14e.png)|

| Mobile |
|--------|
|![image](https://user-images.githubusercontent.com/13165846/39294979-0a47763e-4935-11e8-9c75-2e120d8799ae.png)|
