### PR TITLE
10756 remove welsh text

### DIFF
--- a/app/views/shared/_panel_webchat.html.erb
+++ b/app/views/shared/_panel_webchat.html.erb
@@ -2,7 +2,7 @@
   <!-- Top Logo -->
   <%= heading_tag level: 2, class: 'contact-panel__heading' do %>
     <span class="icon icon--web-chat"></span>
-    <%= @footer.web_chat.heading %>
+    <%= t('contact_panels.chat.title') %>
   <% end %>
   <!-- No js enabled text -->
   <p class="contact-panel__chat-javascript t-chat-javascript">

--- a/features/footer.feature
+++ b/features/footer.feature
@@ -20,7 +20,7 @@ Feature: Footer
     Given I visit the website in Welsh
     Then I should see the footer
       | text                                                                |
-      | Gwe-sgwrs            |
+      | Gwe-sgwrs                                                           |
       | A oes gennych chi gwestiwn? Bydd ein cynghorwyr yn eich arwain      |
       | Dydd Llun i Dydd Gwener, 8am i 8pm                                  |
       | Dydd Sadwrn, 9am i 1pm                                              |

--- a/features/footer.feature
+++ b/features/footer.feature
@@ -20,7 +20,7 @@ Feature: Footer
     Given I visit the website in Welsh
     Then I should see the footer
       | text                                                                |
-      | Gwe-sgwrs * Dim ond yn Saesneg mae gwe-sgwrsio ar gael.             |
+      | Gwe-sgwrs            |
       | A oes gennych chi gwestiwn? Bydd ein cynghorwyr yn eich arwain      |
       | Dydd Llun i Dydd Gwener, 8am i 8pm                                  |
       | Dydd Sadwrn, 9am i 1pm                                              |


### PR DESCRIPTION
[TP10756](https://maps.tpondemand.com/entity/10756-remove-additional-text-from-welsh-web)

Removes the text informs the user that webchat is not available in Welsh when in fact it is. Updates expect text in cucumber tests.