### PR TITLE
11363 sticky banner coronavirus info

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ gem 'whenever', require: false
 # Dependencies
 gem 'adal', git: 'git@github.com:moneyadviceservice/azure-activedirectory-library-for-ruby'
 gem 'cream', '2.1.8'
-gem 'dough-ruby', '~> 5.39'
+gem 'dough-ruby', git: 'git@github.com:moneyadviceservice/dough.git', branch: '11363_Sticky-banner_Coronavirus-info_v5.39'
 gem 'mas-cms-client', '1.20.0'
 gem 'site_search', '0.3.0'
 # Tools

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,17 @@ GIT
       nokogiri (~> 1.6)
       uri_template (~> 0.7)
 
+GIT
+  remote: git@github.com:moneyadviceservice/dough.git
+  revision: 029a3600a809e047ea16608186c889b91d2de4e0
+  branch: 11363_Sticky-banner_Coronavirus-info_v5.39
+  specs:
+    dough-ruby (5.39.0)
+      activemodel
+      activesupport
+      rails (>= 3.2, < 5.1.0)
+      sass-rails
+
 GEM
   remote: https://rubygems.org/
   remote: http://gems.dev.mas.local/
@@ -283,11 +294,6 @@ GEM
     dotenv-rails (2.2.1)
       dotenv (= 2.2.1)
       railties (>= 3.2, < 5.2)
-    dough-ruby (5.39.0)
-      activemodel
-      activesupport
-      rails (>= 3.2, < 5.1.0)
-      sass-rails
     dragonfly (1.2.0)
       addressable (~> 2.3)
       multi_json (~> 1.0)
@@ -817,7 +823,7 @@ DEPENDENCIES
   devise-encryptable
   dotenv
   dotenv-rails
-  dough-ruby (~> 5.39)
+  dough-ruby!
   draper (< 3)
   ejs
   email_spec (< 2)

--- a/app/assets/javascripts/require_config.js.erb
+++ b/app/assets/javascripts/require_config.js.erb
@@ -27,6 +27,7 @@
 //= depend_on_asset dough/assets/js/components/SearchFocus
 //= depend_on_asset dough/assets/js/components/ChatPopup
 //= depend_on_asset dough/assets/js/components/BackToTop
+//= depend_on_asset dough/assets/js/components/CovidBanner
 //= depend_on_asset dough/assets/js/components/DoughBaseComponent
 //= depend_on_asset dough/assets/js/components/PopupTip
 //= depend_on_asset dough/assets/js/components/RangeInput
@@ -110,6 +111,7 @@
     SearchFocus: requirejs_path('dough/assets/js/components/SearchFocus'),
     ChatPopup: requirejs_path('dough/assets/js/components/ChatPopup'),
     BackToTop: requirejs_path('dough/assets/js/components/BackToTop'),
+    CovidBanner: requirejs_path('dough/assets/js/components/CovidBanner'),
     Collapsable: requirejs_path('dough/assets/js/components/Collapsable'),
     CollapsableMobile: requirejs_path('dough/assets/js/components/CollapsableMobile'),
     DoughBaseComponent: requirejs_path('dough/assets/js/components/DoughBaseComponent'),

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,6 +15,8 @@ class ApplicationController < ActionController::Base
   include NotFound
   COOKIE_MESSAGE_COOKIE_NAME = '_cookie_notice'.freeze
   COOKIE_MESSAGE_COOKIE_VALUE = 'y'.freeze
+  BANNER_DISMISSED_COOKIE_NAME = '_covid_banner'.freeze
+  BANNER_DISMISSED_COOKIE_VALUE = 'y'.freeze
 
   before_action :fetch_footer_content
   def fetch_footer_content
@@ -44,6 +46,12 @@ class ApplicationController < ActionController::Base
   end
 
   helper_method :cookies_not_accepted?
+
+  def covid_banner_dismissed?
+    cookies.permanent[BANNER_DISMISSED_COOKIE_NAME] != BANNER_DISMISSED_COOKIE_VALUE
+  end
+
+  helper_method :covid_banner_dismissed?
 
   def display_search_box_in_header?
     true

--- a/app/views/layouts/_application_shared.html.erb
+++ b/app/views/layouts/_application_shared.html.erb
@@ -13,6 +13,10 @@
   <%= render 'shared/no_js_nav' %>
   <%= render 'shared/global_nav' %>
 
+  <% if covid_banner_dismissed? %>
+    <%= render 'shared/covid_banner' %>
+  <% end %>
+
   <%= yield %>
 
   <%= render 'shared/contact_panels', contact_panels_border_top: contact_panels_border_top?, contact_panels_homepage: contact_panels_homepage? %>

--- a/app/views/shared/_covid_banner.erb
+++ b/app/views/shared/_covid_banner.erb
@@ -1,0 +1,15 @@
+<div class="covid_banner" data-dough-component="CovidBanner">
+	<div class="l-constrained">
+		<div class="covid_banner__content">
+			<div class="covid_banner__inner">
+				<a href="#" class="covid_banner__close" data-dough-close>
+					<svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--mobile-close-box">
+						<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--mobile-close-box"></use>
+					</svg>
+				</a>
+				<p class="covid_banner__head"><%= t('covid_banner.head') %></p>
+				<p class="covid_banner__body"><%= t('covid_banner.body_html', href: t('covid_banner.href')) %></p>
+			</div>
+		</div>
+	</div>
+</div>

--- a/bower.json.erb
+++ b/bower.json.erb
@@ -12,7 +12,7 @@
     "jquery-ujs": "*",
     "jquery-migrate": "3.0.*",
     "bind-polyfill": "^1.0.0",
-    "yeast": "1.13.0",
+    "yeast": "1.14.0",
     "advice_plans": "<%= gem_path('advice_plans') %>",
     "car_cost_tool": "<%= gem_path('car_cost_tool') %>",
     "debt_advice_locator": "<%= gem_path('debt_advice_locator') %>",

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -293,6 +293,11 @@ cy:
     mps_provided_2: yn cael ei ddarparu gan
     mps: Gwasanaeth Arian a Phensiynau
 
+  covid_banner: 
+    head: Coronafeirws – beth mae’n ei olygu i chi
+    body_html: <a href="%{href}">Darganfyddwch beth mae gennych hawl iddo</a>
+    href: /cy/articles/coronafirws-beth-mae-yn-ei-olygu-i-chi
+
   footer_secondary:
     title: Adroddwch broblem mynediad
     link_title: Defnyddiwch y botwm hwn i ddweud wrthym os oes gennych chi unrhyw faterion hygyrchedd i'w hadrodd am y wefan

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -294,6 +294,11 @@ en:
     mps_provided_2: Service is provided by
     mps: Money & Pensions Service
 
+  covid_banner: 
+    head: Coronavirus – what it means for you
+    body_html: <a href="%{href}">Find out what you're entitled to</a>
+    href: /en/articles/coronavirus-what-it-means-for-you
+
   footer_secondary:
     title: Report an accessibility problem
     link_title: Please use this button to tell us if you have an accessibility issue on our website


### PR DESCRIPTION
[TP11363](https://maps.tpondemand.com/entity/11363-sticky-banner-on-mas-website-for)

This work adds a banner to direct users to our articles on Coronavirus. 

There are three PRs that make up the implementation of this component: 
- PR2201 in frontend (this PR) that provides the content and markup for the banner, as well as the Rails functionality to render the component only when this is not recorded in a Cookie as having been previously dismissed, and the reference to the associated Dough component. 
- [PR61](https://github.com/moneyadviceservice/yeast/pull/61) in yeast that provides the styles for the component, and which will be shared with other repos, such as RAD. 
- [PR338](https://github.com/moneyadviceservice/dough/pull/338) in dough that provides the JavaScript component and associated Unit Tests for the behaviour of the banner. This PR also updates the ChatPopup component, necessary to handle the dynamic positioning of the banner on article pages. 

**Banner on the home page**

![image](https://user-images.githubusercontent.com/6080548/77449907-7a4f1780-6dea-11ea-9885-7ffabf3969fc.png)

**Banner on an article page**

![image](https://user-images.githubusercontent.com/6080548/77450028-9e125d80-6dea-11ea-9eca-52217aa2a05e.png)
