### PR TITLE
[DEV APPROVED] 11111 pace tagging

### DIFF
--- a/app/views/pace/_faqs.html.erb
+++ b/app/views/pace/_faqs.html.erb
@@ -10,8 +10,9 @@
             <div
               data-dough-component="Collapsable"
               data-dough-collapsable-config='{"iconPosition":"right","oneGroupOpenOnly":"true","focusTarget":false}'
-              data-dough-collapsable-trigger="<%= listitem[:id] %>">
-              <%= heading_tag listitem[:heading], level: 4, class: 'l-pace__faqs__list__heading' %>
+              data-dough-collapsable-trigger="<%= listitem[:id] %>"
+            >
+              <%= heading_tag listitem[:heading], level: 4, class: 'l-pace__faqs__list__heading', id: 'faq_' + listitem[:id] %>
             </div>
 
             <div

--- a/app/views/pace/_nav.html.erb
+++ b/app/views/pace/_nav.html.erb
@@ -8,7 +8,7 @@
       <% end %>
 
       <li class="l-pace-nav__cta">
-        <a class="button" href="https://www.stepchange.org/start.aspx" target="_blank">
+        <a class="button" href="https://www.stepchange.org/start.aspx" target="_blank" id="cta_nav">
           <%= t('pace.nav.CTA') %>
         </a>
 

--- a/app/views/pace/_online_advice.html.erb
+++ b/app/views/pace/_online_advice.html.erb
@@ -6,7 +6,7 @@
         <%= t('pace.online_advice.text_html') %>
       </div>
 
-      <a class="button l-pace__online_advice__cta" href="https://www.stepchange.org/start.aspx" target="_blank">
+      <a class="button l-pace__online_advice__cta" href="https://www.stepchange.org/start.aspx" target="_blank" id="cta_online-advice">
         <%= t('pace.nav.CTA') %>
       </a>
 

--- a/app/views/pace/_organisations.html.erb
+++ b/app/views/pace/_organisations.html.erb
@@ -12,7 +12,7 @@
 
       <ul class="l-pace__organisations__list">
         <% t('pace.organisations.list').each do |listitem| %>
-          <li class="l-pace__organisations__list-item">
+          <li class="l-pace__organisations__list-item" id="organisations_<%= listitem[:imageclass] %>">
             <div class="l-pace__organisations__list-item__content">
               <%= heading_tag level: 4, class: "l-pace__organisations__list-item__header #{listitem[:imageclass]}" do %>
                 <span class="visually-hidden"><%= "#{listitem[:name]}" %></span>

--- a/app/views/pace/_referred.html.erb
+++ b/app/views/pace/_referred.html.erb
@@ -5,7 +5,7 @@
         data-dough-component="Collapsable"
         data-dough-collapsable-config='{"iconPosition":"right","oneGroupOpenOnly":"true","focusTarget":false}'
         data-dough-collapsable-trigger="<% t('pace.referred.id') %>">
-        <%= heading_tag t('pace.referred.heading'), level: 3, class: 'l-pace__referred__heading' %>
+        <%= heading_tag t('pace.referred.heading'), level: 3, class: 'l-pace__referred__heading', id: 'referred' %>
       </div>
 
       <div


### PR DESCRIPTION
[TP11111](https://maps.tpondemand.com/entity/11111-pace-microsite-tagging)

This work adds unique identifiers to a number of elements on the page so that user engagement with them can be tracked. The elements requiring tracking are: 
- Each of the expandable FAQs headers
![image](https://user-images.githubusercontent.com/6080548/74045911-83646080-49c5-11ea-88a1-0f072198523b.png)

- The header of the expandable "How referred you" section
![image](https://user-images.githubusercontent.com/6080548/74045991-a55de300-49c5-11ea-9856-13721f01fcbd.png)

- Each of the boxes in the "The advice organisations that will help you" section
![image](https://user-images.githubusercontent.com/6080548/74046141-ed7d0580-49c5-11ea-933d-aaebcaab4679.png)

- Each of the "Get online advice" Call to Actions
![image](https://user-images.githubusercontent.com/6080548/74046257-2321ee80-49c6-11ea-9b87-387c391dd93e.png)
![image](https://user-images.githubusercontent.com/6080548/74046303-35039180-49c6-11ea-99f3-62a67a4c2b37.png)
