### PR TITLE
[DEV APPROVED] Updates PACE URL

### DIFF
--- a/app/views/pace/_privacy.html.erb
+++ b/app/views/pace/_privacy.html.erb
@@ -4,7 +4,7 @@
       <%= heading_tag t('pace.privacy.heading'), level: 3, class: 'l-pace__privacy__heading' %>
       <p><%= t('pace.privacy.text') %></p>
       <p>
-        <%= link_to t('pace.privacy.link'), 'pace/privacy' %>
+        <%= link_to t('pace.privacy.link'), t('pace.privacy.url') %>
       </p>
     </div>
   </div>

--- a/config/locales/pace.en.yml
+++ b/config/locales/pace.en.yml
@@ -116,4 +116,5 @@ en:
       heading: Your data and privacy
       text: Your privacy is extremely important to us. We don’t pass your details to anyone outside our network. Within our network we only pass on your contact details to the debt advice agency we connect you with. This speeds up the process and you won’t have to repeat your story every time you speak to someone.
       link: Read our Privacy Policy
+      url: moneyadvisernetwork/privacy
     new_window: opens in a new window

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -166,8 +166,8 @@ Rails.application.routes.draw do
     get '/employer-best-practices/other-employers', to: 'employer_best_practices#other_employers'
 
     # PACE
-    get '/pace', to: 'pace#show'
-    get '/pace/privacy', to: 'pace#privacy'
+    get '/moneyadvisernetwork', to: 'pace#show'
+    get '/moneyadvisernetwork/privacy', to: 'pace#privacy'
 
     resource :feedback, only: [:new, :create], controller: :technical_feedback, as: :technical_feedback
 


### PR DESCRIPTION
[TP11118](https://maps.tpondemand.com/entity/11118-pace-add-mas-url-for-pace)

The final URL for the PACE microsite has now been decided upon so this work updates that from `/pace` to `/moneyadvisernetwork`. 

Additionally there is a change to add the URL to the translation file to facilitate easier re-use.

The final URLs will now be 
- https://www.moneyadviceservice.org.uk/en/moneyadvisernetwork
- https://www.moneyadviceservice.org.uk/en/moneyadvisernetwork/privacy
