### PR TITLE
Adds PACE-specific header

### DIFF
--- a/app/views/layouts/pace.html.erb
+++ b/app/views/layouts/pace.html.erb
@@ -1,8 +1,7 @@
 <%= render layout: 'layouts/base' do %>
-
   <%= render 'shared/maps_banner' %>
 
-  <%= render 'shared/header' %>
+  <%= render 'pace/header' %>
 
   <div class="l-pace">
     <main class="l-main__primary" role="main">

--- a/app/views/pace/_header.html.erb
+++ b/app/views/pace/_header.html.erb
@@ -1,0 +1,9 @@
+<header class="l-header" role="banner">
+  <div class="l-constrained l-header__content">
+    <div class="mas-logo">
+      <%= link_to main_app.root_path, class: 'mas-logo__link' do %>
+        <%= image_tag("logo-sprite-#{I18n.locale}.png", alt: t('layouts.base.title'), class: 'mas-logo__img') %>
+      <% end %>
+    </div>
+  </div>
+</header>


### PR DESCRIPTION
[TP11012](https://maps.tpondemand.com/entity/11012-pace-set-up-page-template)

This sets up a basic template for the PACE pages by replacing the MAS header with a simplified version and retaining the existing footer. Viewable locally at: http://localhost:3000/en/pace

![image](https://user-images.githubusercontent.com/6080548/71914955-9e4b7700-3172-11ea-9d59-f246ff57f6e9.png)
