### PR TITLE
wpcc version bump

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,7 @@ gem 'rio', '1.20.0', source: 'http://gems.dev.mas.local'
 gem 'savings_calculator', '~> 1.8.1'
 gem 'timelines', '~> 1.5.0'
 gem 'universal_credit', '3.1.0'
-gem 'wpcc', '2.1.0'
+gem 'wpcc', '2.1.1'
 
 # 1.0.2 has breaking changes as it adds japanese and turkish locales
 gem 'validate_url', '1.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -730,7 +730,7 @@ GEM
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
-    wpcc (2.1.0)
+    wpcc (2.1.1)
       dough-ruby
       meta-tags
       rails (>= 4, < 5)
@@ -840,7 +840,7 @@ DEPENDENCIES
   validate_url (= 1.0.0)
   vcr
   webmock
-  wpcc (= 2.1.0)
+  wpcc (= 2.1.1)
 
 BUNDLED WITH
    1.16.1


### PR DESCRIPTION
This PR bumps wpcc in line with [TP9256](https://moneyadviceservice.tpondemand.com/entity/9256-bug-wpcc-callout-overlap)