### PR TITLE
[DEV APPROVED] 11248 pace update title tag

### DIFF
--- a/app/views/pace/privacy.html.erb
+++ b/app/views/pace/privacy.html.erb
@@ -1,3 +1,3 @@
-<% set_meta_tags(title: 'PACE') %>
+<% set_meta_tags(title: t('pace.title')) %>
 
 PACE Privacy page

--- a/app/views/pace/show.html.erb
+++ b/app/views/pace/show.html.erb
@@ -1,4 +1,4 @@
-<% set_meta_tags(title: 'PACE') %>
+<% set_meta_tags(title: t('pace.title')) %>
 
 <%= render 'pace/introduction' %>
 

--- a/config/locales/pace.en.yml
+++ b/config/locales/pace.en.yml
@@ -1,5 +1,6 @@
 en:
   pace:
+    title: Money Adviser Network
     nav:
       links:
         - id: how-it-works


### PR DESCRIPTION
[TP11248](https://maps.tpondemand.com/entity/11248-pace-change-the-tab-bar-title)

This is a simple change to update the the `<title>` tag from 'PACE' to 'Money Adviser Network' on both the landing and privacy pages. It also adds the title text to the translation file for reusability. 
