### PR TITLE
Revert mortgage-calculator to 3.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,9 @@ gem 'debt_free_day_calculator', '~> 3.0.0'
 gem 'debt_test', '~> 1.8.0'
 gem 'decision_trees', '~> 2.2.1'
 gem 'feedback', '~> 0.5.1'
-gem 'mortgage_calculator', '~> 3.5.0'
+#### DO NOT bump mortgage_calculator beyond 3.4 because until TP 9827 is ready for deployment
+gem 'mortgage_calculator', '~> 3.4.0'
+####
 gem 'pacs', '3.3.0'
 gem 'payday_loans_intervention', '~> 1.8.0'
 gem 'pensions_calculator', '~> 2.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -489,7 +489,7 @@ GEM
       mongo (>= 2.5.1, < 3.0.0)
       origin (~> 2.3)
       tzinfo (>= 0.3.37)
-    mortgage_calculator (3.5.0)
+    mortgage_calculator (3.4.0)
       angularjs-rails (~> 1.2.18)
       dough-ruby (~> 5.0)
       jquery-rails
@@ -863,7 +863,7 @@ DEPENDENCIES
   mas-assets!
   mas-cms-client (= 1.20.0)
   meta-tags (~> 2.4)
-  mortgage_calculator (~> 3.5.0)
+  mortgage_calculator (~> 3.4.0)
   mysql2 (= 0.4.9)
   newrelic_rpm
   nokogiri (>= 1.8.5)


### PR DESCRIPTION
This pr bumps down the mortgage_calculator gem from 3.5 to 3.4.


### Summary
Refer to the blocker on [TP 9827](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5682182231901749200&appConfig=eyJhY2lkIjoiRkRBMzk3RTBGNjU3NDg1RDM4QzczMTJFNzI5MDFBN0MifQ==&searchPopup=userstory/9827). 

The requirement for different text was added when TP 9827 reached staging.