### PR TITLE
11584 money navigator journey logic

### DIFF
--- a/spec/javascripts/fixtures/MoneyNavigatorQuestions.html
+++ b/spec/javascripts/fixtures/MoneyNavigatorQuestions.html
@@ -9,7 +9,7 @@
 				<div class="question__content" data-question-id="q0">
 					<fieldset>
 						<div data-response>
-							<input type="radio" name="questions[q0]" value="a1">
+							<input type="radio" name="questions[q0]" value="a1" checked>
 						</div>
 
 						<div data-response>
@@ -31,7 +31,7 @@
 						<legend>A custom question</legend>
 
 						<div data-response>
-							<input type="radio" name="questions[q1]" value="a1">
+							<input type="radio" name="questions[q1]" value="a1" checked>
 							<label>A custom response</label>
 						</div>
 
@@ -43,6 +43,11 @@
 						<div data-response>
 							<input type="radio" name="questions[q1]" value="a3">
 							<label>Yet another custom response</label>
+						</div>
+
+						<div data-response>
+							<input type="radio" name="questions[q1]" value="a4">
+							<label>Not really a meaningful response at all</label>
 						</div>
 					</fieldset>
 				</div>
@@ -56,7 +61,7 @@
 						<legend>A multiple question</legend>
 
 						<div data-response>
-							<input type="checkbox" name="questions[q2][]" value="a1">
+							<input type="checkbox" name="questions[q2][]" value="a1" checked>
 						</div>
 
 						<div data-response>
@@ -76,7 +81,7 @@
 				<div class="question__content" data-question-id="q3">
 					<fieldset>
 						<div data-response>
-							<input type="radio" name="questions[q3]" value="a1">
+							<input type="radio" name="questions[q3]" value="a1" checked>
 						</div>
 
 						<div data-response>
@@ -102,7 +107,7 @@
 				<div class="question__content" data-question-id="q5">
 					<fieldset>
 						<div data-response>
-							<input type="radio" name="questions[q5]" value="a1">
+							<input type="radio" name="questions[q5]" value="a1" checked>
 						</div>
 					</fieldset>
 				</div>


### PR DESCRIPTION
[TP11584](https://maps.tpondemand.com/entity/11584-money-navigator-logic-issue-with-employed)

This work adds the display logic to allow customised journeys to be made. 

For this release we wish to skip certain questions on "Continue" depending on which response is selected for Q1 ("What is your employment status") according to the logic below. The same route should be followed on "Back" and should be changed if the user updates their selection on Q1. 

```
If user answers      | Go to
A1 ("Employed")      | Q2 ("Are you at risk ...?") then Q4 ("How would you describe  ...?")
A2 ("Self-employed") | Q3 ("If you are self-employed ...?") then Q4 ("How would you describe  ...?")
A3 ("Unemployed")    | Q4 ("How would you describe  ...?")
A4 ("Retired")       | Q4 ("How would you describe  ...?")
```

The tool can be accessed at `/en/tools/money-navigator-tool/questionnaire`. 

![image](https://user-images.githubusercontent.com/6080548/86488983-c3542780-bd5a-11ea-9ca5-60b01642b98e.png)
