### PR TITLE
11424 global nav no js improvement

### DIFF
--- a/app/assets/javascripts/components/GlobalNav.js
+++ b/app/assets/javascripts/components/GlobalNav.js
@@ -42,7 +42,6 @@ define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities', 'common'], 
    * Set up component
    */
   GlobalNav.prototype._bindEvents = function() {
-    this.$globalNav.removeClass('uninitialised');
     $(window).on('resize', utilities.debounce($.proxy(this._setUpMobileAnimation, this), 100));
   };
 
@@ -218,6 +217,8 @@ define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities', 'common'], 
   */
   GlobalNav.prototype._setUpMobileInteraction = function() {
     var self = this;
+
+    this.$mobileNavButton.removeClass('is-hidden'); 
 
     this.$mobileNavButton.click(function(e) {
       e.preventDefault();

--- a/app/assets/stylesheets/components/common/_global_nav.scss
+++ b/app/assets/stylesheets/components/common/_global_nav.scss
@@ -138,6 +138,10 @@ $global-nav-transition-duration: 300ms;
 .no-js {
   .global-nav {
     display: none;
+
+    @include respond-to($mq-m) {
+      display: block;
+    }
   }
 }
 // -- no-js fallback

--- a/app/assets/stylesheets/components/common/_global_subnav.scss
+++ b/app/assets/stylesheets/components/common/_global_subnav.scss
@@ -44,10 +44,14 @@ $global-nav-transition-duration: 300ms !default; // Defined in _global_nav.scss
 
 .is-hidden {
   display: none;
+
+  @include respond-to($mq-m) {
+    display: block; 
+  }
 }
 
-// no-js fallback --
-.uninitialised {
+// nav not initialised --
+.global-nav:not([data-dough-global-nav-initialised="yes"]) {
   @include respond-to($mq-m) {
     .global-nav__clump__heading {
       &:hover {
@@ -64,7 +68,7 @@ $global-nav-transition-duration: 300ms !default; // Defined in _global_nav.scss
     }
   }
 }
-// -- no-js fallback
+// -- nav not initialised
 
 .global-subnav__heading {
   position: relative;

--- a/app/assets/stylesheets/components/common/_mobile_nav.scss
+++ b/app/assets/stylesheets/components/common/_mobile_nav.scss
@@ -16,9 +16,17 @@
   @include respond-to($mq-m) {
     margin: $baseline-unit*1.5 $baseline-unit $baseline-unit*1.5 0;
   }
+}
 
+.mobile-nav__item--search {
   body:not([data-dough-component-loader-all-loaded="yes"]) & {
     display: none;
+  }
+}
+
+.mobile-nav__link--menu {
+  &.is-hidden {
+    display: none; 
   }
 }
 

--- a/app/assets/stylesheets/components/common/_no-js_nav.scss
+++ b/app/assets/stylesheets/components/common/_no-js_nav.scss
@@ -67,14 +67,11 @@
 // JS is enabled but nav hasn't initialised
 .js {
   .global-nav:not([data-dough-global-nav-initialised="yes"]) {
-    display: none; 
-
     & ~ .no-js-nav {
       display: block;      
 
       @include respond-to($mq-m) {
-        background: $color-yellow-light;
-        padding-top: 0;
+        display: none; 
       }
     }
   }
@@ -86,8 +83,7 @@
     display: block;
 
     @include respond-to($mq-m) {
-      background: $color-yellow-light;
-      padding-top: 0;
+      display: none;
     }
   }
 }

--- a/app/views/shared/_global_nav.html.erb
+++ b/app/views/shared/_global_nav.html.erb
@@ -1,4 +1,4 @@
-<nav class="global-nav uninitialised" role="navigation" aria-label="main" id="global-nav" tabindex="-1" data-dough-component="GlobalNav">
+<nav class="global-nav" role="navigation" aria-label="main" id="global-nav" tabindex="-1"  data-dough-component="GlobalNav">
   <div class="l-constrained">
     <ul data-dough-nav-clumps class="global-nav__clumps" role="menubar" aria-label="main site navigation">
       <% clumps.each do |clump| %>

--- a/app/views/shared/_mobile_nav.html.erb
+++ b/app/views/shared/_mobile_nav.html.erb
@@ -1,7 +1,9 @@
 <ul class="mobile-nav">
   <% unless hide_elements_irrelevant_for_third_parties? %>
-    <li class="mobile-nav__item">
-      <a data-dough-mobile-nav-button class="mobile-nav__link mobile-nav__link--menu" href="#" role="button"><%= t('mobile_nav.menu') %></a>
+    <li class="mobile-nav__item mobile-nav__item--menu">
+      <a data-dough-mobile-nav-button class="mobile-nav__link mobile-nav__link--menu is-hidden" href="#" role="button">
+        <%= t('mobile_nav.menu') %>
+      </a>
     </li>
   <% end %>
   <% if display_search_box_in_header? %>

--- a/bower.json.erb
+++ b/bower.json.erb
@@ -12,7 +12,7 @@
     "jquery-ujs": "*",
     "jquery-migrate": "3.0.*",
     "bind-polyfill": "^1.0.0",
-    "yeast": "1.15.0", 
+    "yeast": "1.16.0", 
     "advice_plans": "<%= gem_path('advice_plans') %>",
     "car_cost_tool": "<%= gem_path('car_cost_tool') %>",
     "debt_advice_locator": "<%= gem_path('debt_advice_locator') %>",

--- a/spec/javascripts/fixtures/GlobalNav.html
+++ b/spec/javascripts/fixtures/GlobalNav.html
@@ -1,6 +1,6 @@
 <div>
-  <a data-dough-mobile-nav-button></a>
-  <nav data-dough-component="GlobalNav" class="uninitialised no-transition">
+  <a data-dough-mobile-nav-button class="is-hidden"></a>
+  <nav data-dough-component="GlobalNav" class="no-transition">
     <ul data-dough-nav-clumps>
       <li data-dough-nav-clump id="clump-1">
         <a data-dough-nav-clump-heading tabindex="0">

--- a/spec/javascripts/tests/GlobalNav_spec.js
+++ b/spec/javascripts/tests/GlobalNav_spec.js
@@ -51,10 +51,6 @@ describe('GlobalNav', function() {
     beforeEach(function() {
       this.obj.init();
     });
-
-    it('removes the uninialised class when component is loaded', function() {
-      expect(this.component.hasClass('uninitialised')).to.be.false;
-    });
   });
 
   describe('Mobile animation', function() {
@@ -70,6 +66,10 @@ describe('GlobalNav', function() {
   describe('Mobile interaction', function() {
     beforeEach(function() {
       this.obj.init();
+    }); 
+
+    it('displays the menu button', function() {
+      expect(this.mobileNavButton.hasClass('is-hidden')).to.be.false;
     }); 
 
     it('toggles nav visibility when menu button is clicked', function() {


### PR DESCRIPTION
[TP11424](https://maps.tpondemand.com/entity/11424-global-navigation-no-js-improvement)

There are 2 PRs for this piece of work: 
- [PR63](https://github.com/moneyadviceservice/yeast/pull/63) in yeast
- PR2213 in frontend (this one)

This work makes some small improvements to the Global Navigation arising from the work carried out to fix issues associated with our empty template in [TP11381](https://maps.tpondemand.com/entity/11381-dough-not-initialised-on-some-mas). It updates the display of the component in desktop viewports when: 
- JavaScript does not load at all on the page
- JavaScript loads on the page but the component is not initialised
- the component is fully initialised

It also deals with the state of the component in transition between those states that gives a more satisfactory user experience. 

**When JavaScript does not load at all on the page**

The navigation displays as a dropdown menu, driven by CSS rather than JS. The current production version displays the full list of categories. 

**When the component is not initialised**

The navigation displays as a dropdown menu, driven by CSS as above. The current production version displays list of categories as above. 

**When the component is fully initialised**

The navigation displays as a dropdown menu, driven by JS, in line with the current production version, providing various UI and A11Y enhancements.
