### PR TITLE
[DEV APPROVED] TP-10333: Remove mas-assets requirement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,6 @@ gem 'whenever', require: false
 gem 'adal', git: 'git@github.com:moneyadviceservice/azure-activedirectory-library-for-ruby'
 gem 'cream', '2.1.7'
 gem 'dough-ruby', '~> 5.35.0'
-gem 'mas-assets', git: 'git@github.com:moneyadviceservice/mas-assets'
 gem 'mas-cms-client', '1.20.0'
 gem 'site_search', '0.3.0'
 # Tools

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,16 +14,6 @@ GIT
       nokogiri (~> 1.6)
       uri_template (~> 0.7)
 
-GIT
-  remote: git@github.com:moneyadviceservice/mas-assets
-  revision: 1a2a449235eae7a589dbcf55c2107764a49fad5d
-  specs:
-    mas-assets (1.2.0)
-      compass-rails
-      google-analytics-rails
-      sass
-      sass-rails
-
 GEM
   remote: https://rubygems.org/
   remote: http://gems.dev.mas.local/
@@ -161,7 +151,6 @@ GEM
       railties (>= 3.1)
       sprockets
     chronic (0.10.2)
-    chunky_png (1.3.10)
     cliver (0.3.2)
     cocoon (1.2.12)
     codeclimate-test-reporter (0.6.0)
@@ -174,12 +163,6 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    compass (0.12.7)
-      chunky_png (~> 1.2)
-      fssm (>= 0.2.7)
-      sass (~> 3.2.19)
-    compass-rails (2.0.0)
-      compass (>= 0.12.2)
     concurrent-ruby (1.1.4)
     cost_calculator_builder (1.0.0)
       bowndler
@@ -380,7 +363,6 @@ GEM
       formtastic (~> 2.2)
     friendly_id (5.2.5)
       activerecord (>= 4.0.0)
-    fssm (0.2.10)
     geokit (1.13.1)
     geokit-rails (2.3.1)
       geokit (~> 1.5)
@@ -388,7 +370,6 @@ GEM
     gherkin (5.0.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    google-analytics-rails (1.1.1)
     haml (5.0.4)
       temple (>= 0.8.0)
       tilt
@@ -860,7 +841,6 @@ DEPENDENCIES
   link_header
   mail
   mailjet
-  mas-assets!
   mas-cms-client (= 1.20.0)
   meta-tags (~> 2.4)
   mortgage_calculator (~> 3.4.0)


### PR DESCRIPTION
[TP-10333](https://moneyadviceservice.tpondemand.com/entity/10333-test-to-remove-mas-assets-gem)
According to MAS Assets Readme, in order to use the gem in your project
you need to "require mas/shared" or "@import 'mas/shared'".

There is no reference at all to "mas/shared" within Frontend project,
so having green both unit and feature tests and the app starting
without issues when removing this dependency... I assume is safe to
just delete it from the project.


