### PR TITLE
[DEV APPROVED] Add more data to Faraday instrumentation

### DIFF
--- a/config/initializers/instrumentation.rb
+++ b/config/initializers/instrumentation.rb
@@ -2,8 +2,14 @@ ActiveSupport::Notifications.subscribe('request.faraday') do |name, starts, ends
   url         = env[:url]
   http_method = env[:method].to_s.upcase
   duration    = ends - starts
+  status      = env[:status]
+  body        = env[:body]
 
-  Rails.logger.info '[%s] %s %s (%.3f s)' % [url.host, http_method, url.request_uri, duration]
+  Rails.logger.info '[%s] %s %s (%.3f s) %s' % [url.host, http_method, url.request_uri, duration, status]
+
+  if status.to_i != 200
+    Rails.logger.info body
+  end
 end
 
 statsd = Statsd.new(ENV['STATSD_HOST'], ENV['STATSD_PORT']).tap do |client|


### PR DESCRIPTION
To assist with debugging Defaqto API requests in production, make some
additions to the Faraday log output.

- Add status code.
- Output body if request was unsuccessful.