### PR TITLE
Updates JS to avoid URL Web API, which is not compatible with IE

### DIFF
--- a/app/assets/javascripts/syndication/widget.js.coffee
+++ b/app/assets/javascripts/syndication/widget.js.coffee
@@ -22,8 +22,9 @@ class window.PartnerMAS.Widget
       'www.staging.dev.mas.local': 'https://staging-partner-tools.dev.mas.local/',
       'www.uat.moneyadviceservice.org.uk': 'https://uat-partner-tools.moneyadviceservice.org.uk/'
     }
-    toolLink = document.getElementsByClassName(masConfig.targetSelector)[0].getAttribute('href')
-    hostname = new URL(toolLink).hostname
+
+    hostname = document.getElementsByClassName(masConfig.targetSelector)[0].hostname;
+
     masConfig.toolsConfig = {
       syndication_url: 'https://partner-tools.moneyadviceservice.org.uk',
       syndication: {


### PR DESCRIPTION
[TP9686](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=bug/9686)

Partner tools currently do not display on IE. 

This appears to be because the [URL Web API](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL#Browser_compatibility) used is not compatible with IE (all versions). 

This fix updates the JS to avoid using this. 

Testing is not easy since this fix needs to be deployed first but it can be done when this is on a Test environment by running a local page along the lines suggested in the comments in the TP ticket. 