### PR TITLE
[DEV APPROVED] 10600 update cookie consent message

### DIFF
--- a/app/assets/stylesheets/components/common/_cookie_message.scss
+++ b/app/assets/stylesheets/components/common/_cookie_message.scss
@@ -12,24 +12,19 @@
 
 .cookie-message__content {
   @extend %type-small;
-  @include column(11);
+  @include column(12);
   margin-top: $baseline-unit*3;
   margin-bottom: $baseline-unit*3;
 }
 
 .cookie-message__link {
   margin-top: $baseline-unit*2;
-  display: block;
   @extend %type-small;
-
-  @include respond-to($mq-l) {
-    display: inline;
-  }
 }
 
 .cookie-message__close-button {
-  @extend .unstyled-button;
-  position: absolute;
-  right: 0;
-  padding: $baseline-unit*3 $baseline-unit*2 $baseline-unit*2 $baseline-unit*2;
+  float: right;
+  font-size: 0.875rem;
+  padding: $baseline-unit $baseline-unit;
+  margin: 0 0 $baseline-unit $baseline-unit*3;
 }

--- a/app/views/shared/_footer_secondary.html.erb
+++ b/app/views/shared/_footer_secondary.html.erb
@@ -102,12 +102,10 @@
 <div class="cookie-message">
   <div class="l-constrained">
     <%= form_tag main_app.cookie_notice_acceptance_path, remote: true, authenticity_token: true, class: 'js-cookie-message' do %>
-    <p class="cookie-message__content"><%= t('footer.cookie_message.body_html', url: t('footer.cookie_guide_link')) %>
-    </p>
-    <button class="cookie-message__close-button">
-      <span class="visually-hidden"><%= t('footer.cookie_message.close_button') %></span><span
-        class="icon icon--close"></span>
-    </button>
+      <p class="cookie-message__content">
+        <button class="cookie-message__close-button button"><%= t('footer.cookie_message.close_button') %></button>
+        <%= t('footer.cookie_message.body_html', url: t('footer.cookie_guide_link')) %>
+      </p>
     <% end %>
   </div>
 </div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -315,10 +315,9 @@ cy:
     cookie_guide_link: /cy/corporate/sut-yr-ydym-yn-defnyddio-cwcis
     cookie_message:
       body_html: |
-        Rydym yn defnyddio cwcis i sicrhau eich bod yn cael y profiad gorau posibl.
-        Drwy barhau i ddefnyddio ein gwefan rydych yn cytuno â'r defnydd a wneir ohoni.
-        <a class="cookie-message__link" href="%{url}">Canfyddwch fwy am cwcis.</a>
-      close_button: Cau
+        Rydym yn defnyddio Cwcis: Trwy ddefnyddio'r wefan hon, rydych chi'n cydsynio i'w defnydd. Ceir rhagor o fanylion yn ein
+        <a class="cookie-message__link" href="%{url}">polisi cwcis</a>.
+      close_button: Derbyn a chau
     new-window-label: Yn agor mewn ffenestr newydd
     facebook-likes: Wedi hoffi
     twitter-followers: Dilynwyr

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -316,10 +316,9 @@ en:
     cookie_guide_link: /en/corporate/cookie_notice_en
     cookie_message:
       body_html: |
-        We use cookies to ensure that you get the best possible experience.
-        By continuing to use our website you are agreeing to their use.
-        <a class="cookie-message__link" href="%{url}">Find out more about cookies.</a>
-      close_button: Close cookie message
+        We use Cookies: By using this website, you consent to their use. More details can be found in our
+        <a class="cookie-message__link" href="%{url}">cookies policy</a>.
+      close_button: Accept and close
     new-window-label: Opens in a new window
     facebook-likes: Likes
     twitter-followers: Followers


### PR DESCRIPTION
[TP10600](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=userstory/10600)

The work in this PR 
- updates the cookie consent message 
- replaces the close button with one that states that the user accepts the use of cookies on the site. 

Existing functionality remains unchanged. 

Current cookie message: 
![image](https://user-images.githubusercontent.com/6080548/62366548-1dcb7f00-b51f-11e9-912a-1b112c2c9a46.png)

Updated cookie message: 
![image](https://user-images.githubusercontent.com/6080548/62366582-39368a00-b51f-11e9-882c-079782e35eec.png)