### PR TITLE
Revert "[10472] Add metatag provided by Pinterest support team for verification"

### DIFF
--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -29,7 +29,6 @@
   <meta name="msapplication-square150x150logo" content="/favicon_ms_150x150.png">
   <meta name="msapplication-wide310x150logo" content="/favicon_ms_310x150.png">
   <meta name="msapplication-square310x310logo" content="/favicon_ms_310x310.png">
-  <meta name="pinterest_domain_verify" content="aef390d29af3532d99f8cabb0e10bdaa">
   <%= tag 'link', rel: 'icon', type: 'image/png', sizes: '32x32', href: '/favicon_32x32.png' %>
   <%= tag 'link', rel: 'icon', type: 'image/png', sizes: '48x48', href: '/favicon_48x48.png' %>
   <%= tag 'link', rel: 'icon', type: 'image/png', sizes: '96x96', href: '/favicon_96x96.png' %>


### PR DESCRIPTION
Reverts moneyadviceservice/frontend#2117

As we finally successfully claimed MAS website in Pinterest and the authentication process was an one/off code, there is no need to keep it anymore in our codebase.

Related with: https://moneyadviceservice.tpondemand.com/entity/10472-spike-investigate-pinterest-verification-process