### PR TITLE
[DEV APPROVED] - 9412 Update README to allow the `bundle install` phase pass on a brand new machine (dev)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ $ bowndler install
 Install Mysql 5.5
 
 ```sh
-$ brew tap homebrew/versions
 $ brew install mysql55
 ```
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Install Mysql 5.5
 
 ```sh
 $ brew install mysql55
+$ brew link mysql55 --force
 ```
 
 Make sure MySQL is running.


### PR DESCRIPTION
[TP 9412](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=userstory/9412)

The `README` needs to be updated to have the `bundle install` correctly executed on a brand new OSX machine. The problem encountered has been documented in the ticket and is related to the `mysql@5.5` brew formula.
