### PR TITLE
Update minor websocket-extensions from 0.1.3 to 0.1.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -772,7 +772,7 @@ GEM
       hashdiff
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.3)
+    websocket-extensions (0.1.5)
     whenever (0.10.0)
       chronic (>= 0.6.3)
     wpcc (2.8.3)


### PR DESCRIPTION
ReDoS vulnerability in Sec-WebSocket-Extensions parser

https://github.com/faye/websocket-extensions-ruby/security/advisories/GHSA-g6wq-qcwm-j5g2