### PR TITLE
[DEV APPROVED] Moves location of smallprint on Whatsapp and Webchat panels

### DIFF
--- a/app/views/shared/_panel_webchat.html.erb
+++ b/app/views/shared/_panel_webchat.html.erb
@@ -24,6 +24,7 @@
     <li class="contact-panel__additional-info"><%= @footer.web_chat.additional_three %></li>
   </ul>
   <!-- Button -->
+  <p class="smallprint t-welsh-smallprint"><%= @footer.web_chat.small_print %></p>
   <div class="contact-panel__button-container" id="js-chat-cta">
     <div class="contact-panel__button button is-disabled t-chat-button">
       <%= chat_opening_hours.call_to_action %>
@@ -38,5 +39,4 @@
       </a>
     </div>
   <% end %>
-  <p class="smallprint t-welsh-smallprint"><%= @footer.web_chat.small_print %></p>
 </div>

--- a/app/views/shared/_panel_whatsapp.html.erb
+++ b/app/views/shared/_panel_whatsapp.html.erb
@@ -14,6 +14,7 @@
       <%= t('contact_panels.whatsapp.text3') %>
     </li>
   </ul>
+  <p class="smallprint t-welsh-smallprint"><%= @footer.web_chat.small_print %></p>
   <% if chat_opening_hours.open? %>
   <div class="contact-panel__button-container">
     <a class="contact-panel__button button t-whatsapp-button" href="https://wa.me/447701342744">
@@ -25,5 +26,4 @@
     <%= t('contact_panels.chat.unavailable.call_to_action') %>
   </p>
   <% end %>
-  <p class="smallprint t-welsh-smallprint"><%= @footer.web_chat.small_print %></p>
 </div>

--- a/bower.json.erb
+++ b/bower.json.erb
@@ -12,7 +12,7 @@
     "jquery-ujs": "*",
     "jquery-migrate": "3.0.*",
     "bind-polyfill": "^1.0.0",
-    "yeast": "1.12.0",
+    "yeast": "1.13.0",
     "advice_plans": "<%= gem_path('advice_plans') %>",
     "car_cost_tool": "<%= gem_path('car_cost_tool') %>",
     "debt_advice_locator": "<%= gem_path('debt_advice_locator') %>",
@@ -25,7 +25,6 @@
     "cost_calculator_builder": "<%= gem_path('cost_calculator_builder') %>"
   },
   "resolutions": {
-    "jquery": "3.3.*",
-    "yeast": "1.12.0"
+    "jquery": "3.3.*"
   }
 }


### PR DESCRIPTION
[TP10734](https://maps.tpondemand.com/entity/10734-remove-whatsapp-contact-option-from-welsh)

This work updates the small-print text that is found on two fo the panels in the footer when viewing the site in Welsh.  The requirement is to move this text so that it is above the buttons and to make it bold. There is a further requirement to update the content of that text but that is out of the scope fo this work as it is CMS controlled. 

The work is in 2 PRs: 
- This one, which makes the markup change to alter the position
- [PR60](https://github.com/moneyadviceservice/yeast/pull/60) in Yeast that makes the style change to embolden the text and remove from English language rendering of footer. 

Current
![image](https://user-images.githubusercontent.com/6080548/72916124-55322000-3d39-11ea-80a5-6472d4c4d4b6.png)

Updated
![image](https://user-images.githubusercontent.com/6080548/72916151-69761d00-3d39-11ea-9cbc-6a5a0baee3e3.png)
