### PR TITLE
Update wpcc version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,7 +86,7 @@ gem 'rio', '~> 2.1.0', source: 'http://gems.dev.mas.local'
 gem 'savings_calculator', '1.9.0'
 gem 'timelines', '~> 1.7.0'
 gem 'universal_credit', '4.0.0'
-gem 'wpcc', '2.4.0'
+gem 'wpcc', '2.5.0'
 
 group :assets do
   gem 'autoprefixer-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -774,7 +774,7 @@ GEM
     websocket-extensions (0.1.3)
     whenever (0.10.0)
       chronic (>= 0.6.3)
-    wpcc (2.4.0)
+    wpcc (2.5.0)
       dough-ruby (~> 5.36)
       meta-tags
       modernizr-rails (~> 2.6.2)
@@ -892,7 +892,7 @@ DEPENDENCIES
   vcr
   webmock
   whenever
-  wpcc (= 2.4.0)
+  wpcc (= 2.5.0)
 
 BUNDLED WITH
    1.17.3


### PR DESCRIPTION
Update wpcc engine to 2.5 for [TP 10440](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5682182231901749200&appConfig=eyJhY2lkIjoiRkRBMzk3RTBGNjU3NDg1RDM4QzczMTJFNzI5MDFBN0MifQ==&searchPopup=userstory/10440)