### PR TITLE
updated wpcc dependencies to fix the 404 reset link

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,7 +86,7 @@ gem 'rio', '~> 2.2.0', source: 'http://gems.dev.mas.local'
 gem 'savings_calculator', '~> 1.10.2'
 gem 'timelines', '~> 1.7.0'
 gem 'universal_credit', '~> 4.1.1'
-gem 'wpcc', '2.8.1'
+gem 'wpcc', '2.8.2'
 
 group :assets do
   gem 'autoprefixer-rails'


### PR DESCRIPTION
TP-11267: bug fix for wpcc reset generating 404

