### PR TITLE
[DEV APPROVED] Upgrade sprockets gem, vulnerability in 2.12.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -519,7 +519,7 @@ GEM
       friendly_id (>= 5.0)
       jquery-rails
       rails (>= 4, < 5)
-    rack (1.6.9)
+    rack (1.6.10)
     rack-accept (0.4.5)
       rack (>= 0.4)
     rack-livereload (0.3.17)
@@ -657,7 +657,7 @@ GEM
       capybara (~> 2.7)
     spreadsheet (1.1.7)
       ruby-ole (>= 1.0)
-    sprockets (2.12.4)
+    sprockets (2.12.5)
       hike (~> 1.2)
       multi_json (~> 1.0)
       rack (~> 1.0)


### PR DESCRIPTION
CVE-2018-3760 in sprockets 2.12.4 
Specially crafted requests can be used to access files that exist on the filesystem that is outside an application's root directory, when the Sprockets server is used in production.

Bump version to 2.12.5