### PR TITLE
[DEV APPROVED] Only show view all button if there are more items to view

### DIFF
--- a/app/views/categories/_content_items.html.erb
+++ b/app/views/categories/_content_items.html.erb
@@ -12,7 +12,9 @@
     </li>
   <% end %>
 </ol>
-<button class="unstyled-button category-detail__toggle-view js-category-detail__toggle-view">
-  <span class="category-detail__view_all"><%= t('categories.show.view_all') %></span>
-  <span class="category-detail__view_less"><%= t('categories.show.view_less') %></span>
-</button>
+<% if extended_contents.present? %>
+  <button class="unstyled-button category-detail__toggle-view js-category-detail__toggle-view">
+    <span class="category-detail__view_all"><%= t('categories.show.view_all') %></span>
+    <span class="category-detail__view_less"><%= t('categories.show.view_less') %></span>
+  </button>
+<% end %>


### PR DESCRIPTION
[TP 10677](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5682182231901749200&appConfig=eyJhY2lkIjoiRkRBMzk3RTBGNjU3NDg1RDM4QzczMTJFNzI5MDFBN0MifQ==&boardPopup=userstory/10677/silent)

**Background**
On the [tools and calculators page](https://www.moneyadviceservice.org.uk/en/categories/tools-and-calculators), a view all button is displayed for each category. For some of the categories, this button doesn't do or add anything, if it is clicked nothing additional is shown. 
![Screenshot 2019-08-21 at 13 03 13](https://user-images.githubusercontent.com/3481059/63430303-29221400-c414-11e9-97a9-4dbfbc18d722.png)
![Screenshot 2019-08-21 at 13 03 21](https://user-images.githubusercontent.com/3481059/63430304-29221400-c414-11e9-90e6-be2ab696720f.png)

**Solution**
Only display the view all button, if there are additional items to be displayed.
![Screenshot 2019-08-21 at 13 05 40](https://user-images.githubusercontent.com/3481059/63430405-67b7ce80-c414-11e9-9209-85b9b2bf1861.png)

