### PR TITLE
Excludes unnecessary components from general print stylesheet

### DIFF
--- a/app/assets/stylesheets/_print.scss
+++ b/app/assets/stylesheets/_print.scss
@@ -13,12 +13,15 @@
 
   // Hide unnecessary components
 
+  .l-maps_banner, 
   .mobile-nav,
   .l-menu-nav,
   .l-search,
   .l-context-bar,
   .l-nav,
   .related-links,
+  .mobile-webchat__container, 
+  .covid_banner, 
   .l-footer,
   .promo img,
   .search,


### PR DESCRIPTION
[TP11591](https://maps.tpondemand.com/entity/11591-mas-core-site-update-general-print)

This work adds three elements to the list of components to be excluded from the print stylesheet: 
- MAPS banner
- Floating mobile Webchat
- Covid banner

Whilst this is a general task that needs to be done, this card is also part of the work to add a print stylesheet to the Money Navigator Tool (see [TP11446](https://maps.tpondemand.com/entity/11446-moneynavigator-add-print-option-to-results)). 
