### PR TITLE
[DEV APPROVED] 9321 Welsh logo bug - mobile overlapping

### DIFF
--- a/app/assets/stylesheets/components/common/_mas_logo.scss
+++ b/app/assets/stylesheets/components/common/_mas_logo.scss
@@ -10,6 +10,26 @@
   }
 }
 
+.theme-cy {
+  .l-header__content {
+    min-height: 54px;
+
+    @include respond-to($mq-m) {
+      min-height: 0;
+    }
+  }
+    
+  .mas-logo__img {
+    margin-left: -180px;
+    width: 360px;
+
+    @include respond-to($mq-m) {
+      margin-left: -285px;
+      width: 570px;
+    }
+  }
+}
+
 .mas-logo__link {
   display: inline-block;
   overflow: hidden;


### PR DESCRIPTION
[TP9321](https://moneyadviceservice.tpondemand.com/entity/9321-mas-logo-in-welsh-gets-cropped)
A bug was raised when the code for the ticket was pushed to staging https://github.com/moneyadviceservice/frontend/pull/1979

This PR addresses the comment in the tp ticket where the welsh logo overlapped with the buttons on mobile (320px)

<img width="328" alt="screen shot 2018-10-02 at 15 27 22" src="https://user-images.githubusercontent.com/3898629/46354962-b2432780-c657-11e8-989c-b015b3e2cad0.png">
<img width="339" alt="screen shot 2018-10-02 at 15 27 02" src="https://user-images.githubusercontent.com/3898629/46354961-b2432780-c657-11e8-9a55-40567b9a7c40.png">
