### PR TITLE
[DEV APPROVED] Update source of aes gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,11 +11,15 @@ source 'http://gems.dev.mas.local'
 gem 'rails', '4.2.11.1'
 
 gem 'activerecord-session_store'
-# The aes gem is no longer supported, so point to a fork that resolves
-# deprecation warnings in Ruby's OpenSSL module. This could feasibly be
-# replaced by an implementation within this repo, as all the gem is doing is
-# wrapping OpenSSL.
-gem 'aes', git: 'git@github.com:jalerson/aes.git', ref: '8366dc165'
+
+##############################################################
+# The aes gem is no longer supported, so point to the repo that
+# resolves deprecation warnings in Ruby's OpenSSL module. 
+#
+# This could feasibly be replaced by an implementation within 
+# this repo, as all the gem is doing is wrapping OpenSSL.
+##############################################################
+gem 'aes', git: 'git@github.com:chicks/aes.git'
 gem 'algoliasearch'
 gem 'attr_encrypted', '~> 3.1'
 gem 'blind_index', '0.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,6 @@
 GIT
-  remote: git@github.com:jalerson/aes.git
-  revision: 8366dc165c90cb8b4809e4aedf597dbe745a4450
-  ref: 8366dc165
+  remote: git@github.com:chicks/aes.git
+  revision: 001f77806a2cbef513315993e19a8f679f8f5786
   specs:
     aes (0.5.0)
 


### PR DESCRIPTION
The source we were previously using for this gem was made private. This pr updates the source of the gem to the public repo.

We use this gem to provide encryption/decryption on top of OpenSSL.

