### PR TITLE
[DEV APPROVED] 10975 maps banner

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -69,6 +69,12 @@ class ApplicationController < ActionController::Base
 
   helper_method :show_floating_chat?
 
+  def show_home_banner?
+    false
+  end
+
+  helper_method :show_home_banner?
+
   def display_skip_to_main_navigation?
     true
   end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -15,6 +15,10 @@ class HomeController < ApplicationController
     true
   end
 
+  def show_home_banner?
+    true
+  end
+
   private
 
   def resource

--- a/app/views/layouts/_application_shared.html.erb
+++ b/app/views/layouts/_application_shared.html.erb
@@ -8,6 +8,7 @@
   <a class="skip-to-link" href="<%= t('footer.accessibility_link') %>"><%= t('skip_links.to_accessibility_statement') %></a>
 
   <%= render 'shared/alerts' if alerts? %>
+  <%= render 'shared/maps_banner' %>
   <%= render 'shared/header' %>
   <%= render 'shared/no_js_nav' %>
   <%= render 'shared/global_nav' %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,5 +1,5 @@
-<header class="l-header" role="banner">
-  <div class="l-constrained l-header__content<%= ' l-header__content--non-sticky' if hide_sticky_header? %>">
+<header class="l-header<%= ' l-header--non-sticky' if hide_sticky_header? %><%= ' l-header--home' if show_home_banner? %>" role="banner">
+  <div class="l-constrained l-header__content">
     <div class="mas-logo">
       <%= link_to main_app.root_path, class: 'mas-logo__link' do %>
         <%= image_tag("logo-sprite-#{I18n.locale}.png", alt: t('layouts.base.title'), class: 'mas-logo__img') %>

--- a/app/views/shared/_maps_banner.html.erb
+++ b/app/views/shared/_maps_banner.html.erb
@@ -1,0 +1,16 @@
+<div class="l-maps_banner<%= ' l-maps_banner--non-sticky' if hide_sticky_header? %><%= ' l-maps_banner--home' if show_home_banner? %>">
+  <div class="l-constrained">
+    <div class="l-maps_banner__content">
+      <a href="https://moneyandpensionsservice.org.uk/" target="_blank" class="maps_banner__link">
+        <span class="maps_banner__mps-text">
+          <span><%= t('maps_banner.mps_provided_1') %></span>
+          <span><%= t('maps_banner.mps_provided_2') %></span>
+        </span>
+
+        <span class="maps_banner__mps-logo"></span>
+
+        <span class="visually-hidden">opens in a new window</span>
+      </a>
+    </div>
+  </div>
+</div>

--- a/bower.json.erb
+++ b/bower.json.erb
@@ -12,7 +12,7 @@
     "jquery-ujs": "*",
     "jquery-migrate": "3.0.*",
     "bind-polyfill": "^1.0.0",
-    "yeast": "1.10.0",
+    "yeast": "1.11.0",
     "advice_plans": "<%= gem_path('advice_plans') %>",
     "car_cost_tool": "<%= gem_path('car_cost_tool') %>",
     "debt_advice_locator": "<%= gem_path('debt_advice_locator') %>",
@@ -26,6 +26,6 @@
   },
   "resolutions": {
     "jquery": "3.3.*",
-    "yeast": "1.10.0"
+    "yeast": "1.11.0"
   }
 }

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -288,6 +288,11 @@ cy:
       %201443%20827658%20%0ALlun%20i%20Wener%3A%208am-8pm%20%0ADydd%20Sadwrn%3A
       %209am-1pm%20%0ADydd%20Sul%20a%20Gwyliau%20Banc%3A%20ar%20gau
 
+  maps_banner:
+    mps_provided_1: Gwasanaeth Cynghori Ariannol
+    mps_provided_2: yn cael ei ddarparu gan
+    mps: Gwasanaeth Arian a Phensiynau
+
   footer_secondary:
     title: Adroddwch broblem mynediad
     link_title: Defnyddiwch y botwm hwn i ddweud wrthym os oes gennych chi unrhyw faterion hygyrchedd i'w hadrodd am y wefan

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -289,6 +289,11 @@ en:
       %20Friday%3A%208am-8pm%0ASaturday%3A%209am-1pm%0ASunday%20and%20Bank
       %20Holidays%3A%20closed
 
+  maps_banner:
+    mps_provided_1: The Money Advice
+    mps_provided_2: Service is provided by
+    mps: Money & Pensions Service
+
   footer_secondary:
     title: Report an accessibility problem
     link_title: Please use this button to tell us if you have an accessibility issue on our website

--- a/spec/views/header_search_box_spec.rb
+++ b/spec/views/header_search_box_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'shared/_header', type: :view do
     allow(view).to receive(:display_search_box_in_header?) { display }
     allow(view).to receive(:alternate_locales) { [] }
     allow(view).to receive(:hide_elements_irrelevant_for_third_parties?) { false }
+    allow(view).to receive(:show_home_banner?) { false }
   end
 
   context 'when the search box should be displayed in the header' do


### PR DESCRIPTION
[TP10975](https://maps.tpondemand.com/entity/10975-add-maps-brand-banner-to-mas)

This work adds a MAPS banner to the MAS site. There are two related PRs for this: the one in Yeast, [PR57](https://github.com/moneyadviceservice/yeast/pull/57), adds the styles to the markup that is contained here. For testing both need to be loaded locally. 

The banner is rendered in three different sizes: 
- Home page mobile
- Home page larger viewports
- All other pages

There is also variations on when the header is sticky on mobile versions and otherwise (mostly tool pages). 

![image](https://user-images.githubusercontent.com/6080548/70617277-238d4b80-1c08-11ea-8621-839c7d7a763d.png)

![image](https://user-images.githubusercontent.com/6080548/70617295-2be58680-1c08-11ea-951b-215859e9016f.png)

![image](https://user-images.githubusercontent.com/6080548/70617313-356eee80-1c08-11ea-92bb-754cabde8953.png)
