### PR TITLE
[DEV APPROVED] - Make sure partner tools is loaded by each environment

### DIFF
--- a/app/assets/javascripts/syndication/tools.js.coffee
+++ b/app/assets/javascripts/syndication/tools.js.coffee
@@ -349,10 +349,7 @@
   iframeUrl: (node)->
     locale = masConfig.getLocale(node)
     toolpath = masConfig.toolConfig[node.id][locale].path
-
-    if toolsConfig?
-    then "#{toolsConfig['syndication_url']}/#{toolpath}"
-    else "https://partner-tools.moneyadviceservice.org.uk/#{toolpath}"
+    "#{masConfig.toolsConfig['syndication_url']}/#{toolpath}"
 
   iframeSrc: (node)->
     "src='#{masConfig.iframeUrl(node)}'"
@@ -360,13 +357,8 @@
   gaIframeUrl: (node)->
     locale = masConfig.getLocale(node)
     toolId = node.id
-
-    if toolsConfig?
-    then toolURL = toolsConfig['syndication']['ga_iframe_url']
-    else toolURL = "https://partner-tools.moneyadviceservice.org.uk/partner_ga_iframe.html"
-
+    toolURL = masConfig.toolsConfig['syndication']['ga_iframe_url']
     toolArgs = "?tool=#{toolId}&lang=#{locale}"
-
     "#{toolURL}#{toolArgs}"
 
   gaIframeSrc: (node)->

--- a/app/assets/javascripts/syndication/widget.js.coffee
+++ b/app/assets/javascripts/syndication/widget.js.coffee
@@ -5,12 +5,31 @@ class window.PartnerMAS.Widget
     @id = @targetNode.id
 
   render: ->
+    this.setPartnerToolsURL()
     renderParts = []
     renderParts.push(this.createLogo()) unless this.dataAttr("omit_logo")
     renderParts.push(this.createIFrame())
     renderParts.push(this.createGAIFrame()) if masConfig.gaIframeRequired(@targetNode)
     this.addToDocument this.createContainer(renderParts...)
     this.removeTargetNode()
+
+  setPartnerToolsURL: ->
+    domains = {
+      'preview.dev.mas.local': 'https://preview-partner-tools.dev.mas.local/',
+      'qa.dev.mas.local': 'https://qa-partner-tools.dev.mas.local/',
+      'uat.dev.mas.local': 'https://uat-partner-tools.dev.mas.local/',
+      'cultivate.dev.mas.local': 'https://cultivate-partner-tools.dev.mas.local/',
+      'staging.dev.mas.local': 'https://staging-partner-tools.dev.mas.local/'
+    }
+    toolLink = document.getElementsByClassName(masConfig.targetSelector)[0].getAttribute('href')
+    hostname = new URL(toolLink).hostname
+    masConfig.toolsConfig = {
+      syndication_url: 'https://partner-tools.moneyadviceservice.org.uk',
+      syndication: {
+        ga_iframe_url: 'https://partner-tools.moneyadviceservice.org.uk/partner_ga_iframe.html'
+      }
+    }
+    masConfig.toolsConfig['syndication_url'] = domains[hostname] if domains[hostname]
 
   createContainer: (contents...) ->
     """
@@ -33,7 +52,7 @@ class window.PartnerMAS.Widget
                 width='#{this.dataAttr('width')}' height='#{this.dataAttr('height')}' title='#{this.dataAttr('title')}'>
         </iframe>
         """
-        
+
   createGAIFrame: ->
     """
         <iframe class='#{masConfig.gaIframeClass}' id='#{@targetNode.id}-ga-iframe' #{masConfig.gaIframeSrc(@targetNode)}

--- a/app/assets/javascripts/syndication/widget.js.coffee
+++ b/app/assets/javascripts/syndication/widget.js.coffee
@@ -19,7 +19,8 @@ class window.PartnerMAS.Widget
       'www.qa.dev.mas.local': 'https://qa-partner-tools.dev.mas.local/',
       'www.uat.dev.mas.local': 'https://uat-partner-tools.dev.mas.local/',
       'www.cultivate.dev.mas.local': 'https://cultivate-partner-tools.dev.mas.local/',
-      'www.staging.dev.mas.local': 'https://staging-partner-tools.dev.mas.local/'
+      'www.staging.dev.mas.local': 'https://staging-partner-tools.dev.mas.local/',
+      'www.uat.moneyadviceservice.org.uk': 'https://uat-partner-tools.moneyadviceservice.org.uk/'
     }
     toolLink = document.getElementsByClassName(masConfig.targetSelector)[0].getAttribute('href')
     hostname = new URL(toolLink).hostname

--- a/app/assets/javascripts/syndication/widget.js.coffee
+++ b/app/assets/javascripts/syndication/widget.js.coffee
@@ -15,11 +15,11 @@ class window.PartnerMAS.Widget
 
   setPartnerToolsURL: ->
     domains = {
-      'preview.dev.mas.local': 'https://preview-partner-tools.dev.mas.local/',
-      'qa.dev.mas.local': 'https://qa-partner-tools.dev.mas.local/',
-      'uat.dev.mas.local': 'https://uat-partner-tools.dev.mas.local/',
-      'cultivate.dev.mas.local': 'https://cultivate-partner-tools.dev.mas.local/',
-      'staging.dev.mas.local': 'https://staging-partner-tools.dev.mas.local/'
+      'www.preview.dev.mas.local': 'https://preview-partner-tools.dev.mas.local/',
+      'www.qa.dev.mas.local': 'https://qa-partner-tools.dev.mas.local/',
+      'www.uat.dev.mas.local': 'https://uat-partner-tools.dev.mas.local/',
+      'www.cultivate.dev.mas.local': 'https://cultivate-partner-tools.dev.mas.local/',
+      'www.staging.dev.mas.local': 'https://staging-partner-tools.dev.mas.local/'
     }
     toolLink = document.getElementsByClassName(masConfig.targetSelector)[0].getAttribute('href')
     hostname = new URL(toolLink).hostname


### PR DESCRIPTION
[TP Card](https://moneyadviceservice.tpondemand.com/entity/9533-partner-tools-syndication-test-environments)

## Problem

The tools.js was pointing always to partner tools production site.

There was a piece of code that always was returning undefined on tools.js:

```
   # tools.js.coffee
    if toolsConfig?
    then "#{toolsConfig['syndication_url']}/#{toolpath}"
    else "https://partner-tools.moneyadviceservice.org.uk/#{toolpath}"

    # ... Few lines later ...

    if toolsConfig?
    then toolURL = toolsConfig['syndication']['ga_iframe_url']
    else toolURL = "https://partner-tools.moneyadviceservice.org.uk/partner_ga_iframe.html"
```

Above toolsConfig were never defined (ever even on git history!). 

## Solution

So we actually implemented the tools config to have the default behaviour and search by environment.

**Unfortunately we had to hard code the envs because the client html is not on our control**.

## Testing

In order to test we needed to simulate a partner site integration with any of our syndicated tools. This can be done by the following:

```
<html>
  <head>
  </head>
<body>
  <div>
     <noscript><p>You have javascript turned off. Please turn javascript on to see the tools in action.</p></noscript>
     <p>
       <a id="debt_advice_locator_f2f" class="mas-widget" target="_blank" href="https://moneyadviceservice.org.uk/en/tools/debt-advice-locator">Where to go to get free debt advice</a>
     </p>
  </div>
<script class='application_scripts' src="https://moneyadviceservice.org.uk/assets/syndication/tools.js"></script>
</body>
</html>
```

By controlling the src of the domain of the syndication tools on the tools.js
we need to hard code the environments that we need to point out and
returning production as default.