### PR TITLE
[DEV APPROVED] Adds MAPS banner partial to error page

### DIFF
--- a/app/views/layouts/error.html.erb
+++ b/app/views/layouts/error.html.erb
@@ -1,5 +1,7 @@
 <%= render layout: 'layouts/base' do %>
 
+  <%= render 'shared/maps_banner' %>
+
   <%= render 'shared/header' %>
 
   <div class="l-error-page">


### PR DESCRIPTION
[TP11020](https://maps.tpondemand.com/entity/11020-add-maps-brand-banner-to-mas)

When the work was done to add the MAPS banner to the MAS core site the error page was not included. 

![image](https://user-images.githubusercontent.com/6080548/71521863-5434dc80-28ba-11ea-97ae-347e3ac164ab.png)

The work in this PR adds the banner to that page.  

![image](https://user-images.githubusercontent.com/6080548/71521871-5bf48100-28ba-11ea-965f-a07007440846.png)
