### PR TITLE
[DEV APPROVED] Updates A/B Testing GTM snippet

### DIFF
--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -19,7 +19,7 @@
       h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
       (a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c;
       })(window,document.documentElement,'async-hide','dataLayer',4000,
-      {'<%= Rails.application.config.google_optimize_id %>':true});
+      {'<%= Rails.application.config.google_tag_manager_id %>':true});
     </script>
   <% end %>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,7 +25,6 @@ module Frontend
 
     config.crazy_egg_url         = '//dnn506yrbagrg.cloudfront.net/pages/scripts/0018/4438.js'
     config.google_tag_manager_id = 'GTM-WVFLH9'
-    config.google_optimize_id = 'GTM-PFLN6KX'
 
     config.time_zone = 'Europe/London'
     config.chat_opening_hours = OpeningHours.new('8:00 AM', '6:00 PM')


### PR DESCRIPTION
[TP10589](https://moneyadviceservice.tpondemand.com/entity/10589-update-gtm-tracking-code-snippet)

This change updates a previous update ([TP10537](https://moneyadviceservice.tpondemand.com/entity/10537-update-ab-testing-lessheadgreater-code-snippets)) to the A/B Testing code snippet that moved the site from Optimizely to  Google Optimize. Following this change it was recommended that we use a different ID, which is implemented here. The recommended ID is in fact the already-existing one for Google Tag Manager. 

**Current snippet:** 
![image](https://user-images.githubusercontent.com/6080548/63259274-ddd1ff00-c275-11e9-9aa9-51eaeb5a3831.png)

**Updated snippet:** 
![image](https://user-images.githubusercontent.com/6080548/63259307-f510ec80-c275-11e9-9097-d3aeea0a9d0a.png)
