### PR TITLE
[DEV APPROVED] Temporarily removes 'referred' section

### DIFF
--- a/app/views/pace/show.html.erb
+++ b/app/views/pace/show.html.erb
@@ -16,7 +16,7 @@
     <%= render 'pace/online_advice' %>
     <%= render 'pace/faqs' %>
     <%= render 'pace/organisations' %>
-    <%= render 'pace/referred' %>
+    <%# render 'pace/referred' %>
     <%= render 'pace/privacy' %>
   </main>
 </div>


### PR DESCRIPTION
[TP11280](https://maps.tpondemand.com/entity/11280-pace-remove-who-referred-you-section)

This work temporarily removes the section headed 'Who referred you'. Since this will be restored to the page at the earliest opportunity this change simply comments out a section of the main view so that the partial for this section is not rendered. 

**On production:** 

![image](https://user-images.githubusercontent.com/6080548/77165708-c3316400-6aaa-11ea-978e-8432a3cd4b7f.png)

**Updated in this PR:** 

![image](https://user-images.githubusercontent.com/6080548/77165745-d17f8000-6aaa-11ea-8d27-7b8be4e2d5b7.png)
