### PR TITLE
8962 8965 linked boxes

### DIFF
--- a/app/assets/stylesheets/components/page_specific/home_beta/_information_guides.scss
+++ b/app/assets/stylesheets/components/page_specific/home_beta/_information_guides.scss
@@ -41,6 +41,20 @@
   }
 }
 
+.information-guides__list-link {
+  float: left;
+  height: 100%;
+  width: 100%;
+  &:hover {
+    text-decoration: none;
+
+    .information-guides__list-title,
+    .information-guides__list-more {
+      text-decoration: underline;
+    }
+  }
+}
+
 .information-guides__list-title {
   @include body(18, 24);
   color: $color-black;
@@ -50,12 +64,13 @@
 }
 
 .information-guides__list-text {
+  color: $color-grey-primary;
   @include respond-to($mq-m) {
     margin-bottom: $baseline-unit*6;
   }
 }
 
-a.information-guides__list-link {
+.information-guides__list-more {
   display: block;
   color: $color-black;
   text-align: right;

--- a/app/assets/stylesheets/components/page_specific/home_beta/_most_read.scss
+++ b/app/assets/stylesheets/components/page_specific/home_beta/_most_read.scss
@@ -39,6 +39,9 @@
 
 .most-read__link {
   @extend %clearfix;
+  float: left;
+  height: 100%;
+  width: 100%;
 
   .item__heading {
     @extend %font-heading-medium;
@@ -51,7 +54,8 @@
   &:hover {
     text-decoration: none;
 
-    .item__heading {
+    .item__heading,
+    .most-read__CTA {
       text-decoration: underline;
     }
   }

--- a/app/assets/stylesheets/components/page_specific/home_beta/_tool_promo.scss
+++ b/app/assets/stylesheets/components/page_specific/home_beta/_tool_promo.scss
@@ -19,7 +19,21 @@
   position: relative;
 }
 
-a.tool_promo-beta__item-link {
+.tool_promo-beta__item-link {
+  float: left;
+  height: 100%;
+  width: 100%;
+  &:hover {
+    text-decoration: none;
+
+    .tool_promo-beta__item-heading,
+    .tool_promo-beta__item-more {
+      text-decoration: underline;
+    }
+  }
+}
+
+.tool_promo-beta__item-more {
   @include body(16, 24);
   color: $color-grey-primary;
   padding: $baseline-unit*2 0;

--- a/app/views/shared/home_beta/_information_guides.html.erb
+++ b/app/views/shared/home_beta/_information_guides.html.erb
@@ -5,16 +5,18 @@
   <ul class="information-guides__list">
       <% t('home_beta.information_guides.item').each do |item| %>
       <li class="information-guides__list-item">
-        <h3 class="information-guides__list-title">
-          <%= item[:title] %>
-        </h3>
-        <p class="information-guides__list-text"><%= item[:description] %></p>
         <%= link_to item[:link_url], html_options = {class: 'information-guides__list-link'} do %>
-          <%= item[:link_text] %>
-          <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--arrow-right-ball information-guides__list-arrow" focusable="false">
-            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--arrow-right-ball"></use>
-          </svg>
-          <span class="icon icon--arrow-right"></span>
+          <h3 class="information-guides__list-title">
+            <%= item[:title] %>
+          </h3>
+          <p class="information-guides__list-text"><%= item[:description] %></p>
+          <div class="information-guides__list-more">
+            <%= item[:link_text] %>
+            <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--arrow-right-ball information-guides__list-arrow" focusable="false">
+              <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--arrow-right-ball"></use>
+            </svg>
+            <span class="icon icon--arrow-right"></span>
+          </div>  
         <% end %>
       </li>
       <% end %>

--- a/app/views/shared/home_beta/_tool_promos.html.erb
+++ b/app/views/shared/home_beta/_tool_promos.html.erb
@@ -14,40 +14,44 @@
     <% items.each do |item| %>
       <div class="tool_promo-beta__item">
         <div class="l-constrained">
-          <div class="l-2col-main">
-            <%= link_to item['url'], class: 'tool_promo-beta__item-content' do %>
-              <%= heading_tag(level: 4, class: 'tool_promo-beta__item-heading') do %>
-                <%= item['heading'] %>
-              <% end %>
-              <%= item['text'] %>
-            <% end %>
-          </div>
-          <div class="l-2col-side">
-            <%= link_to item['url'], class: 'tool_promo-beta__item-link' do %>
-              <%= t('home.show.tools_get_started') %>
-              <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--arrow-right-ball tool_promo-beta__item-arrow" focusable="false">
-                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--arrow-right-ball"></use>
-              </svg>
-              <span class="icon icon--arrow-right"></span>
-            <% end %>
-          </div>
+          <%= link_to item['url'], class: 'tool_promo-beta__item-link' do %>
+            <div class="l-2col-main">
+              <div class="tool_promo-beta__item-content">
+                <%= heading_tag(level: 4, class: 'tool_promo-beta__item-heading') do %>
+                  <%= item['heading'] %>
+                <% end %>
+                <%= item['text'] %>
+              </div>
+            </div>
+            <div class="l-2col-side">
+              <div class="tool_promo-beta__item-more">
+                <%= t('home.show.tools_get_started') %>
+                <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--arrow-right-ball tool_promo-beta__item-arrow" focusable="false">
+                  <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--arrow-right-ball"></use>
+                </svg>
+                <span class="icon icon--arrow-right"></span>
+              </div>
+            </div>
+          <% end %>
         </div>
-
       </div>
     <% end %>
 
     <!-- View all link -->
     <div class="l-tool-promos__view-all tool_promo-beta__item">
       <div class="l-constrained">
-        <div class="l-1col">
-          <%= link_to(t('home.show.tools_view_all'), class: 'tool_promo-beta__item-link') do %>
-            <%= t('home.show.tools_view_all_text') %><span class="visually-hidden"><%= t('home.show.view_all_link_expanded') %></span>
-            <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--arrow-right-ball tool_promo-beta__item-arrow" focusable="false">
-              <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--arrow-right-ball"></use>
-            </svg>
-            <span class="icon icon--arrow-right"></span>
-          <% end %>
-        </div>
+
+        <%= link_to(t('home.show.tools_view_all'), class: 'tool_promo-beta__item-link') do %>
+          <div class="l-1col">
+            <div class="tool_promo-beta__item-more"/>
+              <%= t('home.show.tools_view_all_text') %><span class="visually-hidden"><%= t('home.show.view_all_link_expanded') %></span>
+              <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--arrow-right-ball tool_promo-beta__item-arrow" focusable="false">
+                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--arrow-right-ball"></use>
+              </svg>
+              <span class="icon icon--arrow-right"></span>
+            </div>
+          </div>
+        <% end %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
# 8962 - Get started links
[TP8962](https://moneyadviceservice.tpondemand.com/entity/8962-hp-get-started-links-require-more)
# 8965 - Info guides links
[TP8962](https://moneyadviceservice.tpondemand.com/entity/8965-hp-make-the-whole-boxes-clickable)

-Moved the links to encompass the entire content in the boxes for info guides and most read.
-Updated styling on all to have consistent hover states on info guides, most read, and additionally tools.
-Also added a little fix to fix the issue with 'hover dead zones' where there was gaps in the clickable area between the link's child elements

