### PR TITLE
9744 Disable Scotland support on Debt Advice Foundation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -125,10 +125,10 @@ group :build, :test, :development do
 end
 
 group :test, :development do
-  gem 'byebug'
   gem 'chai-jquery-rails'
   gem 'dotenv-rails'
   gem 'ejs'
+  gem 'pry-byebug'
   gem 'pry-rails'
   gem 'pry-rescue'
   gem 'rack-livereload'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -558,6 +558,9 @@ GEM
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    pry-byebug (3.6.0)
+      byebug (~> 10.0)
+      pry (~> 0.10)
     pry-rails (0.3.6)
       pry (>= 0.10.4)
     pry-rescue (1.4.5)
@@ -814,7 +817,6 @@ DEPENDENCIES
   bowndler (~> 1.0)
   budget_planner (~> 5.3.0)
   bugsnag
-  byebug
   capybara
   car_cost_tool (~> 1.2.2)
   chai-jquery-rails
@@ -867,6 +869,7 @@ DEPENDENCIES
   pensions_calculator (~> 1.9.0)
   poltergeist
   postcode_anywhere-email_validation
+  pry-byebug
   pry-rails
   pry-rescue
   psych (>= 2.0.5)

--- a/db/migrate/20181113141810_disable_scotland_on_debt_advice_foundation_org.rb
+++ b/db/migrate/20181113141810_disable_scotland_on_debt_advice_foundation_org.rb
@@ -1,0 +1,25 @@
+class DisableScotlandOnDebtAdviceFoundationOrg < ActiveRecord::Migration
+  def up
+    if ActiveRecord::Base.connection.table_exists?('debt_advice_locator_organisations')
+      debt_advice_foundation = DebtAdviceLocator::Organisation
+        .where(name: 'Debt Advice Foundation')
+        .where('provides_telephone = true OR provides_web = true')
+
+      debt_advice_foundation.each do |organisation|
+        organisation.update(region_scotland: false)
+      end
+    end
+  end
+
+  def down
+    if ActiveRecord::Base.connection.table_exists?('debt_advice_locator_organisations')
+      debt_advice_foundation = DebtAdviceLocator::Organisation
+        .where(name: 'Debt Advice Foundation')
+        .where('provides_telephone = true OR provides_web = true')
+
+      debt_advice_foundation.each do |organisation|
+        organisation.update(region_scotland: true)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181026112617) do
+ActiveRecord::Schema.define(version: 20181113141810) do
 
   create_table "action_plans_expense_items", force: :cascade do |t|
     t.string  "kind",       limit: 256,             null: false


### PR DESCRIPTION
<!--
** Please read the guidelines below. **
   The PR title should:

   * Incorporate the Target Process story ID
   * Avoid technical and non-MAS acronyms
   * Some MASisms are fine
   * Write a complete sentence
   * Write in the present tense
   * Keep it as short as is practical but no shorter

   The PR description should include clear explanations of what the PR delivers.

-->

**Target Process ticket**

[TP Ticket](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx#page=board/5682182231901749200&appConfig=eyJhY2lkIjoiOUZDOTM4RDBCNEZGRERFMDRGQjZERDg1NTE5MTA1NzQiLCJhcHBDb250ZXh0Ijp7InByb2plY3RDb250ZXh0Ijp7Im5vIjpmYWxzZX0sInRlYW1Db250ZXh0Ijp7Im5vIjpmYWxzZX19fQ==&boardPopup=userstory/9744/silent)

**Summary**
Debt Advice Foundation no longer serve Scotland for telephone or online
advice services. The organisation needs to be updated to reflect this change on [the Debt Advice Locator tool](https://www.moneyadviceservice.org.uk/en/tools/debt-advice-locator). There are two Organisation records for DAF in production, one for telephone and one for online. This PR updates both to be `region_scotland: false`.
