### PR TITLE
[DEV APPROVED] 9321 Tweaking logo size so welsh isn't cropped

### DIFF
--- a/app/assets/stylesheets/components/common/_header.scss
+++ b/app/assets/stylesheets/components/common/_header.scss
@@ -1,0 +1,30 @@
+.theme-cy {
+  .l-header {
+    .mas-logo {
+      @include respond-to($mq-m) {
+        @include column(8);
+      }
+
+      @include respond-to($mq-xl) {
+        @include column(6);
+      }
+    }
+
+    .authentication {
+      @include respond-to($mq-m) {
+        @include column(1);
+      }
+      
+      @include respond-to($mq-xl) {
+        @include column(3);
+      }
+    }
+
+    .l-search {
+      @include respond-to($mq-xl) {
+        @include column(3);
+      }
+    }
+    
+  }
+}

--- a/app/assets/stylesheets/components/common/_mas_logo.scss
+++ b/app/assets/stylesheets/components/common/_mas_logo.scss
@@ -14,11 +14,10 @@
   display: inline-block;
   overflow: hidden;
   vertical-align: middle;
-  width: 173px;
+  width: 203px;
 
   @include respond-to($mq-m) {
-    width: 245px;
-    margin-right: 40px;
+    width: 285px;
   }
 
   &:focus,


### PR DESCRIPTION
[TP9321](https://moneyadviceservice.tpondemand.com/entity/9321-mas-logo-in-welsh-gets-cropped)

This PR tweaks the logo size so that it doesn't crop the Welsh logo

### Screenshots
Please note, the screenshots look a bit of a hybrid as welsh wasn't working correctly locally, so I manually put the welsh logo into the english page to do this ticket. 
Before:
<img width="325" alt="screen shot 2018-10-01 at 08 54 06" src="https://user-images.githubusercontent.com/3898629/46276322-9bb5a700-c557-11e8-83c3-c1104a167381.png">
<img width="374" alt="screen shot 2018-10-01 at 08 54 14" src="https://user-images.githubusercontent.com/3898629/46276323-9bb5a700-c557-11e8-8753-daa4ed373178.png">
After:
<img width="277" alt="screen shot 2018-10-01 at 08 49 50" src="https://user-images.githubusercontent.com/3898629/46276297-7fb20580-c557-11e8-9751-a5193d4c578e.png">
<img width="416" alt="screen shot 2018-10-01 at 08 49 59" src="https://user-images.githubusercontent.com/3898629/46276298-7fb20580-c557-11e8-8147-59a1a8558be0.png">