### PR TITLE
Point to car_cost_tool 1.5.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (>= 2.0, < 4.0)
-    car_cost_tool (1.5.0)
+    car_cost_tool (1.5.1)
       dough-ruby (~> 5.36)
       nokogiri
       rails (>= 4, < 5)
@@ -653,7 +653,7 @@ GEM
     rubytree (0.9.7)
       json (~> 1.8)
       structured_warnings (~> 0.2)
-    rubyzip (1.2.2)
+    rubyzip (1.2.3)
     safe_yaml (1.0.4)
     sass (3.2.19)
     sass-rails (4.0.5)
@@ -727,7 +727,7 @@ GEM
     underscore-rails (1.8.3)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.5)
+    unf_ext (0.0.7.6)
     unicode-display_width (1.3.0)
     unicorn (5.4.0)
       kgio (~> 2.6)


### PR DESCRIPTION
[TP](https://moneyadviceservice.tpondemand.com/entity/9610-broken-link-in-car-costs-calculator)