### PR TITLE
11044 pace page behaviour

### DIFF
--- a/app/assets/stylesheets/layout/page_specific/_pace.scss
+++ b/app/assets/stylesheets/layout/page_specific/_pace.scss
@@ -5,7 +5,7 @@
 .l-pace__online_advice__content,
 .l-pace__faqs__content,
 .l-pace__organisations__content,
-.l-pace__referred__content,
+.l-pace__referred__inner,
 .l-pace__privacy__content {
   @include column(12);
 }
@@ -142,16 +142,38 @@
   @include clearfix();
 
   border: solid 2px $color-yellow-light;
+
+  .js & {
+    .collapsable__trigger-icon {
+      right: $baseline-unit;
+      top: 50%;
+      margin-right: 0;
+      transform: translateY(-6px);
+    }
+  }
 }
 
 .l-pace__faqs__list__heading {
   background: $color-grey-pale;
   margin-top: 0;
+  margin-bottom: 0;
   padding: $baseline-unit;
+
+  .js & {
+    padding-right: calc(#{$baseline-unit * 2} + 18px);
+  }
 }
 
 .l-pace__faqs__list__content {
   @include column(12);
+
+  .js & {
+    display: none;
+
+    &.is-active {
+      display: block;
+    }
+  }
 }
 
 .l-pace__organisations,
@@ -187,14 +209,37 @@
   }
 }
 
-.l-pace__referred__content {
+.l-pace__referred__inner {
   background: $color-white;
   border: solid 2px $color-yellow-light;
   margin-bottom: $baseline-unit*4;
+
+  .js & {
+    .collapsable__trigger-icon {
+      right: $baseline-unit;
+      top: 50%;
+      margin-right: 0;
+      transform: translateY(-6px);
+    }
+  }
 }
 
 .l-pace__referred__heading {
   @include column(12);
+
+  .js & {
+    padding-right: calc(#{$baseline-unit} + 18px);
+  }
+}
+
+.l-pace__referred__content {
+  .js & {
+    display: none;
+
+    &.is-active {
+      display: block;
+    }
+  }
 }
 
 .l-pace__referred__list-item {

--- a/app/views/pace/_faqs.html.erb
+++ b/app/views/pace/_faqs.html.erb
@@ -4,9 +4,20 @@
       <%= heading_tag t('pace.faqs.heading'), level: 3 %>
       <ul class="l-pace__faqs__list">
         <% t('pace.faqs.list').each do |listitem| %>
-          <li class="l-pace__faqs__list-item">
-            <%= heading_tag listitem[:heading], level: 4, class: 'l-pace__faqs__list__heading' %>
-            <div class="l-pace__faqs__list__content">
+          <li
+            class="l-pace__faqs__list-item"
+          >
+            <div
+              data-dough-component="Collapsable"
+              data-dough-collapsable-config='{"iconPosition":"right","oneGroupOpenOnly":"true","focusTarget":false}'
+              data-dough-collapsable-trigger="<%= listitem[:id] %>">
+              <%= heading_tag listitem[:heading], level: 4, class: 'l-pace__faqs__list__heading' %>
+            </div>
+
+            <div
+              class="l-pace__faqs__list__content"
+              data-dough-collapsable-target="<%= listitem[:id] %>"
+            >
               <p><%= listitem[:content] %></p>
             </div>
           </li>

--- a/app/views/pace/_referred.html.erb
+++ b/app/views/pace/_referred.html.erb
@@ -1,15 +1,26 @@
 <section class="l-pace__referred">
   <div class="l-constrained">
-    <div class="l-pace__referred__content">
-      <%= heading_tag t('pace.referred.heading'), level: 3, class: 'l-pace__referred__heading' %>
-      <ul class="l-pace__referred__list">
-        <% t('pace.referred.list').each do |listitem| %>
-          <li class="l-pace__referred__list-item <%= "#{listitem[:imageclass]}" %>">
-            <div class="l-pace__referred__list-item__image"></div>
-            <span class="visually-hidden"><%= "#{listitem[:name]}" %></span>
-          </li>
-        <% end %>
-      </ul>
+    <div class="l-pace__referred__inner">
+      <div
+        data-dough-component="Collapsable"
+        data-dough-collapsable-config='{"iconPosition":"right","oneGroupOpenOnly":"true","focusTarget":false}'
+        data-dough-collapsable-trigger="<% t('pace.referred.id') %>">
+        <%= heading_tag t('pace.referred.heading'), level: 3, class: 'l-pace__referred__heading' %>
+      </div>
+
+      <div
+        class="l-pace__referred__content"
+        data-dough-collapsable-target="<% t('pace.referred.id') %>"
+      >
+        <ul class="l-pace__referred__list">
+          <% t('pace.referred.list').each do |listitem| %>
+            <li class="l-pace__referred__list-item <%= "#{listitem[:imageclass]}" %>">
+              <div class="l-pace__referred__list-item__image"></div>
+              <span class="visually-hidden"><%= "#{listitem[:name]}" %></span>
+            </li>
+          <% end %>
+        </ul>
+      </div>
     </div>
   </div>
 </section>

--- a/config/locales/pace.en.yml
+++ b/config/locales/pace.en.yml
@@ -37,25 +37,35 @@ en:
     faqs:
       heading: Frequently asked questions
       list:
-        - heading: What information will I have to provide?
+        - id: what-information-will-i-have-to-provide
+          heading: What information will I have to provide?
           content: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eu quam eget erat tempus egestas a vel nibh. Aliquam interdum velit leo, non molestie lectus ullamcorper id. Duis quis vulputate urna, id bibendum eros. Vivamus elementum laoreet dui quis imperdiet. Quisque magna ligula, finibus ac egestas quis, porttitor id ante. Sed eu orci non nunc tempor condimentum.
-        - heading: Is it private/ confidential?
+        - id: is-it-private-confidential
+          heading: Is it private/confidential?
           content: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eu quam eget erat tempus egestas a vel nibh. Aliquam interdum velit leo, non molestie lectus ullamcorper id. Duis quis vulputate urna, id bibendum eros. Vivamus elementum laoreet dui quis imperdiet. Quisque magna ligula, finibus ac egestas quis, porttitor id ante. Sed eu orci non nunc tempor condimentum.
-        - heading: What options will be open to me?
+        - id: what-options-will-be-open-to-me
+          heading: What options will be open to me?
           content: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eu quam eget erat tempus egestas a vel nibh. Aliquam interdum velit leo, non molestie lectus ullamcorper id. Duis quis vulputate urna, id bibendum eros. Vivamus elementum laoreet dui quis imperdiet. Quisque magna ligula, finibus ac egestas quis, porttitor id ante. Sed eu orci non nunc tempor condimentum.
-        - heading: Will debt advice affect my credit score?
+        - id: will-debt-advice-affect-my-credit-score
+          heading: Will debt advice affect my credit score?
           content: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eu quam eget erat tempus egestas a vel nibh. Aliquam interdum velit leo, non molestie lectus ullamcorper id. Duis quis vulputate urna, id bibendum eros. Vivamus elementum laoreet dui quis imperdiet. Quisque magna ligula, finibus ac egestas quis, porttitor id ante. Sed eu orci non nunc tempor condimentum.
-        - heading: Could I lose my home or other possessions?
+        - id: could-i-lose-my-home-or-other-possessions
+          heading: Could I lose my home or other possessions?
           content: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eu quam eget erat tempus egestas a vel nibh. Aliquam interdum velit leo, non molestie lectus ullamcorper id. Duis quis vulputate urna, id bibendum eros. Vivamus elementum laoreet dui quis imperdiet. Quisque magna ligula, finibus ac egestas quis, porttitor id ante. Sed eu orci non nunc tempor condimentum.
-        - heading: Will I have to pay for the service?
+        - id: will-i-have-to-pay-for-the-service
+          heading: Will I have to pay for the service?
           content: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eu quam eget erat tempus egestas a vel nibh. Aliquam interdum velit leo, non molestie lectus ullamcorper id. Duis quis vulputate urna, id bibendum eros. Vivamus elementum laoreet dui quis imperdiet. Quisque magna ligula, finibus ac egestas quis, porttitor id ante. Sed eu orci non nunc tempor condimentum.
-        - heading: Is it a quality service?
+        - id: is-it-a-quality-service
+          heading: Is it a quality service?
           content: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eu quam eget erat tempus egestas a vel nibh. Aliquam interdum velit leo, non molestie lectus ullamcorper id. Duis quis vulputate urna, id bibendum eros. Vivamus elementum laoreet dui quis imperdiet. Quisque magna ligula, finibus ac egestas quis, porttitor id ante. Sed eu orci non nunc tempor condimentum.
-        - heading: Who do debt advisers work for and will they really do what’s best for me?
+        - id: who-do-debt-advisers-work-for-and-will-they-really-do-whats-best-for-me
+          heading: Who do debt advisers work for and will they really do what’s best for me?
           content: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eu quam eget erat tempus egestas a vel nibh. Aliquam interdum velit leo, non molestie lectus ullamcorper id. Duis quis vulputate urna, id bibendum eros. Vivamus elementum laoreet dui quis imperdiet. Quisque magna ligula, finibus ac egestas quis, porttitor id ante. Sed eu orci non nunc tempor condimentum.
-        - heading: I’m afraid I will be judged
+        - id: im-afraid-i-will-be-judged
+          heading: I’m afraid I will be judged
           content: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eu quam eget erat tempus egestas a vel nibh. Aliquam interdum velit leo, non molestie lectus ullamcorper id. Duis quis vulputate urna, id bibendum eros. Vivamus elementum laoreet dui quis imperdiet. Quisque magna ligula, finibus ac egestas quis, porttitor id ante. Sed eu orci non nunc tempor condimentum.
-        - heading: I also need help with other issues (e.g. benefits, housing) - can they help with those?
+        - id: i-also-need-help-with-other-issues-can-they-help-with-those
+          heading: I also need help with other issues (e.g. benefits, housing) - can they help with those?
           content: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eu quam eget erat tempus egestas a vel nibh. Aliquam interdum velit leo, non molestie lectus ullamcorper id. Duis quis vulputate urna, id bibendum eros. Vivamus elementum laoreet dui quis imperdiet. Quisque magna ligula, finibus ac egestas quis, porttitor id ante. Sed eu orci non nunc tempor condimentum.
     organisations:
       heading: The advice organisations that will help you
@@ -71,6 +81,7 @@ en:
           name: StepChange
           text: We provide the UK’s most comprehensive debt advice service. We help people with debt problems take back control of their finances and their lives.
     referred:
+      id: referred
       heading: How referred you
       list:
         - imageclass: bristol-city-council


### PR DESCRIPTION
[TP11044](https://maps.tpondemand.com/entity/11044-pace-add-page-behaviour-for-the)

This work adds the Dough Collapsable component to the FAQs and Referral sections of the page to add collapse/expand behaviours. These are all fully expanded in a non-JavaScript environment and all closed otherwise on initial page load. 

**FAQs, collapsed**

![image](https://user-images.githubusercontent.com/6080548/73462071-1cb2c780-4373-11ea-9175-01c8088bd4b8.png)

**FAQs, expanded**

![image](https://user-images.githubusercontent.com/6080548/73462102-276d5c80-4373-11ea-8ae0-2848c41ab4e9.png)

**Referrals, collapsed**

![image](https://user-images.githubusercontent.com/6080548/73462174-44099480-4373-11ea-8253-8c60f88f23a6.png)

**Referrals, expanded**

![image](https://user-images.githubusercontent.com/6080548/73462188-4a980c00-4373-11ea-9655-04a9ecf5aeaf.png)
