### PR TITLE
[DEV APPROVED] 10506 Fix locale switching on AMP pages

### DIFF
--- a/app/controllers/amp_articles_controller.rb
+++ b/app/controllers/amp_articles_controller.rb
@@ -25,7 +25,7 @@ class AmpArticlesController < ActionController::Base
   private
 
   def retrieve_article
-    @article ||= Mas::Cms::Article.find(params[:article_id], locale: I18n.locale)
+    @article ||= Mas::Cms::Article.find(params[:article_id], locale: params[:locale])
   end
 
   def redirect_page(e)


### PR DESCRIPTION
[TP](https://moneyadviceservice.tpondemand.com/entity/10506-bug-welsh-amp-intermittent-404)

The controller for AMP articles uses I18n.locale, which isn't being
dynamically updated based on the request params. Use the locale param
directly.