### PR TITLE
[DEV APPROVED] [10472] Add metatag provided by Pinterest support team for verification

### DIFF
--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -29,6 +29,7 @@
   <meta name="msapplication-square150x150logo" content="/favicon_ms_150x150.png">
   <meta name="msapplication-wide310x150logo" content="/favicon_ms_310x150.png">
   <meta name="msapplication-square310x310logo" content="/favicon_ms_310x310.png">
+  <meta name="pinterest_domain_verify" content="aef390d29af3532d99f8cabb0e10bdaa">
   <%= tag 'link', rel: 'icon', type: 'image/png', sizes: '32x32', href: '/favicon_32x32.png' %>
   <%= tag 'link', rel: 'icon', type: 'image/png', sizes: '48x48', href: '/favicon_48x48.png' %>
   <%= tag 'link', rel: 'icon', type: 'image/png', sizes: '96x96', href: '/favicon_96x96.png' %>


### PR DESCRIPTION
[TP-10472](https://moneyadviceservice.tpondemand.com/entity/10472-spike-investigate-pinterest-verification-process)

This is just to add the given code that will be manually checked by Pinterest support team member: 

> If the meta tag or file method isn't working for you, there is one alternative you can try. Temporarily add this tag to the source code anywhere on your website's homepage: aef390d29af3532d99f8cabb0e10bdaa

> Once you add the tag, email me to let me know, and I'll check your site's homepage for it. If it's there, I'll be able to confirm that you're the site owner and confirm your site for you. You can remove the tag after the verification is complete.

So we don't need to worry much about name/format as the code shows up and can be checked manually.