### PR TITLE
Updates version of action_plans repo to 5.5.0 for TP11416

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ gem 'dough-ruby', git: 'git@github.com:moneyadviceservice/dough.git', branch: '1
 gem 'mas-cms-client', '1.20.0'
 gem 'site_search', '0.3.0'
 # Tools
-gem 'action_plans', '~> 5.4.0'
+gem 'action_plans', '~> 5.5.0'
 gem 'advice_plans', '~> 4.1.0'
 gem 'agreements', '~> 2.5.0'
 gem 'budget_planner', '~> 5.7.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,7 +28,7 @@ GEM
   remote: https://rubygems.org/
   remote: http://gems.dev.mas.local/
   specs:
-    action_plans (5.4.0)
+    action_plans (5.5.0)
       autoprefixer-rails
       dough-ruby (~> 5.0)
       draper
@@ -787,7 +787,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  action_plans (~> 5.4.0)
+  action_plans (~> 5.5.0)
   activerecord-session_store
   adal!
   advice_plans (~> 4.1.0)


### PR DESCRIPTION
[TP11416](https://maps.tpondemand.com/entity/11416-redundancy-pay-calculator-northern-ireland-update)
