### PR TITLE
[DEV APPROVED] Removes flag 'hide_elements_irrelevant_for_third_parties' from base view

### DIFF
--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -238,11 +238,9 @@
   <!--<![endif]-->
 <% end %>
 
-<% unless hide_elements_irrelevant_for_third_parties? %>
-  <%# START RequireJS load of application %>
-  <%= javascript_include_tag 'requirejs/require', data: { main: javascript_path('application') } %>
-  <%# END RequireJS load of application %>
-<% end %>
+<%# START RequireJS load of application %>
+<%= javascript_include_tag 'requirejs/require', data: { main: javascript_path('application') } %>
+<%# END RequireJS load of application %>
 
 <%= yield :javascripts %>
 


### PR DESCRIPTION
[TP11381](https://maps.tpondemand.com/entity/11381-dough-not-initialised-on-some-mas)

- This allows all JS to load as expected, including on 'empty templates'.
- This flag is described in the section [Consuming the front-end without having to manually import dependencies](https://github.com/moneyadviceservice/frontend#consuming-the-front-end-without-having-to-manually-import-dependencies) of the README.
- The tools that are the subject of [TP11381](https://maps.tpondemand.com/entity/11381-dough-not-initialised-on-some-mas) were included in this flag and were badly affected by it so the decision was made, as discussed in that card, to delete the flag in this instance.
