### PR TITLE
Fix reset password token

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -55,7 +55,11 @@ class User < ActiveRecord::Base
   before_save :fake_send_confirmation_email
   after_create :create_to_crm
   after_update :update_to_crm
- 
+
+  def self.find_first_by_auth_conditions(conditions)
+    User.where(conditions.symbolize_keys).first
+  end
+
   def to_customer
     Converters::UserToCustomer.new(self).call
   end
@@ -97,10 +101,6 @@ class User < ActiveRecord::Base
     compute_email_bidx
     compute_first_name_bidx
     compute_last_name_bidx
-  end
-
-  def self.find_first_by_auth_conditions(conditions)
-    User.where(email: conditions[:email]).first
   end
 
   def create_to_crm

--- a/features/cassettes/CMS/get/api/TR/REC-html40/loose_dtd_json.yml
+++ b/features/cassettes/CMS/get/api/TR/REC-html40/loose_dtd_json.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3000/api/TR/REC-html40/loose.dtd.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mas-Responsive/1.0 (Margo-Urey-00241.local; margourey; 41368) ruby/2.2.5 (319;
+        x86_64-darwin16)
+      X-Request-Id:
+      - 982c6857-f27f-4399-98c1-1cb8a1c84401
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 17 Jul 2018 15:06:27 GMT
+      Status:
+      - 404 Not Found
+      Connection:
+      - close
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 982c6857-f27f-4399-98c1-1cb8a1c84401
+      X-Runtime:
+      - '0.028730'
+    body:
+      encoding: UTF-8
+      string: '{"message":"Site \"TR\" not found"}'
+    http_version: 
+  recorded_at: Tue, 17 Jul 2018 15:06:27 GMT
+recorded_with: VCR 4.0.0

--- a/features/step_definitions/change_password_steps.rb
+++ b/features/step_definitions/change_password_steps.rb
@@ -1,0 +1,6 @@
+Then(/^I should be able to change my password$/) do
+  change_password_page.password.set 'securePassword'
+  change_password_page.password_confirmation.set 'securePassword'
+  change_password_page.submit.click 
+  step 'I should be signed in'
+end

--- a/features/step_definitions/email_steps.rb
+++ b/features/step_definitions/email_steps.rb
@@ -180,10 +180,6 @@ When /^(?:I|they|"([^"]*?)") follows? "([^"]*?)" in the email$/ do |address, lin
   visit_in_email(link, address)
 end
 
-When /^(?:I|they) click the first link in the email$/ do
-  click_first_link_in_email
-end
-
 #
 # Debugging
 # These only work with Rails and OSx ATM since EmailViewer uses RAILS_ROOT and OSx's 'open' command.

--- a/features/step_definitions/sign_in_steps.rb
+++ b/features/step_definitions/sign_in_steps.rb
@@ -73,10 +73,6 @@ When(/^I fill in my email$/) do
   forgot_password_page.submit.click
 end
 
-Then(/^I should be able to change my password$/) do
-  expect(page.current_path).to include('/en/users/password/edit')
-end
-
 Then(/^I should see an email sent notification$/) do
   expect(page.html).to include(I18n.t('devise.passwords.send_instructions', locale: 'en'))
 end

--- a/features/support/ui/pages/change_password.rb
+++ b/features/support/ui/pages/change_password.rb
@@ -1,0 +1,11 @@
+require_relative '../page'
+
+module UI::Pages
+  class ChangePassword < UI::Page
+    set_url '{/locale}/users/password/edit'
+
+    element :password, "input[name='user[password]']"
+    element :password_confirmation, "input[name='user[password_confirmation]']"
+    element :submit, "input[value='Change my password']"
+  end
+end

--- a/features/support/world/pages.rb
+++ b/features/support/world/pages.rb
@@ -9,6 +9,7 @@ module World
       article
       article_feedback
       category
+      change_password
       corporate
       corporate_categories
       corporate_tool

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe User, type: :model do
 
       context 'when token does not exist' do
         let(:conditions) do
-          { reset_password_token: "#{user.reset_password_token}C" }
+          { reset_password_token: "invalid_#{user.reset_password_token}" }
         end
 
         it 'returns nil' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,6 +16,57 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe '.find_first_by_auth_conditions' do
+    let!(:user) { create(:user, reset_password_token: SecureRandom.uuid) }
+    subject(:find_first_by_auth_conditions) do
+      User.find_first_by_auth_conditions(conditions)
+    end
+
+    context 'when searching by email' do
+      context 'when email exists' do
+        let(:conditions) do
+          { 'email' => user.email }
+        end
+
+        it 'returns user with same email' do
+          expect(find_first_by_auth_conditions).to eq(user)
+        end
+      end
+
+      context 'when email does not exist' do
+        let(:conditions) do
+          { 'email' => 'someemail@domain.uk' }
+        end
+
+        it 'returns nil' do
+          expect(find_first_by_auth_conditions).to be_nil
+        end
+      end
+    end
+
+    context 'when searching by reset password token' do
+      context 'when token exists' do
+        let(:conditions) do
+          { reset_password_token: user.reset_password_token }
+        end
+
+        it 'returns user with same token' do
+          expect(find_first_by_auth_conditions).to eq(user)
+        end
+      end
+
+      context 'when token does not exist' do
+        let(:conditions) do
+          { reset_password_token: "#{user.reset_password_token}C" }
+        end
+
+        it 'returns nil' do
+          expect(find_first_by_auth_conditions).to be_nil
+        end
+      end
+    end
+  end
+
   describe '#fake_send_confirmation_email' do
     it 'sends a fake confirmation email when user is saved' do
       subject.save!


### PR DESCRIPTION
[TP card](https://moneyadviceservice.tpondemand.com/entity/9322-reset-password-token-is-invalid)

## Context

When a user follows the journey to reset their password, at the point where a new password is entered and submitted, the following error is displayed and the task can not be completed - 'Reset password token is invalid'.
 
After implementing the encryption PR #1948, the reset password token stopped working.

The reason is the overwrite of the `find_first_by_auth_conditions`
 method on the user model. This method is used  by **Devise** for authentication and **_also for
the reset password token._** The original change to the method resulted in a search **only  by email**, hence searching by token was no longer working.

Making the `conditions` more general makes both scenarios work.
