### PR TITLE
[DEV APPROVED] Adds class 'covid_banner__link' to covid banner link

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -295,7 +295,7 @@ cy:
 
   covid_banner: 
     head: Coronafeirws – beth mae’n ei olygu i chi
-    body_html: <a href="%{href}">Darganfyddwch beth mae gennych hawl iddo</a>
+    body_html: <a href="%{href}" class="covid_banner__link">Darganfyddwch beth mae gennych hawl iddo</a>
     href: /cy/articles/coronafirws-beth-mae-yn-ei-olygu-i-chi
 
   footer_secondary:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -296,7 +296,7 @@ en:
 
   covid_banner: 
     head: Coronavirus – what it means for you
-    body_html: <a href="%{href}">Find out what you're entitled to</a>
+    body_html: <a href="%{href}" class="covid_banner__link">Find out what you're entitled to</a>
     href: /en/articles/coronavirus-what-it-means-for-you
 
   footer_secondary:


### PR DESCRIPTION
[TP11380](https://maps.tpondemand.com/entity/11380-add-ability-to-track-covid-banner)

The changes in this PR adds the class `covid_banner__link` to the link on the Covid banner. This is in order to facilitate tracking on this element. 