### PR TITLE
11045 pace landing page desktop

### DIFF
--- a/app/assets/images/pace/adviser_arrow.svg
+++ b/app/assets/images/pace/adviser_arrow.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="3 10 30 100" preserveAspectRatio="none">
+  <path
+    fill="none"
+    stroke="#fff"
+    stroke-width="4"
+    d="M 2 0 L 31 60 2 120"
+  />
+</svg>

--- a/app/assets/stylesheets/layout/page_specific/_pace.scss
+++ b/app/assets/stylesheets/layout/page_specific/_pace.scss
@@ -1,19 +1,82 @@
+.l-pace {
+  main {
+    @include respond-to($mq-m) {
+      display: flex;
+      flex-wrap: wrap;
+    }
+  }
+
+  .l-pace__2-section {
+    @include respond-to($mq-m) {
+      display: flex;
+      align-items: stretch;
+    }
+  }
+
+  section {
+    width: 100%;
+    margin-bottom: $baseline-unit * 4;
+
+    @include respond-to($mq-m) {
+      &.l-pace__help,
+      &.l-pace__advice {
+        @include column(6);
+      }
+
+      &.l-pace__organisations {
+        margin-bottom: 0;
+        padding-bottom: $baseline-unit * 4;
+      }
+    }
+  }
+}
+
+.l-pace__header {
+  .mas-logo {
+    width: calc(164px + #{$baseline-unit * 3});
+
+    @include respond-to($mq-m) {
+      width: calc(230px + #{$baseline-unit * 3});
+    }
+  }
+
+  .l-header__strapline {
+    @include paragraph(14, 24);
+
+    color: $color-white;
+    border-left: 1px solid;
+    font-weight: 500;
+    padding-left: $baseline-unit*3;
+    position: absolute;
+    top: 50%;
+    margin-top: -$baseline-unit*1.5;
+
+    @include respond-to($mq-s) {
+      display: inline-block;
+    }
+  }
+}
+
+.l-pace-nav {
+  display: none;
+
+  @include respond-to($mq-m) {
+    display: block;
+    width: 100%;
+    background: $color-yellow-light;
+  }
+}
+
 .l-pace__introduction__panel__content,
 .l-pace__help__content,
 .l-pace__advice__content,
 .l-pace__wellbeing__content,
-.l-pace__online_advice__content,
+.l-pace__online_advice__inner,
 .l-pace__faqs__content,
-.l-pace__organisations__content,
-.l-pace__referred__inner,
+.l-pace__organisations__inner,
+.l-pace__referred__content,
 .l-pace__privacy__content {
   @include column(12);
-}
-
-.l-pace__online_advice__content {
-  padding: $baseline-unit * 2;
-  border-radius: $baseline-unit * 2;
-  background: $color-yellow-light;
 }
 
 .l-pace__introduction__heading,
@@ -29,41 +92,192 @@
 .l-pace__introduction__heading,
 .l-pace__adviser__heading {
   @include column(12);
+
+  @include respond-to($mq-l) {
+    @include column(8);
+  }
+}
+
+.l-pace__online_advice {
+  @include respond-to($mq-m) {
+    background: $color-yellow-light;
+  }
+}
+
+.l-pace__online_advice__inner {
+  padding: $baseline-unit * 2;
+  border-radius: $baseline-unit * 2;
+  background: $color-yellow-light;
+
+  @include respond-to($mq-m) {
+    width: 100%;
+    margin-left: 0;
+    margin-right: 0;
+    padding-left: 0;
+    padding-right: 0;
+    border-radius: none;
+    background: transparent;
+  }
 }
 
 .l-pace__online_advice__heading {
   margin-top: 0;
 }
 
+.l-pace__online_advice__heading,
+.l-pace__online_advice__content,
+.l-pace__online_advice__cta {
+  @include respond-to($mq-m) {
+    @include column(6);
+  }
+}
+
+.l-pace__online_advice__heading,
+.l-pace__online_advice__cta {
+  @include respond-to($mq-m) {
+    float: left;
+  }
+
+  @include respond-to($mq-l) {
+    @include column(4);
+  }
+}
+
+.l-pace__online_advice__content {
+  @include respond-to($mq-m) {
+    float: right;
+
+    p:first-child {
+      margin-top: 0;
+    }
+
+    p:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  @include respond-to($mq-l) {
+    @include column(8);
+
+    float: right;
+  }
+}
+
+.l-pace__online_advice__cta {
+  @include respond-to($mq-m) {
+    width: auto;
+  }
+}
+
 .l-pace__advice__organisations,
 .l-pace__adviser__list,
 .l-pace__faqs__list,
 .l-pace__organisations__list,
-.l-pace__referred__list {
+.l-pace__referred__list,
+.l-pace-nav__items {
   list-style: none;
   padding: 0;
 }
 
-.l-pace__introduction__image,
-.l-pace__wellbeing__image,
-.l-pace__organisations__image {
+.l-pace__introduction__image__content,
+.l-pace__wellbeing__image__content,
+.l-pace__organisations__image__content {
   background-repeat: no-repeat;
   background-size: contain;
 }
 
-.l-pace__introduction__image {
+.l-pace__wellbeing {
+  @include respond-to($mq-m) {
+    background-color: $color-grey-pale;
+  }
+}
+
+.l-pace__wellbeing__inner {
+  @include respond-to($mq-m) {
+    display: flex;
+    align-items: stretch;
+  }
+}
+
+.l-pace__wellbeing__image,
+.l-pace__wellbeing__content {
+  @include respond-to($mq-m) {
+    @include column(6);
+  }
+}
+
+.l-pace__wellbeing__content {
+  @include respond-to($mq-m) {
+    display: flex;
+    align-items: center;
+    flex-direction: row;
+  }
+}
+
+.l-pace__wellbeing__image__content {
+  @include respond-to($mq-m) {
+    height: 100%;
+    background-size: cover;
+    background-position: center;
+  }
+}
+
+.l-pace-nav__items {
   @include column(12);
+
+  position: relative;
+  display: flex;
+  align-items: center;
+  margin-top: $baseline-unit;
+  margin-bottom: $baseline-unit;
+}
+
+.l-pace-nav__item {
+  margin: 0;
+  padding: $baseline-unit*3 10px;
+  font-size: 0.875rem;
+  font-weight: 700;
+}
+
+.l-pace-nav__item:first-child {
+  padding-left: 0;
+}
+
+.l-pace-nav__cta {
+  position: absolute;
+  right: 0;
+}
+
+.l-pace__introduction__content {
+  @include respond-to($mq-m) {
+    display: inline-flex;
+    align-items: baseline;
+    flex-direction: row-reverse;
+  }
+
+  @include respond-to($mq-l) {
+    display: inline-block;
+    position: relative;
+  }
+}
+
+.l-pace__introduction__image__content {
+  @include column(12);
+  @include respond-to($mq-m) {
+    width: 100%;
+    margin: 0;
+  }
 
   padding-top: 401/409*100%;
   background-image: image_url('pace/introduction.png');
 }
 
-.l-pace__wellbeing__image {
+.l-pace__wellbeing__image__content {
   padding-top: 370/570*100%;
   background-image: image_url('pace/wellbeing.png');
 }
 
-.l-pace__organisations__image {
+.l-pace__organisations__image__content {
   padding-top: 335/597*100%;
   background-image: image_url('pace/organisations.png');
 }
@@ -75,24 +289,101 @@
   background-color: $color-off-white;
 }
 
+.l-pace__introduction__panel {
+  @include respond-to($mq-m) {
+    @include column(8);
+  }
+}
+
+.l-pace__introduction__panel__content {
+  @include column(12);
+}
+
+.l-pace__introduction__image {
+  @include respond-to($mq-m) {
+    @include column(4);
+  }
+
+  @include respond-to($mq-l) {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+  }
+}
+
+.l-pace__help,
+.l-pace__advice {
+  @include respond-to($mq-m) {
+    position: relative;
+  }
+}
+
+.l-pace__help:before,
+.l-pace__advice:before {
+  @include respond-to($mq-m) {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: (22 / 16) + rem;
+    bottom: 0;
+    border-left: solid 3px $color-green-secondary;
+  }
+
+  @include respond-to($mq-l) {
+    top: (22 * 1.5) / 16 + rem;
+  }
+}
+
+.l-pace__help__content {
+  @include respond-to($mq-m) {
+    padding-bottom: 1.5rem;
+  }
+}
+
+.l-pace__advice__content {
+  @include respond-to($mq-m) {
+    padding-bottom: calc(45px + 1rem);
+  }
+}
+
+.l-pace__help__content,
+.l-pace__advice__content {
+  @include respond-to($mq-m) {
+    padding-left: 10px;
+  }
+}
+
+.l-pace__help__link,
+.l-pace__advice__organisations {
+  @include respond-to($mq-m) {
+    position: absolute;
+    bottom: 0;
+    margin-bottom: 0;
+  }
+}
+
+.l-pace__advice__organisation {
+  @include respond-to($mq-m) {
+    float: left;
+    margin: 0 10px 0 0;
+  }
+}
+
 .l-pace__advice__organisations__fca img,
 .l-pace__advice__organisations__hmgovernment img {
-  height: 50px;
+  height: 45px;
 }
 
 .l-pace__adviser__list {
   counter-reset: adviser;
-}
 
-.l-pace__adviser__list-item {
-  display: inline-block;
-
-  &:last-of-type .l-pace__adviser__list-item__content:before {
-    content: none;
+  @include respond-to($mq-m) {
+    @include column(12);
   }
 }
 
 .l-pace__adviser__list-item__heading {
+  position: relative;
   display: inline-block;
   background-color: $color-grey-pale;
   width: 100%;
@@ -112,6 +403,60 @@
     border-radius: 50%;
     color: $color-white;
     background-color: $color-green-secondary;
+
+    @include respond-to($mq-m) {
+      margin-left: $default-gutter * 3;
+      color: $color-green-secondary;
+      background-color: $color-white;
+    }
+  }
+
+  &:after {
+    @include respond-to($mq-m) {
+      position: absolute;
+      top: 0;
+      right: $default-gutter * -2;
+      z-index: 1;
+      content: '';
+      display: block;
+      width: $default-gutter * 4;
+      height: 98px;
+      background-image: image_url('pace/adviser_arrow.svg');
+      background-size: 100% 98px;
+      background-position: center;
+      background-repeat: no-repeat;
+    }
+  }
+}
+
+.l-pace__adviser__list-item {
+  display: inline-block;
+
+  &:first-of-type {
+    .l-pace__adviser__list-item__heading {
+      border-radius: $baseline-unit * 2 0 0 $baseline-unit * 2;
+    }
+  }
+
+  &:last-of-type {
+   .l-pace__adviser__list-item__content:before {
+      content: none;
+    }
+
+    .l-pace__adviser__list-item__heading {
+      border-radius: 0 $baseline-unit * 2 $baseline-unit * 2 0;
+
+      &:after {
+        @include respond-to($mq-m) {
+          content: none;
+        }
+      }
+    }
+  }
+
+  @include respond-to($mq-m) {
+    width: (1 / 3) * 100%;
+    float: left;
   }
 }
 
@@ -120,6 +465,11 @@
   align-items: center;
   height: 45px;
   padding: 0 $default-gutter;
+
+  @include respond-to($mq-m) {
+    padding-left: $default-gutter * 3;
+    padding-right: $default-gutter * 3;
+  }
 }
 
 .l-pace__adviser__list-item__content {
@@ -135,6 +485,19 @@
     top: calc(-0.5rem - 26.5px);
     height: calc(100% + 2.25rem + 53px);
     border-left: solid 4px $color-yellow-light;
+    z-index: 1;
+  }
+
+  @include respond-to($mq-m) {
+    width: 100%;
+    margin-left: 0;
+    margin-right: 0;
+    padding-left: $default-gutter * 3;
+    padding-right: $default-gutter * 3;
+
+    &:before {
+      content: none;
+    }
   }
 }
 
@@ -181,14 +544,67 @@
   background: $color-grey-pale;
 }
 
+.l-pace__organisations__inner {
+  @include respond-to($mq-m) {
+    width: 100%;
+    margin-left: 0;
+    margin-right: 0;
+  }
+}
+
+.l-pace__organisations__image,
+.l-pace__organisations__content {
+  @include respond-to($mq-m) {
+    @include column(6);
+  }
+}
+
+.l-pace__organisations__content {
+  @include respond-to($mq-l) {
+    @include column(7);
+  }
+}
+
+.l-pace__organisations__image {
+  @include respond-to($mq-m) {
+    float: right;
+  }
+
+  @include respond-to($mq-l) {
+    @include column(5);
+
+    float: right;
+  }
+}
+
+.l-pace__organisations__list {
+  @include respond-to($mq-m) {
+    float: left;
+    display: flex;
+    align-items: stretch;
+  }
+}
+
 .l-pace__organisations__list-item {
   @include clearfix();
 
   background: $color-white;
+
+  @include respond-to($mq-m) {
+    @include column(4);
+  }
 }
 
 .l-pace__organisations__list-item__content {
   @include column(12);
+
+  @include respond-to($mq-m) {
+    width: 100%;
+    margin-left: 0;
+    margin-right: 0;
+    padding-left: $default-gutter * 3;
+    padding-right: $default-gutter * 3;
+  }
 }
 
 .l-pace__organisations__list-item__header {
@@ -244,10 +660,18 @@
 
 .l-pace__referred__list-item {
   float: left;
-  width: 50%;
+  width: 100 / 2 * 1%;
   margin-bottom: 0;
   border-bottom: solid 1px $color-grey-pale;
   border-right: solid 1px $color-grey-pale;
+
+  @include respond-to($mq-m) {
+    width: 100 / 4 * 1%;
+  }
+
+  @include respond-to($mq-l) {
+    width: 100 / 6 * 1%;
+  }
 
   &.bristol-city-council .l-pace__referred__list-item__image {
     background-image: image_url('pace/bristol-city-council.jpg');
@@ -278,19 +702,47 @@
   }
 }
 
-.l-pace__referred__list-item:first-child,
+.l-pace__referred__list-item:nth-child(1),
 .l-pace__referred__list-item:nth-child(2) {
   border-top: solid 1px $color-grey-pale;
 }
 
-.l-pace__referred__list-item:nth-child(2n) {
-  border-right: none;
+.l-pace__referred__list-item:nth-child(3),
+.l-pace__referred__list-item:nth-child(4) {
+  @include respond-to($mq-m) {
+    border-top: solid 1px $color-grey-pale;
+  }
 }
 
-.l-pace__referred__list-item:last-child:nth-child(odd),
-.l-pace__referred__list-item:nth-last-child(2):nth-child(odd),
-.l-pace__referred__list-item:last-child:nth-child(even) {
-  border-bottom: none;
+.l-pace__referred__list-item:nth-child(5),
+.l-pace__referred__list-item:nth-child(6) {
+  @include respond-to($mq-l) {
+    border-top: solid 1px $color-grey-pale;
+  }
+}
+
+.l-pace__referred__list-item:nth-child(2n) {
+  border-right: none;
+
+  @include respond-to($mq-m) {
+    border-right: solid 1px $color-grey-pale;
+  }
+}
+
+.l-pace__referred__list-item:nth-child(4n) {
+  @include respond-to($mq-m) {
+    border-right: none;
+  }
+
+  @include respond-to($mq-l) {
+    border-right: solid 1px $color-grey-pale;
+  }
+}
+
+.l-pace__referred__list-item:nth-child(6n) {
+  @include respond-to($mq-l) {
+    border-right: none;
+  }
 }
 
 .l-pace__referred__list-item__image {
@@ -298,7 +750,7 @@
 
   margin-top: $baseline-unit * 2;
   margin-bottom: $baseline-unit * 2;
-  height: 50px;
+  height: 45px;
   background-repeat: no-repeat;
   background-position: center;
   background-size: contain;

--- a/app/views/layouts/pace.html.erb
+++ b/app/views/layouts/pace.html.erb
@@ -3,6 +3,8 @@
 
   <%= render 'pace/header' %>
 
+  <%= render 'pace/nav' %>
+
   <div class="l-pace">
     <main class="l-main__primary" role="main">
       <%= yield %>

--- a/app/views/pace/_advice.html.erb
+++ b/app/views/pace/_advice.html.erb
@@ -4,8 +4,9 @@
       <%= heading_tag t('pace.advice.heading'), level: 3, class: 'l-pace__advice__heading' %>
       <%= t('pace.advice.text_html') %>
       <ul class="l-pace__advice__organisations">
-        <li class="l-pace__advice__organisations__fca"><%= image_tag 'pace/fca.png' %></li>
-        <li class="l-pace__advice__organisations__hmgovernment"><%= image_tag 'pace/hmgovernment.png' %></li>
+        <% t('pace.advice.organisations').each do |organisation| %>
+          <li class="l-pace__advice__organisation l-pace__advice__organisations__<%= organisation[:imageclass] %>"><%= image_tag "pace/#{organisation[:imageclass]}.png" %></li>
+        <% end %>
       </ul>
     </div>
   </div>

--- a/app/views/pace/_adviser.html.erb
+++ b/app/views/pace/_adviser.html.erb
@@ -1,4 +1,4 @@
-<section class="l-pace__adviser">
+<section class="l-pace__adviser" id="<%= t('pace.nav.links')[0][:id] %>">
   <div class="l-constrained">
     <%= heading_tag t('pace.adviser.heading'), level: 3, class: 'l-pace__adviser__heading' %>
     <ol class="l-pace__adviser__list">

--- a/app/views/pace/_faqs.html.erb
+++ b/app/views/pace/_faqs.html.erb
@@ -1,4 +1,4 @@
-<section class="l-pace__faqs">
+<section class="l-pace__faqs" id="<%= t('pace.nav.links')[2][:id] %>">
   <div class="l-constrained">
     <div class="l-pace__faqs__content">
       <%= heading_tag t('pace.faqs.heading'), level: 3 %>

--- a/app/views/pace/_header.html.erb
+++ b/app/views/pace/_header.html.erb
@@ -1,9 +1,11 @@
-<header class="l-header" role="banner">
+<header class="l-header l-pace__header" role="banner">
   <div class="l-constrained l-header__content">
     <div class="mas-logo">
       <%= link_to main_app.root_path, class: 'mas-logo__link' do %>
         <%= image_tag("logo-sprite-#{I18n.locale}.png", alt: t('layouts.base.title'), class: 'mas-logo__img') %>
       <% end %>
     </div>
+
+    <div class="l-header__strapline"><%= t('layouts.base.strapline') %></div>
   </div>
 </header>

--- a/app/views/pace/_help.html.erb
+++ b/app/views/pace/_help.html.erb
@@ -3,7 +3,7 @@
     <div class="l-pace__help__content">
       <%= heading_tag t('pace.help.heading'), level: 3, class: 'l-pace__help__heading' %>
       <%= t('pace.help.text_html') %>
-      <p>
+      <p class="l-pace__help__link">
         <%= link_to t('pace.help.link'), '#online_advice' %>
       </p>
     </div>

--- a/app/views/pace/_introduction.html.erb
+++ b/app/views/pace/_introduction.html.erb
@@ -1,11 +1,15 @@
 <section class="l-pace__introduction">
   <div class="l-constrained">
     <%= heading_tag t('pace.introduction.heading'), level: 1, class: 'l-pace__introduction__heading' %>
-    <div class="l-pace__introduction__image"></div>
-    <div class="l-pace__introduction__panel">
-      <div class="l-pace__introduction__panel__content">
-        <%= heading_tag t('pace.introduction.subhead'), level: 2 %>
-        <p><%= t('pace.introduction.text') %></p>
+    <div class="l-pace__introduction__content">
+      <div class="l-pace__introduction__image">
+        <div class="l-pace__introduction__image__content"></div>
+      </div>
+      <div class="l-pace__introduction__panel">
+        <div class="l-pace__introduction__panel__content">
+          <%= heading_tag t('pace.introduction.subhead'), level: 2 %>
+          <p><%= t('pace.introduction.text') %></p>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/pace/_nav.html.erb
+++ b/app/views/pace/_nav.html.erb
@@ -1,0 +1,19 @@
+<nav class="l-pace-nav" role="navigation">
+  <div class="l-constrained">
+    <ul class="l-pace-nav__items">
+      <% t('pace.nav.links').each do |link| %>
+        <li class="l-pace-nav__item">
+          <a href="#<%= link[:id] %>"><%= link[:text] %></a>
+        </li>
+      <% end %>
+
+      <li class="l-pace-nav__cta">
+        <a class="button" href="https://www.stepchange.org/start.aspx" target="_blank">
+          <%= t('pace.nav.CTA') %>
+        </a>
+
+        <span class="visually-hidden"><%= t('pace.new_window') %></span>
+      </li>
+    </ul>
+  </div>
+</nav>

--- a/app/views/pace/_online_advice.html.erb
+++ b/app/views/pace/_online_advice.html.erb
@@ -1,9 +1,16 @@
 <section class="l-pace__online_advice" id="online_advice">
   <div class="l-constrained">
-    <div class="l-pace__online_advice__content">
+    <div class="l-pace__online_advice__inner">
       <%= heading_tag t('pace.online_advice.heading'), level: 3, class: 'l-pace__online_advice__heading' %>
-      <%= t('pace.online_advice.text_html') %>
-      <button class="button"><%= t('pace.online_advice.button') %></button>
+      <div class="l-pace__online_advice__content">
+        <%= t('pace.online_advice.text_html') %>
+      </div>
+
+      <a class="button l-pace__online_advice__cta" href="https://www.stepchange.org/start.aspx" target="_blank">
+        <%= t('pace.nav.CTA') %>
+      </a>
+
+      <span class="visually-hidden"><%= t('pace.new_window') %></span>
     </div>
   </div>
 </section>

--- a/app/views/pace/_organisations.html.erb
+++ b/app/views/pace/_organisations.html.erb
@@ -1,9 +1,15 @@
-<section class="l-pace__organisations">
+<section class="l-pace__organisations" id="<%= t('pace.nav.links')[1][:id] %>">
   <div class="l-constrained">
-    <div class="l-pace__organisations__content">
-      <div class="l-pace__organisations__image"></div>
-      <%= heading_tag t('pace.organisations.heading'), level: 3 %>
-      <p><%= t('pace.organisations.text') %></p>
+    <div class="l-pace__organisations__inner">
+      <div class="l-pace__organisations__image">
+        <div class="l-pace__organisations__image__content"></div>
+      </div>
+
+      <div class="l-pace__organisations__content">
+        <%= heading_tag t('pace.organisations.heading'), level: 3 %>
+        <p><%= t('pace.organisations.text') %></p>
+      </div>
+
       <ul class="l-pace__organisations__list">
         <% t('pace.organisations.list').each do |listitem| %>
           <li class="l-pace__organisations__list-item">

--- a/app/views/pace/_privacy.html.erb
+++ b/app/views/pace/_privacy.html.erb
@@ -1,4 +1,4 @@
-<section class="l-pace__privacy">
+<section class="l-pace__privacy" id="<%= t('pace.nav.links')[3][:id] %>">
   <div class="l-constrained">
     <div class="l-pace__privacy__content">
       <%= heading_tag t('pace.privacy.heading'), level: 3, class: 'l-pace__privacy__heading' %>

--- a/app/views/pace/_wellbeing.html.erb
+++ b/app/views/pace/_wellbeing.html.erb
@@ -1,9 +1,13 @@
 <section class="l-pace__wellbeing">
-  <div class="l-constrained">
-    <div class="l-pace__wellbeing__image"></div>
+  <div class="l-constrained l-pace__wellbeing__inner">
+    <div class="l-pace__wellbeing__image">
+      <div class="l-pace__wellbeing__image__content"></div>
+    </div>
     <div class="l-pace__wellbeing__content">
-      <%= heading_tag t('pace.wellbeing.heading'), level: 3, class: 'l-pace__wellbeing__heading' %>
-      <%= t('pace.wellbeing.text_html') %>
+      <div>
+        <%= heading_tag t('pace.wellbeing.heading'), level: 3, class: 'l-pace__wellbeing__heading' %>
+        <%= t('pace.wellbeing.text_html') %>
+      </div>
     </div>
   </div>
 </section>

--- a/app/views/pace/show.html.erb
+++ b/app/views/pace/show.html.erb
@@ -1,8 +1,12 @@
 <% set_meta_tags(title: 'PACE') %>
 
 <%= render 'pace/introduction' %>
-<%= render 'pace/help' %>
-<%= render 'pace/advice' %>
+
+<div class="l-constrained l-pace__2-section">
+  <%= render 'pace/help' %>
+  <%= render 'pace/advice' %>
+</div>
+
 <%= render 'pace/wellbeing' %>
 <%= render 'pace/adviser' %>
 <%= render 'pace/online_advice' %>

--- a/config/locales/pace.en.yml
+++ b/config/locales/pace.en.yml
@@ -1,5 +1,16 @@
 en:
   pace:
+    nav:
+      links:
+        - id: how-it-works
+          text: How it works
+        - id: advice-organisations
+          text: Advice organisations
+        - id: faqs
+          text: FAQs
+        - id: your-data
+          text: Your data
+      CTA: Get online advice now
     introduction:
       heading: Independent, confidential and impartial money advice
       subhead: The National Money Advice Network
@@ -13,6 +24,9 @@ en:
       heading: Advice you can trust
       text_html: <p>The network is run by the Money Advice Service, a UK government body that helps you access free, confidential and impartial debt advice.</p>
                  <p>All the debt advice services we partner with hold a standard or membership code accredited by the Money Advice Service and the Financial Conduct Authority.</p>
+      organisations:
+        - imageclass: fca
+        - imageclass: hmgovernment
     wellbeing:
       heading: Improving your wellbeing
       text_html: <p>Money worries can take over your life and seriously affect your mental health and relationships.</p>
@@ -102,3 +116,4 @@ en:
       heading: Your data and privacy
       text: Your privacy is extremely important to us. We don’t pass your details to anyone outside our network. Within our network we only pass on your contact details to the debt advice agency we connect you with. This speeds up the process and you won’t have to repeat your story every time you speak to someone.
       link: Read our Privacy Policy
+    new_window: opens in a new window


### PR DESCRIPTION
[TP11045](https://maps.tpondemand.com/entity/11045-pace-create-markup-and-styles-for)

This work adds responsive styles to the PACE landing page to render the layout at larger viewport sizes. 

The design for this can be viewed [here](https://app.zeplin.io/project/5e15b2a4bb77ef7e89ba6be6/screen/5e15b2fdc022025335237932). 

If this is pulled to a local environment it is viewable at localhost:xxxx/en/pace
