### PR TITLE
8963 - Makes read more and get started links equal size

### DIFF
--- a/app/assets/stylesheets/components/page_specific/home_beta/_tool_promo.scss
+++ b/app/assets/stylesheets/components/page_specific/home_beta/_tool_promo.scss
@@ -20,6 +20,7 @@
 }
 
 a.tool_promo-beta__item-link {
+  @include body(16, 24);
   color: $color-grey-primary;
   padding: $baseline-unit*2 0;
   display: block;


### PR DESCRIPTION
# 8963 - Consistent size/style for the 'Get Started' and 'Read More' text

TP Ticket [8963](https://moneyadviceservice.tpondemand.com/entity/8963-hp-consistent-sizestyle-for-the-get)

The 'Get Started' links and the 'read more' links on the homepage are inconsistently sized.

This PR makes the 'Get Started' links match the 'Read more' links in size.

| Screenshot (Links highlighted in red) |
|------------|
|![image](https://user-images.githubusercontent.com/13165846/39295396-3c60ca70-4936-11e8-82a8-7d6f5e1fb446.png)|
