### PR TITLE
[DEV APPROVED] TP: 8969/70/71, Comment: Updates positioning of SVG text

### DIFF
--- a/app/assets/stylesheets/components/page_specific/home_beta/_leader.scss
+++ b/app/assets/stylesheets/components/page_specific/home_beta/_leader.scss
@@ -39,6 +39,7 @@
 .leader__image {
   background-repeat: no-repeat;
   background-size: 100%;
+  background-position: bottom;
   height: 0;
   width: 100%;
   padding-top: 408 / 464 * 100%;

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -14,7 +14,7 @@ module HomeHelper
   end
 
   def leader_text(name, size, x, y, rotation)
-    "<text text-anchor='middle' x=#{x} y=#{y} transform='rotate(#{rotation} #{x} #{y})'>
+    "<text text-anchor='middle' transform='translate(#{x} #{y}) rotate(#{rotation} 0 0)'>
       #{t('home.show.beta_leader.text_' + name + '.' + size + '_html')}
     </text>"
   end

--- a/app/views/shared/home_beta/_leader_text.html.erb
+++ b/app/views/shared/home_beta/_leader_text.html.erb
@@ -14,8 +14,8 @@
     <%# leader_text('name', 'viewport-width', 'x-axis(centre)', 'y-axis(centre)', 'rotation').html_safe %>
     <%= leader_text('student', 'mq_l', '173', '177', '-14').html_safe %>
     <%= leader_text('debt', 'mq_l', '310', '150', '5').html_safe %>
-    <%= leader_text('pension', 'mq_l', '427', '195', '26').html_safe %>
-    <%= leader_text('house', 'mq_l', '580', '275', '-18').html_safe %>
+    <%= leader_text('pension', 'mq_l', '427', '195', '23').html_safe %>
+    <%= leader_text('house', 'mq_l', '580', '283', '-18').html_safe %>
     <%= leader_text('budget', 'mq_l', '756', '137', '18').html_safe %>
     <%= leader_text('uc', 'mq_l', '864', '209', '-15').html_safe %>
     <%= leader_text('retire', 'mq_l', '1002', '206', '36').html_safe %>
@@ -28,8 +28,8 @@
     <%# leader_text('name', 'viewport-width', 'x-axis(centre)', 'y-axis(centre)', 'rotation').html_safe %>
     <%= leader_text('student', 'mq_s', '173', '177', '-14').html_safe %>
     <%= leader_text('debt', 'mq_s', '310', '150', '5').html_safe %>
-    <%= leader_text('pension', 'mq_s', '427', '195', '26').html_safe %>
-    <%= leader_text('house', 'mq_s', '580', '275', '-18').html_safe %>
+    <%= leader_text('pension', 'mq_s', '427', '195', '23').html_safe %>
+    <%= leader_text('house', 'mq_s', '580', '287', '-18').html_safe %>
     <%= leader_text('budget', 'mq_s', '756', '137', '18').html_safe %>
     <%= leader_text('uc', 'mq_s', '864', '209', '-15').html_safe %>
     <%= leader_text('retire', 'mq_s', '1002', '206', '36').html_safe %>
@@ -49,17 +49,17 @@
     class="leader__image_text__mq-0 leader__image_text__mq-0--0"
   >
     <%# leader_text('name', 'viewport-width', 'x-axis(centre)', 'y-axis(centre)', 'rotation').html_safe %>
-    <%= leader_text('student', 'mq_0', '89', '190', '-14').html_safe %>
-    <%= leader_text('debt', 'mq_0', '237', '158.5', '5').html_safe %>
-    <%= leader_text('pension', 'mq_0', '372', '210.5', '26').html_safe %>
+    <%= leader_text('student', 'mq_0', '89', '192', '-14').html_safe %>
+    <%= leader_text('debt', 'mq_0', '237', '161', '5').html_safe %>
+    <%= leader_text('pension', 'mq_0', '370', '210', '23').html_safe %>
   </g>
   <g
     class="leader__image_text__mq-0 leader__image_text__mq-0--1"
   >
     <%# leader_text('name', 'viewport-width', 'x-axis(centre)', 'y-axis(centre)', 'rotation').html_safe %>
-    <%= leader_text('house', 'mq_0', '69.5', '295', '-18').html_safe %>
-    <%= leader_text('budget', 'mq_0', '260.5', '147', '18').html_safe %>
-    <%= leader_text('uc', 'mq_0', '376.5', '224', '-15').html_safe %>
+    <%= leader_text('house', 'mq_0', '77', '311', '-18').html_safe %>
+    <%= leader_text('budget', 'mq_0', '260.5', '151', '18').html_safe %>
+    <%= leader_text('uc', 'mq_0', '376.5', '226', '-15').html_safe %>
   </g>
   <g
     class="leader__image_text__mq-0 leader__image_text__mq-0--2"
@@ -67,6 +67,6 @@
     <%# leader_text('name', 'viewport-width', 'x-axis(centre)', 'y-axis(centre)', 'rotation').html_safe %>
     <%= leader_text('budget', 'mq_0', '96', '143.5', '18').html_safe %>
     <%= leader_text('uc', 'mq_0', '212', '223.5', '-15').html_safe %>
-    <%= leader_text('retire', 'mq_0', '358', '220', '36').html_safe %>
+    <%= leader_text('retire', 'mq_0', '362', '220', '36').html_safe %>
   </g>
 </svg>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -192,33 +192,33 @@ cy:
         title: Sut allwn ni’ch helpu chi heddiw?
         text: Mae’r Gwasanaeth Cynghori Ariannol yma i’ch cefnogi waeth beth yw eich problemau ariannol. Pa un a’ch bod mewn trafferthion gyda dyledion, angen ychydig o help gyda’ch cyllidebau, yn dymuno prynu tŷ, neu’n dymuno canfod pa fudd-daliadau allech chi fod yn gymwys i’w cael, gallwn roi cyngor a chymorth i chi gyda’ch arian.
         text_student:
-          mq_l_html: <tspan dx="0" dy="-21">Mae gen i</tspan><tspan dx="-80" dy="21">fenthyciad</tspan><tspan dx="-86" dy="21">myfyriwr</tspan>
-          mq_s_html: <tspan dx="0" dy="-25">Mae gen i</tspan><tspan dx="-92" dy="25">fenthyciad</tspan><tspan dx="-102" dy="25">myfyriwr</tspan>
-          mq_0_html: <tspan dx="-7" dy="-28">Mae gen i</tspan><tspan dx="-101" dy="28">fenthyciad</tspan><tspan dx="-110" dy="28">myfyriwr</tspan>
+          mq_l_html: <tspan x="-4" y="-21">Mae gen i</tspan><tspan x="0" y="0">fenthyciad</tspan><tspan x="-8" y="21">myfyriwr</tspan>
+          mq_s_html: <tspan x="-3" y="-25">Mae gen i</tspan><tspan x="0" y="0">fenthyciad</tspan><tspan x="-8" y="25">myfyriwr</tspan>
+          mq_0_html: <tspan x="-4" y="-28">Mae gen i</tspan><tspan x="0" y="0">fenthyciad</tspan><tspan x="-9" y="28">myfyriwr</tspan>
         text_debt:
-          mq_l_html: <tspan dx="-6" dy="-21">Dwi mewn</tspan><tspan dx="-88" dy="21">dyled ac</tspan><tspan dx="-68" dy="21">angen help</tspan>
-          mq_s_html: <tspan dx="0" dy="-25">Dwi mewn</tspan><tspan dx="-102" dy="25">dyled ac</tspan><tspan dx="-81" dy="25">angen help</tspan>
-          mq_0_html: <tspan dx="0" dy="-28">Dwi mewn</tspan><tspan dx="-111" dy="28">dyled ac</tspan><tspan dx="-88" dy="28">angen help</tspan>
+          mq_l_html: <tspan x="0" y="-21">Dwi mewn</tspan><tspan x="-10" y="0">dyled ac</tspan><tspan x="2" y="21">angen help</tspan>
+          mq_s_html: <tspan x="-2" y="-25">Dwi mewn</tspan><tspan x="-13" y="0">dyled ac</tspan><tspan x="0" y="25">angen help</tspan>
+          mq_0_html: <tspan x="-2" y="-28">Dwi mewn</tspan><tspan x="-14" y="0">dyled ac</tspan><tspan x="0" y="28">angen help</tspan>
         text_pension:
-          mq_l_html: <tspan dx="-6" dy="-21">Dwi angen</tspan><tspan dx="-87" dy="21">cychwyn</tspan><tspan dx="-74" dy="21">pensiwn</tspan>
-          mq_s_html: <tspan dx="-6" dy="-25">Dwi angen</tspan><tspan dx="-101" dy="25">cychwyn</tspan><tspan dx="-87" dy="25">pensiwn</tspan>
-          mq_0_html: <tspan dx="-16" dy="-24">Dwi angen</tspan><tspan dx="-112" dy="28">cychwyn</tspan><tspan dx="-94" dy="28">pensiwn</tspan>
+          mq_l_html: <tspan x="7" y="-21">Dwi angen</tspan><tspan x="0" y="0">cychwyn</tspan><tspan x="-3" y="21">pensiwn</tspan>
+          mq_s_html: <tspan x="5" y="-25">Dwi angen</tspan><tspan x="-3" y="0">cychwyn</tspan><tspan x="-5" y="25">pensiwn</tspan>
+          mq_0_html: <tspan x="0" y="-28">Dwi angen</tspan><tspan x="-8" y="0">cychwyn</tspan><tspan x="-12" y="28">pensiwn</tspan>
         text_house:
-          mq_l_html: <tspan dx="0" dy="-15">Rydyn ni</tspan><tspan dx="-69" dy="21">eisiau</tspan><tspan dx="-47" dy="21">prynu tŷ</tspan>
-          mq_s_html: <tspan dx="0" dy="-13">Rydyn ni</tspan><tspan dx="-81" dy="25">eisiau</tspan><tspan dx="-55" dy="25">prynu tŷ</tspan>
-          mq_0_html: <tspan dx="0" dy="-16">Rydyn ni</tspan><tspan dx="-88" dy="28">eisiau</tspan><tspan dx="-60" dy="28">prynu tŷ</tspan>
+          mq_l_html: <tspan x="0" y="-21">Rydyn ni</tspan><tspan x="-11" y="0">eisiau</tspan><tspan x="-2" y="21">prynu tŷ</tspan>
+          mq_s_html: <tspan x="4" y="-25">Rydyn ni</tspan><tspan x="-9" y="0">eisiau</tspan><tspan x="3" y="25">prynu tŷ</tspan>
+          mq_0_html: <tspan x="0" y="-28">Rydyn ni</tspan><tspan x="-15" y="0">eisiau</tspan><tspan x="-2" y="28">prynu tŷ</tspan>
         text_budget:
-          mq_l_html: <tspan dx="-8" dy="-21">Dwi angen</tspan><tspan dx="-92" dy="21">sefydlu</tspan><tspan dx="-59" dy="21">cyllideb</tspan>
-          mq_s_html: <tspan dx="-12" dy="-25">Dwi angen</tspan><tspan dx="-101" dy="25">sefydlu</tspan><tspan dx="-68" dy="25">cyllideb</tspan>
-          mq_0_html: <tspan dx="-16" dy="-24">Dwi angen</tspan><tspan dx="-112" dy="28">sefydlu</tspan><tspan dx="-74" dy="28">cyllideb</tspan>
+          mq_l_html: <tspan x="0" y="-21">Dwi angen</tspan><tspan x="-14" y="0">sefydlu</tspan><tspan x="-11" y="21">cyllideb</tspan>
+          mq_s_html: <tspan x="0" y="-25">Dwi angen</tspan><tspan x="-17" y="0">sefydlu</tspan><tspan x="-15" y="25">cyllideb</tspan>
+          mq_0_html: <tspan x="0" y="-28">Dwi angen</tspan><tspan x="-18" y="0">sefydlu</tspan><tspan x="-16" y="28">cyllideb</tspan>
         text_uc:
-          mq_l_html: <tspan dx="-4" dy="-21">Beth yw</tspan><tspan dx="-65" dy="21">Credyd</tspan><tspan dx="-58" dy="21">Cynhwysol?</tspan>
-          mq_s_html: <tspan dx="-4" dy="-29">Beth yw</tspan><tspan dx="-77" dy="25">Credyd</tspan><tspan dx="-69" dy="25">Cynhwysol?</tspan>
-          mq_0_html: <tspan dx="0" dy="-28">Beth yw</tspan><tspan dx="-84" dy="28">Credyd</tspan><tspan dx="-76" dy="28">Cynhwysol?</tspan>
+          mq_l_html: <tspan x="-17" y="-21">Beth yw</tspan><tspan x="-20" y="0">Credyd</tspan><tspan x="0" y="21">Cynhwysol?</tspan>
+          mq_s_html: <tspan x="-18" y="-25">Beth yw</tspan><tspan x="-22" y="0">Credyd</tspan><tspan x="0" y="25">Cynhwysol?</tspan>
+          mq_0_html: <tspan x="-21" y="-28">Beth yw</tspan><tspan x="-25" y="0">Credyd</tspan><tspan x="0" y="28">Cynhwysol?</tspan>
         text_retire:
-          mq_l_html: <tspan dx="-12" dy="-10.5">Hoffwn i</tspan><tspan dx="-69" dy="21">ymddeol</tspan>
-          mq_s_html: <tspan dx="-8" dy="-10.5">Hoffwn i</tspan><tspan dx="-80" dy="25">ymddeol</tspan>
-          mq_0_html: <tspan dx="-8" dy="-14">Hoffwn i</tspan><tspan dx="-88" dy="28">ymddeol</tspan>
+          mq_l_html: <tspan x="-2" y="-10.5">Hoffwn i</tspan><tspan x="0" y="10.5">ymddeol</tspan>
+          mq_s_html: <tspan x="-2" y="-12.5">Hoffwn i</tspan><tspan x="0" y="12.5">ymddeol</tspan>
+          mq_0_html: <tspan x="-2" y="-14">Hoffwn i</tspan><tspan x="0" y="14">ymddeol</tspan>
       title: Cyngor ariannol am ddim a diduedd, sefydlwyd gan y llywodraeth
       strapline: Cyngor ariannol am ddim a diduedd, sefydlwyd gan y llywodraeth
       trust_banner_list:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -191,33 +191,33 @@ en:
         title: How can we help you today?
         text: The Money Advice Service is here to support you no matter what your money problems are. Whether you’re in difficulty with debts, need some help with your budgets, are looking to buy a house, or want to find out about the benefits you might qualify for, we can give you advice and support with your finances.
         text_student:
-          mq_l_html: <tspan dx="0" dy="-10.5">I have a</tspan><tspan dx="-62" dy="21">student loan</tspan>
-          mq_s_html: <tspan dx="-21" dy="-25">I have a</tspan><tspan dx="-72" dy="25">student</tspan><tspan dx="-72" dy="25">loan</tspan>
-          mq_0_html: <tspan dx="-12" dy="-28">I have a</tspan><tspan dx="-79" dy="28">student</tspan><tspan dx="-79" dy="28">loan</tspan>
+          mq_l_html: <tspan x="-20" y="-10.5">I have a</tspan><tspan x="0" y="10.5">student loan</tspan>
+          mq_s_html: <tspan x="0" y="-25">I have a</tspan><tspan x="0" y="0">student</tspan><tspan x="-16" y="25">loan</tspan>
+          mq_0_html: <tspan x="0" y="-28">I have a</tspan><tspan x="0" y="0">student</tspan><tspan x="-16" y="28">loan</tspan>
         text_debt:
-          mq_l_html: <tspan dx="-30" dy="-21">I am in debt</tspan><tspan dx="-96" dy="21">and need</tspan><tspan dx="-76" dy="21">help</tspan>
-          mq_s_html: <tspan dx="0" dy="-25">I am in</tspan><tspan dx="-65" dy="25">debt and</tspan><tspan dx="-85" dy="25">need help</tspan>
-          mq_0_html: <tspan dx="0" dy="-28">I am in</tspan><tspan dx="-70" dy="28">debt and</tspan><tspan dx="-93" dy="28">need help</tspan>
+          mq_l_html: <tspan x="0" y="-21">I am in debt</tspan><tspan x="-10" y="0">and need</tspan><tspan x="-31" y="21">help</tspan>
+          mq_s_html: <tspan x="-16" y="-25">I am in</tspan><tspan x="-6" y="0">debt and</tspan><tspan x="0" y="25">need help</tspan>
+          mq_0_html: <tspan x="-17" y="-28">I am in</tspan><tspan x="-6" y="0">debt and</tspan><tspan x="0" y="28">need help</tspan>
         text_pension:
-          mq_l_html: <tspan dx="0" dy="-21">I need to</tspan><tspan dx="-72" dy="21">start a</tspan><tspan dx="-50" dy="21">pension</tspan>
-          mq_s_html: <tspan dx="0" dy="-25">I need to</tspan><tspan dx="-85" dy="25">start a</tspan><tspan dx="-59" dy="25">pension</tspan>
-          mq_0_html: <tspan dx="-10" dy="-24">I need to</tspan><tspan dx="-92" dy="28">start a</tspan><tspan dx="-65" dy="28">pension</tspan>
+          mq_l_html: <tspan x="0" y="-21">I need to</tspan><tspan x="-12" y="0">start a</tspan><tspan x="-6" y="21">pension</tspan>
+          mq_s_html: <tspan x="4" y="-25">I need to</tspan><tspan x="-8" y="0">start a</tspan><tspan x="0" y="25">pension</tspan>
+          mq_0_html: <tspan x="-2" y="-28">I need to</tspan><tspan x="-16" y="0">start a</tspan><tspan x="-8" y="28">pension</tspan>
         text_house:
-          mq_l_html: <tspan dx="0" dy="-10.5">We want to</tspan><tspan dx="-93" dy="21">buy a house</tspan>
-          mq_s_html: <tspan dx="0" dy="-8">We want to</tspan><tspan dx="-110" dy="25">buy a house</tspan>
-          mq_0_html: <tspan dx="0" dy="-14">We want to</tspan><tspan dx="-120" dy="28">buy a house</tspan>
+          mq_l_html: <tspan x="-2" y="-10.5">We want to</tspan><tspan x="2" y="10.5">buy a house</tspan>
+          mq_s_html: <tspan x="0" y="-12.5">We want to</tspan><tspan x="4" y="12.5">buy a house</tspan>
+          mq_0_html: <tspan x="-4" y="-14">We want to</tspan><tspan x="0" y="14">buy a house</tspan>
         text_budget:
-          mq_l_html: <tspan dx="0" dy="-10.5">I need to set</tspan><tspan dx="-102" dy="21">up a budget</tspan>
-          mq_s_html: <tspan dx="-10" dy="-25">I need to</tspan><tspan dx="-87" dy="25">set up a</tspan><tspan dx="-75" dy="25">budget</tspan>
-          mq_0_html: <tspan dx="-16" dy="-24">I need to</tspan><tspan dx="-93" dy="28">set up a</tspan><tspan dx="-83" dy="28">budget</tspan>
+          mq_l_html: <tspan x="0" y="-10.5">I need to set</tspan><tspan x="-1" y="10.5">up a budget</tspan>
+          mq_s_html: <tspan x="0" y="-25">I need to</tspan><tspan x="-4" y="0">set up a</tspan><tspan x="-8" y="25">budget</tspan>
+          mq_0_html: <tspan x="0" y="-28">I need to</tspan><tspan x="-6" y="0">set up a</tspan><tspan x="-10" y="28">budget</tspan>
         text_uc:
-          mq_l_html: <tspan dx="-16" dy="-21">What is</tspan><tspan dx="-60" dy="21">Universal</tspan><tspan dx="-74" dy="21">Credit?</tspan>
-          mq_s_html: <tspan dx="-8" dy="-25">What is</tspan><tspan dx="-68" dy="25">Universal</tspan><tspan dx="-86" dy="25">Credit?</tspan>
-          mq_0_html: <tspan dx="-9" dy="-28">What is</tspan><tspan dx="-77" dy="28">Universal</tspan><tspan dx="-95" dy="28">Credit?</tspan>
+          mq_l_html: <tspan x="-8" y="-21">What is</tspan><tspan x="0" y="0">Universal</tspan><tspan x="-8" y="21">Credit?</tspan>
+          mq_s_html: <tspan x="-8" y="-25">What is</tspan><tspan x="0" y="0">Universal</tspan><tspan x="-8" y="25">Credit?</tspan>
+          mq_0_html: <tspan x="-9" y="-28">What is</tspan><tspan x="0" y="0">Universal</tspan><tspan x="-10" y="28">Credit?</tspan>
         text_retire:
-          mq_l_html: <tspan dx="-16" dy="-10.5">I would like</tspan><tspan dx="-93" dy="21">to retire</tspan>
-          mq_s_html: <tspan dx="-16" dy="-10.5">I would like</tspan><tspan dx="-109" dy="25">to retire</tspan>
-          mq_0_html: <tspan dx="-18" dy="-14">I would like</tspan><tspan dx="-118" dy="28">to retire</tspan>
+          mq_l_html: <tspan x="0" y="-10.5">I would like</tspan><tspan x="-14" y="10.5">to retire</tspan>
+          mq_s_html: <tspan x="0" y="-12.5">I would like</tspan><tspan x="-16" y="12.5">to retire</tspan>
+          mq_0_html: <tspan x="0" y="-14">I would like</tspan><tspan x="-18" y="14">to retire</tspan>
       title: Free and impartial money advice, set up by government
       strapline: Free and impartial money advice, set up by government
       trust_banner_list:


### PR DESCRIPTION
**Target Process tickets**
[TP8969](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&searchPopup=userstory/8969), [TP8970](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&searchPopup=userstory/8970), [TP8971](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&searchPopup=userstory/8971)

**Summary**
The rendering of the text via SVG over the leader image was displaying inconsistently in some browsers and devices. This was due to an inconsistent interpretation on these browsers of relatively positioned text. This PR updates that to position the text absolutely. 

**Examples**
IE11 (problem, TP8969)
![image](https://user-images.githubusercontent.com/6080548/39299016-aa1af0b4-493f-11e8-9a39-006494e51a89.png)

IE11 (solution)
![image](https://user-images.githubusercontent.com/6080548/39299182-0a18a84e-4940-11e8-9a26-35b679218911.png)

Firefox (problem, TP8970)
![image](https://user-images.githubusercontent.com/6080548/39299210-18687bd6-4940-11e8-934c-fcded765efae.png)

Firefox (solution)
![image](https://user-images.githubusercontent.com/6080548/39299255-3533502e-4940-11e8-8553-b03798493800.png)

IE mobile (problem, TP8971)
![image](https://user-images.githubusercontent.com/6080548/39299281-468e6ebc-4940-11e8-8826-c69410829445.png)

IE mobile (solution)
![image](https://user-images.githubusercontent.com/6080548/39299310-5598b6a6-4940-11e8-9d37-83be89c04bdd.png)

**QA / Testing**
I have checked these via BrowserStack