### PR TITLE
[DEV APPROVED] 11393 chat add coronavirus option

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ gem 'whenever', require: false
 # Dependencies
 gem 'adal', git: 'git@github.com:moneyadviceservice/azure-activedirectory-library-for-ruby'
 gem 'cream', '2.1.8'
-gem 'dough-ruby', git: 'git@github.com:moneyadviceservice/dough.git', branch: '11363_Sticky-banner_Coronavirus-info_v5.39'
+gem 'dough-ruby', git: 'git@github.com:moneyadviceservice/dough.git', branch: '11393_Chat_Add-coronavirus-option_v5.40'
 gem 'mas-cms-client', '1.20.0'
 gem 'site_search', '0.3.0'
 # Tools

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,10 +15,10 @@ GIT
 
 GIT
   remote: git@github.com:moneyadviceservice/dough.git
-  revision: 029a3600a809e047ea16608186c889b91d2de4e0
-  branch: 11363_Sticky-banner_Coronavirus-info_v5.39
+  revision: 6ae1b74232e63674acb08e1198dc760e40906896
+  branch: 11393_Chat_Add-coronavirus-option_v5.40
   specs:
-    dough-ruby (5.39.0)
+    dough-ruby (5.40.0)
       activemodel
       activesupport
       rails (>= 3.2, < 5.1.0)

--- a/app/views/shared/_webchat_popup.html.erb
+++ b/app/views/shared/_webchat_popup.html.erb
@@ -23,6 +23,9 @@
         <% clumps.each do |clump| %>
           <option value="<%= clump.categories[0].id %>"><%= clump.name %></option>
         <% end %>
+        <option value="<%= t('contact_panels.chat_popup.dropdown_options.covid').downcase %>">
+          <%= t('contact_panels.chat_popup.dropdown_options.covid') %>
+        </option>
       </select>
     </div>
     <div class="mobile-webchat__button-container">

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -159,14 +159,7 @@ cy:
         call_to_action: Sgwrs Gwe
         text_webchat: Ddim ar gael
       dropdown_options:
-        debt_borrowing: Dyled a benthyca
-        homes_mortgages: Cartrefi a morgeisi
-        budgeting_saving: Cyllidebu a Chynilo
-        work_benefits: Gwaith a Buddion
-        pensions_retirement: Pensiynau a Ymddeoliad
-        family_care: Teulu a Gofal
-        cars_travel: Ceir a theithio
-        insurance: Yswiriant
+        covid: Coronafeirws
       contact_link: /cy/corporate/cysylltu-a-ni
       contact_text: Dulliau cysylltu eraill
     chat:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -159,14 +159,7 @@ en:
         call_to_action: Chat
         text_webchat: Unavailable
       dropdown_options:
-        debt_borrowing: Debt & Borrowing
-        homes_mortgages: Homes & Mortgages
-        budgeting_saving: Budgeting & Saving
-        work_benefits: Work & Benefits
-        pensions_retirement: Pensions & Retirement
-        family_care: Family & Care
-        cars_travel: Cars & Travel
-        insurance: Insurance
+        covid: Coronavirus
       contact_link: /en/corporate/contact-us
       contact_text: Other contact methods
     chat:


### PR DESCRIPTION
[TP11393](https://maps.tpondemand.com/entity/11393-add-coronavirus-to-dropdown-option-on)

These changes add a Coronavirus option to the floating WebChat dropdown dropdown. 

![image](https://user-images.githubusercontent.com/6080548/79229486-00df9d80-7e5b-11ea-9f90-fac186659033.png)

The accompanying PR in Dough ([PR339](https://github.com/moneyadviceservice/dough/pull/339)) provides the logic to show the WhatsApp link when the Coronavirus option is selected. 

![image](https://user-images.githubusercontent.com/6080548/79229598-34bac300-7e5b-11ea-94b5-75a4a4decd5f.png)
