### PR TITLE
[DEV APPROVED] 11381 js missing

### DIFF
--- a/app/assets/stylesheets/components/common/_mobile_nav.scss
+++ b/app/assets/stylesheets/components/common/_mobile_nav.scss
@@ -17,7 +17,7 @@
     margin: $baseline-unit*1.5 $baseline-unit $baseline-unit*1.5 0;
   }
 
-  .no-js & {
+  body:not([data-dough-component-loader-all-loaded="yes"]) & {
     display: none;
   }
 }

--- a/app/assets/stylesheets/components/common/_no-js_nav.scss
+++ b/app/assets/stylesheets/components/common/_no-js_nav.scss
@@ -1,17 +1,10 @@
-// Footer Navigation
-//
-// Styleguide Footer Navigation
+// No-JS Navigation
 
 .no-js-nav {
   display: none;
   padding-top: $baseline-unit*14;
 
-  .no-js & {
-    display: block;
-  }
-
-  @include respond-to($mq-m) {
-    background: $color-yellow-light;
+  .l-header--non-sticky ~ & {
     padding-top: 0;
   }
 }
@@ -67,6 +60,34 @@
     &:focus {
       background: $color-grey-pale;
       outline-color: $color-grey-pale;
+    }
+  }
+}
+
+// JS is enabled but nav hasn't initialised
+.js {
+  .global-nav:not([data-dough-global-nav-initialised="yes"]) {
+    display: none; 
+
+    & ~ .no-js-nav {
+      display: block;      
+
+      @include respond-to($mq-m) {
+        background: $color-yellow-light;
+        padding-top: 0;
+      }
+    }
+  }
+}
+
+// JS is disabled
+.no-js {
+  .no-js-nav {
+    display: block;
+
+    @include respond-to($mq-m) {
+      background: $color-yellow-light;
+      padding-top: 0;
     }
   }
 }

--- a/app/assets/stylesheets/components/page_specific/_floating_chat.scss
+++ b/app/assets/stylesheets/components/page_specific/_floating_chat.scss
@@ -104,7 +104,7 @@
     padding: $baseline-unit*2;
   }
 
-  .no-js &,
+  &:not([data-dough-chat-popup-initialised="yes"]), 
   .svg & span.icon.icon--web-chat,
   .no-svg & svg.icon-svg--web-chat {
     display: none;

--- a/app/views/layouts/_application_shared.html.erb
+++ b/app/views/layouts/_application_shared.html.erb
@@ -10,8 +10,8 @@
   <%= render 'shared/alerts' if alerts? %>
   <%= render 'shared/maps_banner' %>
   <%= render 'shared/header' %>
-  <%= render 'shared/no_js_nav' %>
   <%= render 'shared/global_nav' %>
+  <%= render 'shared/no_js_nav' %>
 
   <% if covid_banner_dismissed? %>
     <%= render 'shared/covid_banner' %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,4 +1,9 @@
-<header class="l-header<%= ' l-header--non-sticky' if hide_sticky_header? %><%= ' l-header--home' if show_home_banner? %>" role="banner">
+<header 
+  class="l-header
+    <%= ' l-header--non-sticky' if hide_sticky_header? || hide_elements_irrelevant_for_third_parties? %>
+    <%= ' l-header--home' if show_home_banner? %>"
+  role="banner"
+>
   <div class="l-constrained l-header__content">
     <div class="mas-logo">
       <%= link_to main_app.root_path, class: 'mas-logo__link' do %>

--- a/app/views/shared/_maps_banner.html.erb
+++ b/app/views/shared/_maps_banner.html.erb
@@ -1,4 +1,8 @@
-<div class="l-maps_banner<%= ' l-maps_banner--non-sticky' if hide_sticky_header? %><%= ' l-maps_banner--home' if show_home_banner? %>">
+<div 
+  class="l-maps_banner
+    <%= ' l-maps_banner--non-sticky' if hide_sticky_header? || hide_elements_irrelevant_for_third_parties? %>
+    <%= ' l-maps_banner--home' if show_home_banner? %>"
+>
   <div class="l-constrained">
     <div class="l-maps_banner__content">
       <a href="https://moneyandpensionsservice.org.uk/" target="_blank" class="maps_banner__link">

--- a/bower.json.erb
+++ b/bower.json.erb
@@ -12,7 +12,7 @@
     "jquery-ujs": "*",
     "jquery-migrate": "3.0.*",
     "bind-polyfill": "^1.0.0",
-    "yeast": "1.14.0",
+    "yeast": "1.15.0", 
     "advice_plans": "<%= gem_path('advice_plans') %>",
     "car_cost_tool": "<%= gem_path('car_cost_tool') %>",
     "debt_advice_locator": "<%= gem_path('debt_advice_locator') %>",


### PR DESCRIPTION
[TP11381](https://maps.tpondemand.com/entity/11381-dough-not-initialised-on-some-mas)

There are 2 PRs in this piece of work: 
- PR2212 on Frontend (this one)
- [PR62](https://github.com/moneyadviceservice/yeast/pull/62) on Yeast

It makes some small changes to our CSS to deal with issues that have become evident where third party users are loading our "empty template" to create content on the MAS estate.

There are a number of problems on the two tool pages this card caused by the usual MAS JavaScript being blocked and a number of page components break, specifically: 
- The Search Box has no means of clearing the input.
- The Navigation on desktop functions with CSS rather than JavaScript. The JavaScript provides a slightly enhanced experience as well as a number of accessibility features. 
- On mobile the navigation is not rendered at all. 
- On mobile the search box is permanently displayed and is not collapsable. 
- On mobile the floating web chat button is not collapsable or expandable. 
- The Coronavirus banner is not dismissible.

It was decided, in the short term at least, not to fix these issues but to ameliorate the worst effects of them with the CSS additions within these PRs. This is largely based on basing styles on the "dough-initialised" tag rather than the "js" hook in the `<body>` tag.

N.B. This is not easily testable locally since the issue occurs in a third party setting.
