### PR TITLE
10696 popup pensions display

### DIFF
--- a/app/assets/stylesheets/components/page_specific/_floating_chat.scss
+++ b/app/assets/stylesheets/components/page_specific/_floating_chat.scss
@@ -1,19 +1,3 @@
-.chat-box__container,
-.mobile-webchat__container {
-  background-color: $color-white;
-  position: fixed;
-  z-index: 90;
-  box-shadow: 0 0 7px 1px rgba(133, 133, 133, 0.71);
-
-  &:hover {
-    text-decoration: none;
-  }
-
-  &:focus {
-    background-color: $color-white;
-  }
-}
-
 .chat-box__container {
   top: 30%;
   left: 0;
@@ -37,6 +21,22 @@
 
   .chat-box__icon {
     margin-left: -35px;
+  }
+}
+
+.chat-box__container,
+.mobile-webchat__container {
+  background-color: $color-white;
+  position: fixed;
+  z-index: 90;
+  box-shadow: 0 0 7px 1px rgba(133, 133, 133, 0.71);
+
+  &:hover {
+    text-decoration: none;
+  }
+
+  &:focus {
+    background-color: $color-white;
   }
 }
 
@@ -71,6 +71,9 @@
 
   &:focus {
     outline: none;
+  }
+  &.display-flex {
+    display: flex;
   }
 
   // raised state in article pages
@@ -124,6 +127,11 @@
     // min-width 479
     @include respond-to($mq-m) {
       width: 50vw;
+    }
+
+    // min-width 960
+    @include respond-to($mq-l) {
+      width: 450px;
     }
 
     .mobile-webchat--icon {

--- a/app/views/shared/_contact_panels.html.erb
+++ b/app/views/shared/_contact_panels.html.erb
@@ -48,11 +48,13 @@
         var chatPopup = document.getElementById('js-chat-popup'); 
       <% end %>
 
-      chatMobilePopup[0].href = sWOChatstart;
-      chatMobilePopup[0].onclick = function () {
-        window.open(chatMobilePopup[0].href, "Chat", "width=484,height=361,scrollbars=yes,resizable=yes");
-        return false;
-      }; 
+      if(chatMobilePopup) {
+        chatMobilePopup[0].href = sWOChatstart;
+        chatMobilePopup[0].onclick = function () {
+          window.open(chatMobilePopup[0].href, "Chat", "width=484,height=361,scrollbars=yes,resizable=yes");
+          return false;
+        }; 
+      }
 
 
       if (sWOImage.width == 1) {

--- a/app/views/shared/_contact_panels.html.erb
+++ b/app/views/shared/_contact_panels.html.erb
@@ -48,7 +48,7 @@
         var chatPopup = document.getElementById('js-chat-popup'); 
       <% end %>
 
-      if(chatMobilePopup) {
+      if(chatMobilePopup.length > 0) {
         chatMobilePopup[0].href = sWOChatstart;
         chatMobilePopup[0].onclick = function () {
           window.open(chatMobilePopup[0].href, "Chat", "width=484,height=361,scrollbars=yes,resizable=yes");

--- a/app/views/shared/_webchat_popup.html.erb
+++ b/app/views/shared/_webchat_popup.html.erb
@@ -43,8 +43,8 @@
               <span class="form-button__text-heading"><%= t('contact_panels.chat_popup.available.call_to_action') %></span>
               <span class="form-button__text-service"><%= t('contact_panels.chat_popup.available.text_webchat') %></span>
             <% else %>
-              <span class="form-button__text-heading">Chat</span>
-              <span class="form-button__text-service">Unavailable</span>
+              <span class="form-button__text-heading"><%= t('contact_panels.chat_popup.unavailable.call_to_action') %></span>
+              <span class="form-button__text-service"><%= t('contact_panels.chat_popup.unavailable.text_webchat') %></span>
             <% end %>
           </div>
         </a>
@@ -53,7 +53,7 @@
     <% end %>
     <div class="mobile-webchat__contact">
       <a class="mobile-webchat__contact--link" href="<%= t('contact_panels.chat_popup.contact_link') %>">
-        Other Contact Methods
+        <%= t('contact_panels.chat_popup.contact_text') %>
       </a>
     </div>
   </div>

--- a/app/views/shared/_webchat_popup.html.erb
+++ b/app/views/shared/_webchat_popup.html.erb
@@ -1,4 +1,4 @@
-<div aria-hidden="true" class="mobile-webchat__container mobile-webchat--closed" data-dough-component="ChatPopup">
+<div aria-hidden="true" class="mobile-webchat__container mobile-webchat--closed <% if pensions_and_retirement_page? %>display-flex<% end %>" data-dough-component="ChatPopup">
   <button class="mobile-webchat__close" data-dough-webchat-close>
     <span>X</span>
   </button>
@@ -27,7 +27,7 @@
             <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--whatsapp"></use>
           </svg>
           <div class="form-button__text">
-            <span class="form-button__text-heading"><%= t('contact_panels.chat_popup.button_text') %></span>
+            <span class="form-button__text-heading"><%= t('contact_panels.chat_popup.available.call_to_action') %></span>
             <span class="form-button__text-service">WhatsApp</span>
           </div>
         </a>
@@ -40,8 +40,8 @@
           </svg>
           <div class="form-button__text">
             <% if chat_opening_hours.open? %>
-              <span class="form-button__text-heading"><%= t('contact_panels.chat_popup.button_text') %></span>
-              <span class="form-button__text-service">Web Chat</span>
+              <span class="form-button__text-heading"><%= t('contact_panels.chat_popup.available.call_to_action') %></span>
+              <span class="form-button__text-service"><%= t('contact_panels.chat_popup.available.text_webchat') %></span>
             <% else %>
               <span class="form-button__text-heading">Chat</span>
               <span class="form-button__text-service">Unavailable</span>

--- a/app/views/shared/_webchat_popup_pensions.html.erb
+++ b/app/views/shared/_webchat_popup_pensions.html.erb
@@ -18,11 +18,11 @@
       </svg>
       <div class="form-button__text">
         <% if chat_opening_hours.open? %>
-        <span class="form-button__text-heading"><%= t('contact_panels.chat_popup.button_text') %></span>
-        <span class="form-button__text-service">Web Chat</span>
+          <span class="form-button__text-heading"><%= t('contact_panels.chat_popup.available.call_to_action') %></span>
+          <span class="form-button__text-service"><%= t('contact_panels.chat_popup.available.text_webchat') %></span>
         <% else %>
-        <span class="form-button__text-heading">Chat</span>
-        <span class="form-button__text-service">Unavailable</span>
+          <span class="form-button__text-heading">Chat</span>
+          <span class="form-button__text-service">Unavailable</span>
         <% end %>
       </div>
     </a>

--- a/app/views/shared/_webchat_popup_pensions.html.erb
+++ b/app/views/shared/_webchat_popup_pensions.html.erb
@@ -21,8 +21,8 @@
           <span class="form-button__text-heading"><%= t('contact_panels.chat_popup.available.call_to_action') %></span>
           <span class="form-button__text-service"><%= t('contact_panels.chat_popup.available.text_webchat') %></span>
         <% else %>
-          <span class="form-button__text-heading">Chat</span>
-          <span class="form-button__text-service">Unavailable</span>
+          <span class="form-button__text-heading"><%= t('contact_panels.chat_popup.unavailable.call_to_action') %></span>
+          <span class="form-button__text-service"><%= t('contact_panels.chat_popup.unavailable.text_webchat') %></span>
         <% end %>
       </div>
     </a>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -152,7 +152,12 @@ cy:
       url: https://www.pensionsadvisoryservice.org.uk/TPASChat
     chat_popup:
       title: Beth hoffech chi siarad amdano?
-      button_text: Dechrau
+      available:
+        call_to_action: Dechrau
+        text_webchat: Sgwrs Gwe
+      unavailable:
+        call_to_action: Sgwrs Gwe
+        text_webchat: Ddim ar gael
       dropdown_options:
         debt_borrowing: Dyled a benthyca
         homes_mortgages: Cartrefi a morgeisi
@@ -163,6 +168,7 @@ cy:
         cars_travel: Ceir a theithio
         insurance: Yswiriant
       contact_link: /cy/corporate/cysylltu-a-ni
+      contact_text: Dulliau cysylltu eraill
     chat:
       title: Gwe-sgwrs
       available:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -152,7 +152,12 @@ en:
       url: https://www.pensionsadvisoryservice.org.uk/TPASChat
     chat_popup:
       title: What would you like to talk about?
-      button_text: Start
+      available:
+        call_to_action: Start
+        text_webchat: Web Chat
+      unavailable:
+        call_to_action: Chat
+        text_webchat: Unavailable
       dropdown_options:
         debt_borrowing: Debt & Borrowing
         homes_mortgages: Homes & Mortgages
@@ -163,6 +168,7 @@ en:
         cars_travel: Cars & Travel
         insurance: Insurance
       contact_link: /en/corporate/contact-us
+      contact_text: Other contact methods
     chat:
       title: Web chat
       available:


### PR DESCRIPTION
**Target Process ticket**

[TP10695](https://maps.tpondemand.com/entity/10695-replace-popup-chat-content-for-pensions)

**Summary**
In ticket 10695 the contents of the chat popup were altered for pages in the pensions category, however, this popup only displays on mobile.  We would like to display the popup for desktop users who are viewing pensions content only, the chat popup will still be hidden on desktop for all other page types.
