### PR TITLE
Updates jquery in frontend

### DIFF
--- a/app/assets/javascripts/require_config.js.erb
+++ b/app/assets/javascripts/require_config.js.erb
@@ -5,6 +5,7 @@
 //= depend_on_asset jquery-waypoints/waypoints
 //= depend_on_asset jquery-ujs/src/rails
 //= depend_on_asset typeahead.jquery
+//= depend_on_asset jquery-migrate/jquery-migrate
 
 //= depend_on_asset modules/globals
 //= depend_on_asset modules/common
@@ -53,6 +54,7 @@
       typeahead: requirejs_path('typeahead.jquery'),
       ujs: requirejs_path('jquery-ujs/src/rails'),
       waypoints: requirejs_path('jquery-waypoints/waypoints'),
+      jquerymigrate: requirejs_path('jquery-migrate/jquery-migrate'),
 
       # Internal modules
       common: requirejs_path('modules/common'),
@@ -91,6 +93,7 @@
       wpccConfig: requirejs_path('wpcc/require_config')
     },
     shim: {
+      jquery: ['jquerymigrate'],
       typeahead: ['jquery'],
       ujs: ['jquery'],
     }

--- a/bower.json.erb
+++ b/bower.json.erb
@@ -7,9 +7,10 @@
     "sinonjs": "1.7.3",
     "html5shiv": "3.7.0",
     "requirejs": "2.1.*",
-    "jquery": "1.11.*",
+    "jquery": "3.3.*",
     "jquery-waypoints": "2.0.*",
     "jquery-ujs": "*",
+    "jquery-migrate": "*",
     "bind-polyfill": "^1.0.0",
     "yeast": "1.6.7",
     "advice_plans": "<%= gem_path('advice_plans') %>",
@@ -24,6 +25,6 @@
     "cost_calculator_builder": "<%= gem_path('cost_calculator_builder') %>"
   },
   "resolutions": {
-    "jquery": "~1.11.3"
+    "jquery": "3.3.*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
   },
   "scripts": {
     "test": "./node_modules/karma/bin/karma start spec/javascripts/karma.conf.js"
+  },
+  "dependencies": {
+    "jquery": "^3.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,8 +24,5 @@
   },
   "scripts": {
     "test": "./node_modules/karma/bin/karma start spec/javascripts/karma.conf.js"
-  },
-  "dependencies": {
-    "jquery": "^3.3.1"
   }
 }


### PR DESCRIPTION
[9754](https://moneyadviceservice.tpondemand.com/entity/9754-update-jquery-in-frontend-application)

This PR updates the version of jquery in frontend to v3.3.1
Introduces jquery migrate
Have checked a number of tools and there are some errors but they are handled by the migrate plugin
Tests all pass on Frontend

Look in the ticket to see some screen shots of the error.

Oddly we don't seem to be able to get a minified version of jquery 3.3.1, tried a variety of ways