### PR TITLE
[DEV APPROVED] Updates styles to display logos in referred section

### DIFF
--- a/app/assets/stylesheets/layout/page_specific/_pace.scss
+++ b/app/assets/stylesheets/layout/page_specific/_pace.scss
@@ -17,15 +17,15 @@
     width: 100%;
     margin-bottom: $baseline-unit * 4;
 
+    &.l-pace__organisations {
+      margin-bottom: 0;
+      padding-bottom: $baseline-unit * 4;
+    }
+
     @include respond-to($mq-m) {
       &.l-pace__help,
       &.l-pace__advice {
         @include column(6);
-      }
-
-      &.l-pace__organisations {
-        margin-bottom: 0;
-        padding-bottom: $baseline-unit * 4;
       }
     }
   }
@@ -74,7 +74,7 @@
 .l-pace__online_advice__inner,
 .l-pace__faqs__content,
 .l-pace__organisations__inner,
-.l-pace__referred__content,
+.l-pace__referred__inner,
 .l-pace__privacy__content {
   @include column(12);
 }
@@ -643,12 +643,16 @@
 .l-pace__referred__heading {
   @include column(12);
 
+  margin-top: $baseline-unit * 2;
+
   .js & {
     padding-right: calc(#{$baseline-unit} + 18px);
   }
 }
 
 .l-pace__referred__content {
+  @include clearfix;
+
   .js & {
     display: none;
 
@@ -656,6 +660,10 @@
       display: block;
     }
   }
+}
+
+.l-pace__referred__list {
+  margin-top: 0;
 }
 
 .l-pace__referred__list-item {


### PR DESCRIPTION
[TP11240](https://maps.tpondemand.com/entity/11240-pace-logos-on-who-referred-you)

This work updates the display of the "Who referred you?" section. Some styling has been broken in the development process leading to problems with the display of the logos in this section:
- they display against a grey, rather than white, background
- the horizontal spacing across the whole section is wrongly rendered against the design.

The stylesheet has been updated to improve this. 

**Current:** 

![image](https://user-images.githubusercontent.com/6080548/75034360-f9c49080-54a4-11ea-95ec-f9b9832f7e32.png)

**Updated:** 

![image](https://user-images.githubusercontent.com/6080548/75034090-54a9b800-54a4-11ea-80ee-3835c86dbc62.png)
