### PR TITLE
[DEV APPROVED] Adds the PACE privacy URL to the robots.txt file 

### DIFF
--- a/app/views/sitemap/robots.text.erb
+++ b/app/views/sitemap/robots.text.erb
@@ -9,6 +9,8 @@ Disallow: /en/tools/credit-card-calculator-beta
 Disallow: /cy/tools/cyfrifiannell-cerdyn-credyd-beta
 Disallow: /en/polls/
 Disallow: /cy/polls/
+Disallow: /en/moneyadvisernetwork/privacy
+Disallow: /cy/moneyadvisernetwork/privacy
 
 User-Agent: Atomz
 Disallow: /


### PR DESCRIPTION
[TP11015](https://maps.tpondemand.com/entity/11015-pace-add-privacy-policy-page-link)

This card is concerned with the Privacy Policy page, though most of the expectations within it have been met in previous cards:
- the link to the Privacy Policy page has already been added
- the template for the page itself has already been set up

So this work confines itself to the aspect of the Acceptance Criteria that relates to the requirement that this page is not logged by Search Engines. 

This is done by adding the URL to the robots.txt file, listing both `en` and `cy` versions: both will be legitimate URLs even though there is no Welsh language content at this time. 