### PR TITLE
[DEV APPROVED] added back old code that ensures images scale correctly in safari

### DIFF
--- a/app/assets/stylesheets/components/page_specific/home_beta/_most_read.scss
+++ b/app/assets/stylesheets/components/page_specific/home_beta/_most_read.scss
@@ -78,6 +78,10 @@
   margin-bottom: $baseline-unit * 5;
 }
 
+.most-read__image {
+  width: 100%;
+}
+
 .most-read__CTA {
   line-height: $arrow-right-ball_size;
   position: absolute;

--- a/app/views/shared/home_beta/_most_read.html.erb
+++ b/app/views/shared/home_beta/_most_read.html.erb
@@ -12,7 +12,7 @@
               alt: '',
               sizes: size_definition,
               srcset: item['srcset'],
-              class: ''
+              class: 'most-read__image'
             )%>
             <div class="most-read__content">
               <%= heading_tag(level: 3, class: 'item__heading') do %>


### PR DESCRIPTION

# 9170 Safari image width bug
[TP9170](https://moneyadviceservice.tpondemand.com/entity/9170-hp-safari-image-width-doesnt-resize)

Added back in the width:100% styling for most read images that had been lost in homepage-hero branch due to different classes, fixing the bug where in Safari, if you load the page with the window fairly small and then resize it up, the images don't scale..

_Note: won't let me upload before and after pictures, please see [ticket](https://moneyadviceservice.tpondemand.com/entity/9170-hp-safari-image-width-doesnt-resize), after screenshot uploaded in comments_