### PR TITLE
Feature/tp 11520 redirect hub url

### DIFF
--- a/config/locales/content_hub/arweiniad_ariannol_coronafeirws.cy.yml
+++ b/config/locales/content_hub/arweiniad_ariannol_coronafeirws.cy.yml
@@ -1,7 +1,7 @@
 cy:
   content_hub:
     arweiniad_ariannol_coronafeirws:
-      alternate_slug: coronavirus_money_guidance
+      alternate_slug: coronavirus-money-guidance
       page_title: Cymorth coronafeirws
       page_subtitle: Mae’r coronafeirws wedi bod yn sioc, a gwyddom eich bod yn gwneud popeth yn eich gallu i gadw pethau dan reolaeth. Rydym ni wedi dwyn ynghyd ein holl wybodaeth ynglŷn â’r coronafeirws a’r canllawiau ynglŷn â materion eraill sydd efallai yn effeithio arnoch mewn un lle, fel y gallwch chi ddysgu beth allwch chi ei wneud a lle i fynd am gymorth.
       meta_description: Rydym wedi dwyn ynghyd ein holl wybodaeth ynglŷn â’r coronafeirws a’r canllawiau ynglŷn â materion eraill sydd efallai yn effeithio arnoch mewn un lle, fel y gallwch chi ddysgu beth allwch chi ei wneud.

--- a/config/locales/content_hub/coronavirus_money_guidance.en.yml
+++ b/config/locales/content_hub/coronavirus_money_guidance.en.yml
@@ -1,7 +1,8 @@
 en:
+
   content_hub:
     coronavirus_money_guidance:
-      alternate_slug: arweiniad_ariannol_coronafeirws
+      alternate_slug: arweiniad-ariannol-coronafeirws
       page_title: Coronavirus support
       page_subtitle: Coronavirus has been a shock, and we know you're doing all you can to keep things under control. We've put together all of our coronavirus information and the guides around other issues you might be having in one place, so you can find out what you can do and where you can go for help.
       meta_description: We've put together all our coronavirus information and the guides around other issues you might be having in one place, so you can find out what you can do.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -221,6 +221,8 @@ Rails.application.routes.draw do
       end
     end
 
+    get '/hub/coronavirus-support', to: redirect('/en/hub/coronavirus-money-guidance')
+    get '/hub/cymorth-coronafeirws', to: redirect('/cy/hub/arweiniad-ariannol-coronafeirws')
     get '/hub/:slug' => 'content_hub#show', as: :content_hub
   end
 


### PR DESCRIPTION
This redirects the existing c19 hub url to the new one as per TP-11520