### PR TITLE
[DEV APPROVED] Adds an explicit height to the Loan Calculator tool

### DIFF
--- a/app/assets/javascripts/syndication/tools.js.coffee
+++ b/app/assets/javascripts/syndication/tools.js.coffee
@@ -272,6 +272,8 @@
       cy:
         path: "cy/tools/cyfrifiannell-benthyciadau/loan"
       title: "Loan calculator"
+      width: "100%"
+      height: "1200px"
 
     loan_calculator_beta:
       en:


### PR DESCRIPTION
[TP10981](https://maps.tpondemand.com/entity/10981-loan-calculator-no-default-height-causes)

This PR refers to problems arising from embedding the Loan Calculator tool on a web page. The issue became apparent when Jaguar Land Rover embedded this as one of four tools [here](https://wellbeing.jaguarlandrover.com/financial-wellbeing). 

The work in this PR assumes that the problem here is by embedding multiple tools on a page the functionality to dynamically resize the tools is lost, and they are displayed at the default size (if any) specified in the embed code. Since there is no such value in the code pertaining to the Loan Calculator this is not fully displayed when embedded in this scenario (see screenshot below). 

This change simply adds a default height and width, calculated to reasonably cover the display height of the tool in most circumstances, in order that the display of the tool is at least functional to the user. 

![image](https://user-images.githubusercontent.com/6080548/69557796-18e37d00-0f9f-11ea-9279-b72e2d290594.png)
