### PR TITLE
Money navigator results add print option

### DIFF
--- a/app/assets/javascripts/components/MoneyNavigatorResults.js
+++ b/app/assets/javascripts/components/MoneyNavigatorResults.js
@@ -1,16 +1,21 @@
 define(['jquery', 'DoughBaseComponent', 'utilities'], function($, DoughBaseComponent, utilities) {
   'use strict';
 
-  var MoneyNavigatorResults;
-  
+  var MoneyNavigatorResults,
+      i18nStrings = {
+        printBtnText: 'Print this'
+      };
+
   MoneyNavigatorResults = function($el, config) {
     MoneyNavigatorResults.baseConstructor.call(this, $el, config);
 
+    this.i18nStrings = (config && config.i18nStrings) ? config.i18nStrings : i18nStrings;
     this.$headingContent = this.$el.find('[data-heading-content]'); 
     this.$sections = this.$el.find('[data-section]'); 
     this.$sectionTitles = this.$el.find('[data-section-title]'); 
     this.$headingTitles = this.$el.find('[data-heading-title]'); 
     this.$overlay = this.$el.find('[data-overlay]'); 
+    this.$actions = this.$el.find('[data-actions]'); 
     this.hiddenSuffix = '--hidden'; 
     this.hiddenClass = 'is-hidden';
     this.collapsedClass = 'is-collapsed'; 
@@ -31,9 +36,14 @@ define(['jquery', 'DoughBaseComponent', 'utilities'], function($, DoughBaseCompo
     var _this = this; 
     var sectionIcon = document.createElement('span'); 
     var headingTitleIcon = document.createElement('span'); 
+    var printBtn = document.createElement('button'); 
 
     $(sectionIcon).addClass('section__title__icon'); 
     $(headingTitleIcon).addClass('heading__title__icon'); 
+    $(printBtn)
+      .addClass('button button--print')
+      .text(this.i18nStrings.printBtnText); 
+    printBtn.dataset.printBtn = true; 
 
     // Adds hidden classes to headings content
     this.$headingContent.addClass('heading__content' + this.hiddenSuffix); 
@@ -48,6 +58,9 @@ define(['jquery', 'DoughBaseComponent', 'utilities'], function($, DoughBaseCompo
 
     // Adds checkbox element to headings
     this.$headingTitles.append(headingTitleIcon); 
+
+    // Adds print button
+    this.$actions.prepend(printBtn); 
   }; 
 
   MoneyNavigatorResults.prototype._setUpEvents = function() {
@@ -68,6 +81,10 @@ define(['jquery', 'DoughBaseComponent', 'utilities'], function($, DoughBaseCompo
 
     this.$overlay.on('click', function() {
       _this._hideHeading(); 
+    });
+
+    this.$actions.find('[data-print-btn]').on('click', function() {
+      window.print();
     }); 
 
     $(window).on(

--- a/app/assets/stylesheets/layout/page_specific/_money_navigator_results.scss
+++ b/app/assets/stylesheets/layout/page_specific/_money_navigator_results.scss
@@ -303,14 +303,11 @@ $transition-time: 0.4s;
 		}
 
 		.sections__heading {
-			border: solid 1px $color-grey-normal;
-			box-shadow: 0 2px 4px $color-grey-normal; 
-
 			button {
 				border: none; 
 				width: 100%;
 				text-align: left; 
-				padding: $baseline-unit * 2 $default-gutter;
+				padding: 0;
 				background: transparent;
 
 				@include respond-to($mq-m) {
@@ -374,8 +371,12 @@ $transition-time: 0.4s;
 	}
 
 	.results__actions {
+		@include column(12); 
+		
 		text-align: center; 
-		.button--restart {
+
+		.button--restart, 
+		.button--print {
 			width: 100%; 
 
 			@include respond-to($mq-m) {
@@ -384,183 +385,282 @@ $transition-time: 0.4s;
 
 			@include respond-to($mq-l) {
 				width: 25%; 
+				float: right;
+			}
+		}
+
+		.button--restart {
+			@include respond-to($mq-l) {
+				float: right;
+			}
+		}
+
+		.button--print {
+			margin-bottom: $baseline-unit * 4; 
+
+			@include respond-to($mq-l) {
+				float: left;
 			}
 		}
 	}
 
 	// Component initialised
 	.results__sections[data-dough-money-navigator-results-initialised="yes"] {
-		.sections__section {
-			@extend %clearfix; 
+		@media not print {
+			.sections__section {
+				@extend %clearfix; 
 
-			.section__content {
-				overflow: hidden;
+				.section__content {
+					overflow: hidden;
 
-				transition-property: height; 
-				transition-duration: $transition-time; 
-			}
-
-			.section__title {
-				button {
-					position: relative;
+					transition-property: height; 
+					transition-duration: $transition-time; 
 				}
 
-				.section__title__icon {
-					position: absolute;
-					top: 50%; 
-					right: $default-gutter; 
-					width: 18px;
-					height: 12px; 
-					transform: translateY(-50%) rotate(0deg); 
-					transition-property: transform; 
-					transition-duration: $transition-time; 
-					background-image: image_url('money_navigator_tool/section_title_icon.svg');
-					background-repeat: no-repeat;
-					background-size: 100%; 
-					background-position: center; 
-				}			
-			}
+				.section__title {
+					button {
+						position: relative;
+					}
 
-			.sections__heading--done {
-				background: $color-grey-pale;
+					.section__title__icon {
+						position: absolute;
+						top: 50%; 
+						right: $default-gutter; 
+						width: 18px;
+						height: 12px; 
+						transform: translateY(-50%) rotate(0deg); 
+						transition-property: transform; 
+						transition-duration: $transition-time; 
+						background-image: image_url('money_navigator_tool/section_title_icon.svg');
+						background-repeat: no-repeat;
+						background-size: 100%; 
+						background-position: center; 
+					}			
+				}
 
-				.heading__title__icon {
-					&:before {
-						content: '\2713'; 
-						display: block;
-						text-align: center;
-						line-height: 1.25rem; 
+				.sections__heading {
+					border: solid 1px $color-grey-normal;
+					box-shadow: 0 2px 4px $color-grey-normal; 
+
+					button {
+						padding: $baseline-unit * 2 $default-gutter;
 					}
 				}
-			}
 
-			.heading__title {
-				margin-bottom: 0;
-				padding-left: calc(1.25rem + #{$default-gutter}); 
-				position: relative;
+				.sections__heading--done {
+					background: $color-grey-pale;
 
-				.heading__title__icon {
-					display: inline-block;
-					width: 1.25rem; 
-					height: 1.25rem; 
-					border: solid 1px;
-					position: absolute;
-					top: 50%;
-					left: 0;
-					transform: translateY(-50%);
+					.heading__title__icon {
+						&:before {
+							content: '\2713'; 
+							display: block;
+							text-align: center;
+							line-height: 1.25rem; 
+						}
+					}
+				}
+
+				.heading__title {
+					margin-bottom: 0;
+					padding-left: calc(1.25rem + #{$default-gutter}); 
+					position: relative;
+
+					.heading__title__icon {
+						display: inline-block;
+						width: 1.25rem; 
+						height: 1.25rem; 
+						border: solid 1px;
+						position: absolute;
+						top: 50%;
+						left: 0;
+						transform: translateY(-50%);
+						background: $color-white;
+					}
+				}
+
+				.heading__content {
+					position: fixed;
+					top: 0%;
+					left: 0%;
+					height: 100%; 
+					width: 100%;
+					padding: $baseline-unit * 8 $default-gutter * 4 $baseline-unit * 4;
+					z-index: 155; 
 					background: $color-white;
-				}
-			}
-
-			.heading__content {
-				position: fixed;
-				top: 0%;
-				left: 0%;
-				height: 100%; 
-				width: 100%;
-				padding: $baseline-unit * 8 $default-gutter * 4 $baseline-unit * 4;
-				z-index: 155; 
-				background: $color-white;
-				transition-property: top; 
-				transition-duration: $transition-time; 
-				overflow-y: scroll;
-
-				@include respond-to($mq-s) {
-					padding-left: $default-gutter * 3.5;
-					padding-right: $default-gutter * 3.5;
-				}
-
-				@include respond-to($mq-m) {
-					padding-left: $default-gutter * 3;
-					padding-right: $default-gutter * 3;
-				}
-
-				@include respond-to($mq-l) {
-					left: 30%;
-					width: 70%;
-					padding-left: $default-gutter * 2.5;
-					padding-right: $default-gutter * 2.5;
-					transition-property: left; 
-				}
-
-				@include respond-to($mq-xl) {
-					padding-left: $default-gutter * 2;
-					padding-right: $default-gutter * 2;
-				}
-
-				.overlay__hide {
-					position: absolute;
-					margin: 0;
-					top: $baseline-unit * 3;
-					right: $default-gutter * 4;
-					display: inline-block;
-					padding: $baseline-unit $baseline-unit * 4 $baseline-unit $baseline-unit;
+					transition-property: top; 
+					transition-duration: $transition-time; 
+					overflow-y: scroll;
 
 					@include respond-to($mq-s) {
-						right: $default-gutter * 3.5;
+						padding-left: $default-gutter * 3.5;
+						padding-right: $default-gutter * 3.5;
 					}
 
 					@include respond-to($mq-m) {
-						right: $default-gutter * 3;
+						padding-left: $default-gutter * 3;
+						padding-right: $default-gutter * 3;
 					}
 
 					@include respond-to($mq-l) {
-						right: $default-gutter * 2.5;
+						left: 30%;
+						width: 70%;
+						padding-left: $default-gutter * 2.5;
+						padding-right: $default-gutter * 2.5;
+						transition-property: left; 
 					}
 
 					@include respond-to($mq-xl) {
-						right: $default-gutter * 2;
+						padding-left: $default-gutter * 2;
+						padding-right: $default-gutter * 2;
 					}
 
-					&:focus {
-						outline: 3px solid $color-black;
-					}
-
-					.overlay__hide__icon {
+					.overlay__hide {
 						position: absolute;
-						width: 12px;
-						height: 12px;
-						right: $baseline-unit; 
-						top: 50%; 
-						transform: translateY(-50%);
+						margin: 0;
+						top: $baseline-unit * 3;
+						right: $default-gutter * 4;
+						display: inline-block;
+						padding: $baseline-unit $baseline-unit * 4 $baseline-unit $baseline-unit;
+
+						@include respond-to($mq-s) {
+							right: $default-gutter * 3.5;
+						}
+
+						@include respond-to($mq-m) {
+							right: $default-gutter * 3;
+						}
+
+						@include respond-to($mq-l) {
+							right: $default-gutter * 2.5;
+						}
+
+						@include respond-to($mq-xl) {
+							right: $default-gutter * 2;
+						}
+
+						&:focus {
+							outline: 3px solid $color-black;
+						}
+
+						.overlay__hide__icon {
+							position: absolute;
+							width: 12px;
+							height: 12px;
+							right: $baseline-unit; 
+							top: 50%; 
+							transform: translateY(-50%);
+						}
 					}
 				}
-			}
 
-			.heading__content--hidden {
-				top: 100%;
+				.heading__content--hidden {
+					top: 100%;
 
-				@include respond-to($mq-l) {
-					top: 0%;
-					left: 100%;
+					@include respond-to($mq-l) {
+						top: 0%;
+						left: 100%;
+					}
+				}
+
+				&.is-collapsed {
+					.section__title {
+						.section__title__icon {
+							transform: translateY(-50%) rotate(180deg); 
+						}			
+					}
+				}
+
+				.heading__content__title {
+					display: block; 
+					margin-top: 0; 
 				}
 			}
+		}
 
-			&.is-collapsed {
-				.section__title {
-					.section__title__icon {
-						transform: translateY(-50%) rotate(180deg); 
-					}			
-				}
-			}
+		.results__sections__overlay {
+			position: fixed;
+			top: 0;
+			left: 0;
+			bottom: 0;
+			width: 100%;
+			z-index: 150; 
+			background: rgba(0, 0, 0, 0.5);
 
-			.heading__content__title {
-				display: block; 
-				margin-top: 0; 
+			&.is-hidden {
+				display: none; 
 			}
 		}
 	}
 
-	.results__sections__overlay {
-		position: fixed;
-		top: 0;
-		left: 0;
-		bottom: 0;
-		width: 100%;
-		z-index: 150; 
-		background: rgba(0, 0, 0, 0.5);
+	// Enhanced print styles
+	@media print {
+		p, ul, li, a, h1, h2, h3, h4, h5 {
+			font-size: 12pt !important; 
+		}
 
-		&.is-hidden {
+		.results__heading {
+			font-size: 21pt !important; 			
+		}
+
+		.results__urgent-actions {
+			.urgent-actions__heading {
+				font-size: 18pt !important; 
+			}
+
+			.urgent-actions__action {
+				margin: 0;
+
+				.action__content {
+					width: 100%;
+					padding: 0; 	
+					margin: 0;
+
+					.callout {
+						border-color: #000;
+						padding: 12pt;
+
+						.callout__icon {
+							display: none; 
+
+							& + p {
+								margin-top: 0; 
+
+								&:before {
+									display: none; 
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+
+	  .add-action {
+	    background: none !important;
+	    padding: 0 !important;
+
+	    &:before {
+	      content: none !important;
+	    }
+	  }
+
+		.results__sections {
+			.section__title {
+				border-bottom: solid 1pt;
+
+				button {
+					font-size: 15pt !important; 
+				}
+			}
+
+			.section__content {
+				.heading__title {
+					font-size: 12pt !important; 
+				}
+			}
+		}
+
+		.results__actions {
 			display: none; 
 		}
 	}

--- a/app/views/money_navigator_tool/results.html.erb
+++ b/app/views/money_navigator_tool/results.html.erb
@@ -6,7 +6,7 @@
 <div class="l-container-tool">
 	<main>
 		<div class="l-money_navigator-results">
-			<h1><%= t("money_navigator_tool.results.heading") %></h1>
+			<h1 class="results__heading"><%= t("money_navigator_tool.results.heading") %></h1>
 
 			<p class="results__intro"><%= t("money_navigator_tool.results.intro") %></p>
 
@@ -26,7 +26,11 @@
         </section>
       <% end %>
 
-			<section class="results__sections" data-dough-component="MoneyNavigatorResults">
+			<section 
+				class="results__sections" 
+				data-dough-component="MoneyNavigatorResults"
+				data-dough-money-navigator-results-config='{"i18nStrings": {"printBtnText": "<%= t('money_navigator_tool.results.print_btn_text') %>"}}'
+			>
 				<ul class="sections__sections">
           <% @results.reject {|res| res[:section_code] == 'S1'}.each do |result| %>
 						<li class="sections__section" data-section>
@@ -75,13 +79,13 @@
 					<% end %>
 				</ul>
 
-				<div class="results__sections__overlay is-hidden" data-overlay></div>
-			</section>
+				<div class="results__actions" data-actions>
+					<%= link_to('/en/tools/money-navigator-tool/questionnaire', class: 'button button--restart') do %>
+						Re-start the diagnostic
+					<% end %>
+				</div>
 
-			<section class="results__actions">
-				<%= link_to('/en/tools/money-navigator-tool/questionnaire', class: 'button button--restart') do %>
-					Re-start the diagnostic
-				<% end %>
+				<div class="results__sections__overlay is-hidden" data-overlay></div>
 			</section>
 		</div>
 	</main>

--- a/config/locales/money_navigator_tool/money_navigator_tool.en.yml
+++ b/config/locales/money_navigator_tool/money_navigator_tool.en.yml
@@ -388,6 +388,7 @@ en:
     results:
       heading: Your Money Navigator action plan
       intro: Based on what you’ve told us, here’s our expert view on your personal situation. Find out more about actions you need to take, where you can get free help and support, as well as guidance and tips to help you move forward with your money.
+      print_btn_text: Print this
       S1:
         title: Urgent actions
       S2:

--- a/spec/javascripts/fixtures/MoneyNavigatorResults.html
+++ b/spec/javascripts/fixtures/MoneyNavigatorResults.html
@@ -97,6 +97,10 @@
 			</li>
 		</ul>
 
+		<div data-actions>
+			<a class="button button--restart">Re-start the diagnostic</a>
+		</div>
+
 		<div class="is-hidden" data-overlay></div>
 	</section>
 </div>

--- a/spec/javascripts/tests/MoneyNavigatorResults_spec.js
+++ b/spec/javascripts/tests/MoneyNavigatorResults_spec.js
@@ -65,7 +65,9 @@ describe('MoneyNavigatorResults', function() {
 
       this.$headingTitles.each(function() {
         expect($(this).find('.heading__title__icon').length).to.equal(1); 
-      }); 
+      });
+
+      expect($(this.component).find('[data-print-btn]').length).to.equal(1); 
     }); 
   }); 
 
@@ -77,6 +79,7 @@ describe('MoneyNavigatorResults', function() {
       var showHeadingSpy = sinon.spy(this.obj, '_showHeading'); 
       var hideHeadingSpy = sinon.spy(this.obj, '_hideHeading'); 
       var sectionResizeStub = sinon.stub(this.obj, '_sectionResize'); 
+      var printStub = sinon.stub(window, 'print'); 
       var section_0_btn = $(this.$sectionTitles[0]).find('button'); 
       var section_1_btn = $(this.$sectionTitles[1]).find('button'); 
       var section_2_btn = $(this.$sectionTitles[2]).find('button'); 
@@ -84,6 +87,7 @@ describe('MoneyNavigatorResults', function() {
       var heading_2_btn = $(this.$headings[2]).find('button'); 
       var heading_4_btn = $(this.$headings[4]).find('button'); 
       var overlayHide = $(this.$headingContent[0]).find('[data-overlay-hide]'); 
+      var printBtn = $(this.component).find('[data-print-btn]'); 
 
       this.obj._setUpEvents(); 
 
@@ -111,6 +115,9 @@ describe('MoneyNavigatorResults', function() {
       this.$overlay.trigger('click'); 
       expect(hideHeadingSpy.calledWith()).to.be.true; 
 
+      $(printBtn).trigger('click'); 
+      expect(window.print.calledOnce).to.be.true; 
+
       $(window).trigger('resize'); 
       expect(sectionResizeStub.called).to.be.false; 
 
@@ -118,6 +125,7 @@ describe('MoneyNavigatorResults', function() {
       showHeadingSpy.restore(); 
       hideHeadingSpy.restore(); 
       sectionResizeStub.restore(); 
+      printStub.restore(); 
     }); 
   }); 
 


### PR DESCRIPTION
[TP11446](https://maps.tpondemand.com/entity/11446-moneynavigator-add-print-option-to-results)

This work adds the functionality to allow the user to print the contents of the results page once they have used the tool.

The design on which this is based is [here](https://4zy55q.axshare.com/#id=8c2jys&p=results_page&g=12&view=default). 

The URL for the tool on frontend is `/en/tools/money-navigator-tool`. 

There already exists a site-wide print style-sheet; this work makes a minor update to that and adds more specific styles for this tool. 

![image](https://user-images.githubusercontent.com/6080548/86130706-7531f080-badc-11ea-94ed-74fe1f470ead.png)
