### PR TITLE
[DEV APPROVED] TP: 9414, Comment: Adds reference to pacs in require_config 

### DIFF
--- a/app/assets/javascripts/require_config.js.erb
+++ b/app/assets/javascripts/require_config.js.erb
@@ -86,6 +86,7 @@
       debtFreeDayCalculatorConfig: requirejs_path('debt_free_day_calculator/require_config'),
       debtTestConfig: requirejs_path('debt_test/require_config'),
       universalCreditConfig: requirejs_path('universal_credit/require_config'),
+      pacsConfig: requirejs_path('pacs/require_config'),
       rioConfig: requirejs_path('rio/require_config'),
       wpccConfig: requirejs_path('wpcc/require_config')
     },


### PR DESCRIPTION
[TP9414](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx#page=board/4910826923597700395&appConfig=eyJhY2lkIjoiOUZDOTM4RDBCNEZGRERFMDRGQjZERDg1NTE5MTA1NzQifQ==&boardPopup=userstory/9414/silent)

This adds a reference to PACs in the frontend require_config for JS mounting

It is part of the work to set up the PACs project with all then necessary JavaScript requirements, which is in [PR4](https://github.com/moneyadviceservice/pacs/pull/4).