### PR TITLE
11469 - 11629 - Welsh Translation Files

### DIFF
--- a/app/views/money_navigator_tool/questionnaire.html.erb
+++ b/app/views/money_navigator_tool/questionnaire.html.erb
@@ -69,7 +69,7 @@
                           <%= f.check_box question[:code].downcase, {multiple: true, id: question[:code] + '_' + response[:code], class: 'response__control'}, response[:code].downcase, nil %>
                         <% end %>
 
-                        <label for="<%= question[:code] + "_" + response[:code] %>" class="response__text">
+                        <label for="<%= question[:code].downcase + "_" + response[:code].downcase %>" class="response__text">
                           <span><%= response[:text] %></span>
                         </label>
                       </div>

--- a/app/views/money_navigator_tool/questionnaire.html.erb
+++ b/app/views/money_navigator_tool/questionnaire.html.erb
@@ -31,8 +31,8 @@
               <% end %>
 
               <div 
-                class="question__content question__content--<%= question[:code] %>" 
-                data-question-id="<%= question[:code] %>"
+                class="question__content question__content--<%= question[:code].downcase %>" 
+                data-question-id="<%= question[:code].downcase %>"
                 <% if question[:custom] %>
                   data-question-custom
                 <% end %>

--- a/app/views/money_navigator_tool/questionnaire.html.erb
+++ b/app/views/money_navigator_tool/questionnaire.html.erb
@@ -48,12 +48,12 @@
                     <% if response[:default] %>
                       <div class="question__response" data-response>
                         <% if question[:type] == 'radio' %>
-                          <%= f.radio_button question[:code].downcase, response[:code].downcase, id: question[:code] + '_' + response[:code], class: 'response__control', checked: true %>
+                          <%= f.radio_button question[:code].downcase, response[:code].downcase, id: question[:code].downcase + '_' + response[:code].downcase, class: 'response__control', checked: true %>
                         <% elsif question[:type] == 'checkbox' %>
-                          <%= f.check_box question[:code].downcase, {multiple: true, id: question[:code] + '_' + response[:code], class: 'response__control', checked: true}, response[:code].downcase, nil %>
+                          <%= f.check_box question[:code].downcase, {multiple: true, id: question[:code].downcase + '_' + response[:code].downcase, class: 'response__control', checked: true}, response[:code].downcase, nil %>
                         <% end %>
 
-                        <label for="<%= question[:code] + "_" + response[:code] %>" class="response__text">
+                        <label for="<%= question[:code].downcase + "_" + response[:code].downcase %>" class="response__text">
                           <span><%= response[:text] %></span>
                         </label>
                       </div>
@@ -64,9 +64,9 @@
                     <% if !response[:default] %>
                       <div class="question__response" data-response>
                         <% if question[:type] == 'radio' %>
-                          <%= f.radio_button question[:code].downcase, response[:code].downcase, id: question[:code] + '_' + response[:code], class: 'response__control' %>
+                          <%= f.radio_button question[:code].downcase, response[:code].downcase, id: question[:code].downcase + '_' + response[:code].downcase, class: 'response__control' %>
                         <% elsif question[:type] == 'checkbox' %>
-                          <%= f.check_box question[:code].downcase, {multiple: true, id: question[:code] + '_' + response[:code], class: 'response__control'}, response[:code].downcase, nil %>
+                          <%= f.check_box question[:code].downcase, {multiple: true, id: question[:code].downcase + '_' + response[:code].downcase, class: 'response__control'}, response[:code].downcase, nil %>
                         <% end %>
 
                         <label for="<%= question[:code].downcase + "_" + response[:code].downcase %>" class="response__text">

--- a/app/views/money_navigator_tool/results.html.erb
+++ b/app/views/money_navigator_tool/results.html.erb
@@ -81,7 +81,7 @@
 
 				<div class="results__actions" data-actions>
 					<%= link_to('/en/tools/money-navigator-tool/questionnaire', class: 'button button--restart') do %>
-						Re-start the diagnostic
+						<%= t("money_navigator_tool.controls.re_start") %>
 					<% end %>
 				</div>
 

--- a/config/locales/money_navigator_tool/money_navigator_tool.cy.yml
+++ b/config/locales/money_navigator_tool/money_navigator_tool.cy.yml
@@ -37,11 +37,11 @@ en:
           text: Dechrau
           url: /cy/tools/money-navigator-tool/questionnaire
       crisis-help:
-        heading: Need help with debts right now?
-        text: If you’re really struggling and debts have already mounted up, you can find a free accredited debt adviser with our Debt Advice Locator
+        heading: Angen help gyda dyledion ar hyn o bryd?
+        text: Os ydych yn cael trafferth a bod dyledion eisoes wedi cynyddu, gallwch ddod o hyd i ymgynghorydd dyled achrededig am ddim gyda'n Canfyddwr Cyngor ar Ddyledion.
         cta:
-          text: Find a free debt adviser online
-          url: /cy/tools/debt-advice-locator
+          text: Dewch o hyd i ymgynghorydd dyled am ddim ar-lein
+          url: /cy/tools/canfyddwr-cyngor-ar-ddyledion/organisations
       supporting-partners:
         heading: Ein partneriaid cefnogol
         text: Cefnogir ein arweiniad ariannol gan y partneriaid allweddol hyn sy'n barod i helpu os ydych angen cyngor pellach am y materion cymhleth a achosir gan goronafeirws, gan gynnwys dyled, budd-daliadau, tai a diswyddo.

--- a/config/locales/money_navigator_tool/money_navigator_tool.cy.yml
+++ b/config/locales/money_navigator_tool/money_navigator_tool.cy.yml
@@ -68,7 +68,7 @@ cy:
     banner: Atebwch y cwestiynau hyn i gael cyngor wedi'i deilwra i chi
     counter: Cwestiwn %{number} o %{total}
     questions:
-      - code: Q0
+      - code: q0
         type: radio
         text: Lle rydych yn byw?
         sort_order: 1

--- a/config/locales/money_navigator_tool/money_navigator_tool.cy.yml
+++ b/config/locales/money_navigator_tool/money_navigator_tool.cy.yml
@@ -68,7 +68,7 @@ cy:
     banner: Atebwch y cwestiynau hyn i gael cyngor wedi'i deilwra i chi
     counter: Cwestiwn %{number} o %{total}
     questions:
-      - code: q0
+      - code: Q0
         type: radio
         text: Lle rydych yn byw?
         sort_order: 1

--- a/config/locales/money_navigator_tool/money_navigator_tool.cy.yml
+++ b/config/locales/money_navigator_tool/money_navigator_tool.cy.yml
@@ -1,0 +1,473 @@
+en:
+  money_navigator_tool:
+    meta:
+      title: Teclyn Llywio Ariannol
+      description: ''
+      canonical: https://www.moneyadviceservice.org.uk/cy/tools/money-navigator-tool
+      alternate:
+        en-GB: https://www.moneyadviceservice.org.uk/en/tools/money-navigator-tool
+        cy-GB: https://www.moneyadviceservice.org.uk/cy/tools/money-navigator-tool
+    landing:
+      intro:
+        heading: Teclyn Llywio Ariannol
+        subheading: Gwybod beth i'w wneud nesaf
+        text:
+          paras:
+            - Mae'r mesurau cyfyngiadau coronafeirws yn cael eu llacio ond maent wedi effeithio miliynau o bobl. Bydd beth mae hyn yn ei olygu i'ch cyllid yn bersonol iawn i chi.
+            - Felly os ydych chi'n chwilio am arweiniad ariannol ond nad ydych yn gwybod ble i ddechrau, nid ydych ar eich pen eich hun.
+      who-help:
+        heading: Pwy allwn ni helpu
+        bullets:
+          - Mae'ch incwm wedi gostwng ac rydych yn poeni am eich cyllid yn y dyfodol
+          - Rydych chi wedi cael eich rhoi ar ffyrlo ac rydych angen help i fynd yn ôl ar y trywydd iawn, gan gynnwys ar ôl gwyliau talu
+          - Rydych yn wynebu cael eich diswyddo neu wedi colli eich swydd
+          - Rydych yn hunangyflogedig ac mae'r gwaith wedi sychu i fyny
+          - Rydych chi am wneud y mwyaf o'r arian rydych wedi'i arbed yn ystod y cyfnod o gyfyngiadau
+      how-help:
+        heading: Cymorth ar unwaith
+        paras:
+          - Mae ein teclyn Llywio Ariannol yn rhoi cynlluniau gweithredu i chi yn seiliedig ar eich sefyllfa chi.
+          - 'Gwybod mewn 30 eiliad:'
+        bullets:
+          - P materion ariannol y mae angen i chi fynd i'r afael â hwy'n gyntaf
+          - Sut i aros yn drefnus gyda biliau a thaliadau
+          - Pa gymorth a chefnogaeth ychwanegol y mae gennych hawl iddo
+          - Ble y gallwch gael cyngor am ddim ar ddyled, tai neu ddiswyddo
+        cta:
+          text: Dechrau
+          url: /cy/tools/money-navigator-tool/questionnaire
+      crisis-help:
+        heading: Need help with debts right now?
+        text: If you’re really struggling and debts have already mounted up, you can find a free accredited debt adviser with our Debt Advice Locator
+        cta:
+          text: Find a free debt adviser online
+          url: /cy/tools/debt-advice-locator
+      supporting-partners:
+        heading: Ein partneriaid cefnogol
+        text: Cefnogir ein arweiniad ariannol gan y partneriaid allweddol hyn sy'n barod i helpu os ydych angen cyngor pellach am y materion cymhleth a achosir gan goronafeirws, gan gynnwys dyled, budd-daliadau, tai a diswyddo.
+        partners:
+          - Citizens Advice
+          - Business Debtline
+          - National Debtline
+          - Stepchange
+          - Payplan
+          - Turn2us
+          - Shelter
+          - Shelter Cymru
+          - Shelter Scotland
+    controls:
+      continue_btn: Parhau
+      back_btn: Yn ôl
+      submit_btn: Anfon
+      submit_label: Anfon
+      re_start: Ail-gychwyn y diagnostig
+      email: E-bostiwch hwn i mi
+    messages:
+      form_error: Invalid Form Values
+    heading: Teclyn Llywio Ariannol
+    banner: Atebwch y cwestiynau hyn i gael cyngor wedi'i deilwra i chi
+    counter: Cwestiwn %{number} o %{total}
+    questions:
+      - code: Q0
+        type: radio
+        text: Lle rydych yn byw?
+        sort_order: 1
+        responses:
+          - code: A1
+            text: Lloegr
+            sort_order: 1
+            default: true
+          - code: A2
+            text: Gogledd Iwerddon
+            sort_order: 2
+          - code: A3
+            text: Yr Alban
+            sort_order: 3
+          - code: A4
+            text: Cymru
+            sort_order: 4
+      - code: Q1
+        type: radio
+        custom: true
+        text: Beth yw eich statws cyflogaeth?
+        sort_order: 2
+        responses:
+          - code: A1
+            text: Cyflogedig (yn cynnwys Ffyrlo)
+            sort_order: 1
+            default: true
+          - code: A2
+            text: Hunangyflogedig
+            sort_order: 2
+          - code: A3
+            text: Di-waith
+            sort_order: 3
+          - code: A4
+            text: Wedi ymddeol
+            sort_order: 4
+      - code: Q2
+        type: radio
+        text: Ydych chi mewn perygl o gael eich diswyddo?
+        sort_order: 3
+        responses:
+          - code: A1
+            text: 'Ydw'
+            sort_order: 1
+            default: true
+          - code: A2
+            text: 'Na'
+            sort_order: 2
+      - code: Q3
+        type: radio
+        text: Os ydych yn hunangyflogedig, a ydych yn gwybod beth yw'ch incwm misol nawr?
+        sort_order: 4
+        responses:
+          - code: A1
+            text: 'Ydw'
+            sort_order: 1
+          - code: A2
+            text: 'Na'
+            sort_order: 2
+          - code: A3
+            text: 'Nid wyf yn hunangyflogedig'
+            default: true
+            sort_order: 3
+      - code: Q4
+        type: radio
+        custom: true
+        text: Sut fyddech chi'n disgrifio'ch incwm o ganlyniad i'r argyfwng coronafeirws?
+        sort_order: 5
+        responses:
+          - code: A4
+            text: Dim newid /wedi arbed arian
+            sort_order: 1
+          - code: A1
+            text: 'Gostyngiad tymor hir mewn incwm (ee: diswyddo neu gwaith wedi stopio am gyfnod amhenodol)'
+            sort_order: 2
+            default: true
+          - code: A2
+            text: Gostyngiad dros dro ac yn poeni am fy niogelwch yn y dyfodol
+            sort_order: 3
+          - code: A3
+            text: Gostyngiad dros dro ond yn disgwyl iddo gynyddu wrth i'r cyfyngiadau leddfu
+            sort_order: 4
+      - code: Q5
+        type: radio
+        text: Ydych chi wedi defnyddio unrhyw gymorth ariannol gan y llywodraeth?
+        sort_order: 6
+        responses:
+          - code: A1
+            text: Cynllun cymhorthdal incwm hunangyflogaeth
+            sort_order: 2
+            default: true
+          - code: A2
+            text: Cynllun ffyrlo
+            sort_order: 3
+          - code: A3
+            text: 'Na'
+            sort_order: 1
+      - code: Q6
+        type: radio
+        text: Ydych chi ar ei hôl hi gyda thaliadau rhent neu forgais? Atebwch "Ydw" os ydych  ar wyliau/egwyl talu y cytunwyd arno
+        sort_order: 7
+        responses:
+          - code: A7
+            text: 'Na'
+            sort_order: 1
+            default: true
+          - code: A1
+            text: Na, ond rwyf yn poeni efallai y byddaf yn mynd ar ei hôl hi gyda rhent (rhentu preifat)
+            sort_order: 2
+          - code: A2
+            text: Na, ond rwyf yn poeni efallai y byddaf yn mynd ar ei hôl hi gyda rhent (Tai cyngor/cymdeithasol)
+            sort_order: 3
+          - code: A3
+            text: Na, ond rwyf yn poeni efallai y byddaf yn mynd ar ei hôl hi gyda thaliadau morgais
+            sort_order: 4
+          - code: A4
+            text: Ydw, rwyf ar ei hôl hi gyda fy rhent oherwydd coronafeirws
+            sort_order: 5
+          - code: A5
+            text: Ydw, rwyf ar ei hôl hi gyda fy nhaliadau morgais oherwydd coronafeirws
+            sort_order: 6
+          - code: A6
+            text: Ydw, ond maent yn ôl-ddyledion sydd ddim yn gysylltiedig â choronafeirws
+            sort_order: 7
+      - code: Q7
+        type: checkbox
+        text: Ydych chi ar ei hôl hi gydag unrhyw un o'r biliau hyn?
+        explainer: Dewiswch bob un sy'n berthnasol
+        sort_order: 8
+        responses:
+          - code: A10
+            text: 'Na'
+            sort_order: 1
+            default: true
+          - code: A1
+            text: Treth cyngor
+            sort_order: 2
+          - code: A2
+            text: Nwy neu drydan
+            sort_order: 3
+          - code: A3
+            text: Taliadau i DWP/ CThEM (ee gordaliadau credydau treth, ad-daliadau benthyciad)
+            sort_order: 4
+          - code: A4
+            text: Trwydded teledu
+            sort_order: 5
+          - code: A5
+            text: Treth Incwm
+            sort_order: 6
+          - code: A6
+            text: Cynhaliaeth plant
+            sort_order: 7
+          - code: A7
+            text: Dirwyon llys
+            sort_order: 8
+          - code: A8
+            text: Cytundebau hurbwrcas
+            sort_order: 9
+          - code: A9
+            text: Dirwyon parcio ceir
+            sort_order: 10
+      - code: Q8
+        type: checkbox
+        text: Ydych chi wedi cymryd egwyl talu neu wyliau ar fenthyciadau neu gredyd?
+        explainer: Dewiswch bob un sy'n berthnasol
+        sort_order: 9
+        responses:
+          - code: A10
+            text: 'Na'
+            sort_order: 1
+            default: true
+          - code: A1
+            text: Morgais
+            sort_order: 2
+          - code: A2
+            text: Benthyciad personol
+            sort_order: 3
+          - code: A3
+            text: Cerdyn credyd
+            sort_order: 4
+          - code: A4
+            text: Cerdyn siop
+            sort_order: 5
+          - code: A5
+            text: Cyllid ceir
+            sort_order: 6
+          - code: A6
+            text: Prynu nawr talu yn nes ymlaen
+            sort_order: 7
+          - code: A7
+            text: rhentu i brynu
+            sort_order: 8
+          - code: A8
+            text: Benthyciad diwrnod talu
+            sort_order: 9
+          - code: A9
+            text: Trefniant gwystlwr
+            sort_order: 10
+      - code: Q9
+        type: checkbox
+        text: A fyddwch chi'n cael trafferth gwneud ad-daliadau yn y dyfodol, neu ydych chi eisoes wedi methu un taliad, ar y benthyciadau neu'r credyd yma?
+        explainer: Dewiswch bob un sy'n berthnasol
+        sort_order: 10
+        responses:
+          - code: A12
+            text: 'Na'
+            sort_order: 1
+            default: true
+          - code: A1
+            text: Benthyciad personol
+            sort_order: 2
+          - code: A2
+            text: Bil dŵr
+            sort_order: 3
+          - code: A3
+            text: Ffôn symudol, teledu neu fand eang
+            sort_order: 4
+          - code: A4
+            text: Cerdyn credyd
+            sort_order: 5
+          - code: A5
+            text: Cerdyn siop
+            sort_order: 6
+          - code: A6
+            text: Cyllid ceir
+            sort_order: 7
+          - code: A7
+            text: Prynu nawr talu yn nes ymlaen
+            sort_order: 8
+          - code: A8
+            text: rhentu i brynu
+            sort_order: 9
+          - code: A9
+            text: Benthyciad diwrnod talu
+            sort_order: 10
+          - code: A10
+            text: Trefniant gwystlwr
+            sort_order: 11
+          - code: A11
+            text: Ad-daliadau i deulu neu ffrindiau
+            sort_order: 12
+      - code: Q10
+        type: radio
+        text: A ydych wedi mynd ar ei hôl hi neu wedi cytuno ar egwyl taliad ar ymrwymiadau credyd neu filiau blaenoriaeth y cartref ers 28 Chwefror 2020?
+        sort_order: 11
+        responses:
+          - code: A1
+            text: 'Ydw'
+            sort_order: 1
+            default: true
+          - code: A2
+            text: 'Na'
+            sort_order: 2
+          - code: A3
+            text: Roeddwn mewn trafferthion ariannol cyn 28ain Chwefror
+            sort_order: 3
+      - code: Q11
+        type: radio
+        text: A fydd yn rhaid i chi fenthyg arian ar gyfer taliadau hanfodol (rhent, bwyd, biliau)?
+        sort_order: 12
+        responses:
+          - code: A1
+            text: 'Ydw'
+            sort_order: 1
+            default: true
+          - code: A2
+            text: 'Na'
+            sort_order: 2
+      - code: Q12
+        type: checkbox
+        text: Ydych chi'n ystyried unrhyw un o'r ffyrdd hyn i dalu dyledion neu i dalu'ch ad-daliadau credyd neu fenthyciad?
+        explainer: Dewiswch bob un sy'n berthnasol
+        sort_order: 13
+        responses:
+          - code: A5
+            text: 'Na'
+            sort_order: 1
+            default: true
+          - code: A1
+            text: Ecwiti yn fy nghartref
+            sort_order: 2
+          - code: A2
+            text: Fy nghronfa bensiwn
+            sort_order: 3
+          - code: A3
+            text: Ailforgeisio
+            sort_order: 4
+          - code: A4
+            text: Defnyddio fy nghynilion neu fuddsoddiadau
+            sort_order: 5
+      - code: Q13
+        type: radio
+        text: Ydych chi'n ystyried canslo neu leihau yswiriant oherwydd eich bod yn poeni am gostau?
+        sort_order: 14
+        responses:
+          - code: A1
+            text: 'Ydw'
+            sort_order: 1
+            default: true
+          - code: A2
+            text: 'Na'
+            sort_order: 2
+          - code: A3
+            text: Efallai
+            sort_order: 3
+      - code: Q14
+        type: radio
+        text: A yw eich pryderon ariannol yn effeithio ar eich iechyd meddwl?
+        sort_order: 15
+        responses:
+          - code: A1
+            text: 'Ydw'
+            sort_order: 1
+            default: true
+          - code: A2
+            text: 'Na'
+            sort_order: 2
+          - code: A3
+            text: Weithiau
+            sort_order: 3
+    results:
+      heading: Eich cynllun gweithredu Llywiwr Ariannol
+      intro: Yn seiliedig ar yr hyn rydych wedi'i ddweud wrthym, dyma ein barn arbenigol ar eich sefyllfa bersonol. Darganfyddwch fwy am gamau y mae'n rhaid i chi eu cymryd, lle gallwch gael help a chefnogaeth am ddim, ynghyd ag arweiniad ac awgrymiadau i'ch helpu i symud ymlaen gyda'ch arian.
+      print_btn_text: Argraffu hwn
+      S1:
+        title: Camau Brys
+      S2:
+        title: Gwyliau talu
+        subtitle: Beth i'w wneud nawr bod eich gwyliau talu wedi dod i ben
+        H1: Gwyliau talu morgais
+        H2: Gwyliau talu benthyciad personol
+        H3: Gwyliau talu cerdyn credyd
+        H4: Gwyliau talu cerdyn siop
+        H5: Gwyliau talu cyllid ceir
+        H6: Gwyliau talu prynu nawr talu yn nes ymlaen (ee Klarma)
+        H7: Gwyliau talu rhentu i brynu
+        H8: Gwyliau talu benthyciad diwrnod cyflog
+        H9: Gwyliau talu gwystlwr
+      S3:
+        title: Eich arian wrth symud ymlaen
+        H1: Cael yn ôl ar y trywydd iawn wedi gostyngiad mewn incwm
+        H2: Cael yn ôl ar y trywydd iawn wedi gostyngiad sylweddol mewn incwm
+        H3: Edrych i'r dyfodol ar ôl y pandemig COVID
+      S4:
+        title: Arian a gwaith
+        H1: Rheoli eich arian pa rydych yn hunangyflogedig
+        H2: Help brys os ydych yn hunangyflogedig
+        H3: Paratoi am ddiswyddo
+        H4: Beth i'w wneud os ydych yn ddi-waith
+      S5:
+        title: Cadw i fyny gyda thaliadau tai
+        H1: Os ydych wedi methu un taliad morgais neu rhent
+        H2: Os ydych yn poeni am daliadau rhent (rhentu preifat)
+        H3: Os ydych yn poeni am daliadau rhent (tai cymdeithasol)
+        H4: Os ydych yn poeni am daliadau morgais
+        H5: Os ydych yn mynd ar ei hôl hi gyda thaliadau rhent oherwydd COVID-19
+        H6: Os ydych yn mynd ar ei hôl hi gyda thaliadau morgais oherwydd COVID-19
+      S6:
+        title: Cadw i fyny gyda biliau blaenoriaeth
+        subtitle: Beth i'w wneud os ydych yn poeni am filiau blaenoriaeth
+        H1: Os ydych wedi methu un taliad
+        H2: Beth i'w wneud am dalu eich Treth Cyngor (Ardrethi Domestig yng Ngogledd Iwerddon)
+        H3: Beth i'w wneud am dalu eich  bil nwy neu drydan
+        H4: Beth i'w wneud am daliadau i DWP/CThEM
+        H5: Beth i'w wneud am dalu eich trwydded teledu
+        H6: Beth i'w wneud am dalu eich bil Treth Incwm
+        H7: Beth i'w wneud am dalu eich cynhaliaeth plant
+        H8: Beth i'w wneud am dalu eich dirwyon llys
+        H9: Beth i'w wneud am gytundebau hurbwrcas
+        H10: Beth i'w wneud am ddirwyon parcio ceir?
+      S7:
+        title: Cadw i fyny gyda biliau sydd ddim yn flaenoriaeth
+        subtitle: Os ydych yn poeni am daliadau neu filiau eraill
+        H1: Taliadau benthyciad personol
+        H2: Bil dŵr
+        H3: Ffôn symudol, teledu neu fand eang
+        H4: Taliadau cerdyn credyd
+        H5: Taliadau cerdyn siop
+        H6: Taliadau cyllid ceir
+        H7: Taliadau prynu nawr talu yn nes ymlaen (ee Klarma)
+        H8: Taliadau rhentu i brynu
+        H9: Talidau benthyciad diwrnod cyflog
+        H10: Taliadau gwystlwr
+        H11: Taliadau i deulu neu ffrindiau
+      S8:
+        title: Benthyca arian
+        subtitle:
+        H1: Os ydych yn meddwl am fenthyca arian
+      S9:
+        title: Defnyddio pensiynau, ecwiti a chynilion
+        subtitle:
+        H1: Os ydych yn meddwl am ddefnyddio eich cronfa bensiwn i dalu dyledion
+        H2: Os ydych yn meddwl am ddefnyddio ecwiti yn eich cartref i dalu dyledion
+        H3: Os ydych yn meddwl am ddefnyddio eich cynilion i dalu dyledion
+      S10:
+        title: Diogelu eich dyfodol
+        subtitle:
+        H1: Os ydych yn meddwl am ganslo yswiriant
+      S11:
+        title: Pryderon am arian a iechyd meddwl
+        subtitle:
+        H1: Os yw pryderon am arian yn effeithio eich iechyd meddwl

--- a/config/locales/money_navigator_tool/money_navigator_tool.cy.yml
+++ b/config/locales/money_navigator_tool/money_navigator_tool.cy.yml
@@ -1,4 +1,4 @@
-en:
+cy:
   money_navigator_tool:
     meta:
       title: Teclyn Llywio Ariannol

--- a/config/locales/money_navigator_tool/money_navigator_tool.en.yml
+++ b/config/locales/money_navigator_tool/money_navigator_tool.en.yml
@@ -7,45 +7,45 @@ en:
       alternate:
         en-GB: https://www.moneyadviceservice.org.uk/en/tools/money-navigator-tool
         cy-GB: https://www.moneyadviceservice.org.uk/cy/tools/money-navigator-tool
-    landing: 
-      intro: 
+    landing:
+      intro:
         heading: Money Navigator Tool
         subheading: Know what to do next
-        text: 
-          paras: 
+        text:
+          paras:
             - The coronavirus lockdown measures are relaxing but they’ve affected millions of people. What this means for your finances will be very personal to you.
             - So if you’re looking for money guidance but don’t know where to start, you’re not alone.
-      who-help: 
+      who-help:
         heading: Who we can help
-        bullets: 
+        bullets:
           - Your income is down and you’re worried about your future finances
           - You’ve been furloughed and need help to get back on track, including after a payment holiday
           - You’re facing redundancy or have lost your job
           - You’re self-employed and work has dried up
           - You want to make the most of money you’ve saved during lockdown
-      how-help: 
+      how-help:
         heading: Instant help
-        paras: 
+        paras:
           - Our Money Navigator tool gives you action plans based on your own situation.
           - 'Know in 30 seconds:'
-        bullets: 
-          - the money issues you need to tackle first
-          - how to stay on top of bills and payments
+        bullets:
+          - The money issues you need to tackle first
+          - How to stay on top of bills and payments
           - What extra help and support you’re entitled to
           - Where you can get free advice for debt, housing or redundancy
-        cta: 
+        cta:
           text: Get started
           url: /en/tools/money-navigator-tool/questionnaire
-      crisis-help: 
+      crisis-help:
         heading: Need help with debts right now?
         text: If you’re really struggling and debts have already mounted up, you can find a free accredited debt adviser with our Debt Advice Locator
-        cta: 
+        cta:
           text: Find a free debt adviser online
           url: /en/tools/debt-advice-locator
-      supporting-partners: 
+      supporting-partners:
         heading: Our supporting partners
         text: Our money guidance is supported by these key partners who are ready to help if you need further advice about the complex issues caused by coronavirus, including debt, benefits, housing and redundancy.
-        partners: 
+        partners:
           - Citizens Advice
           - Business Debtline
           - National Debtline
@@ -57,6 +57,8 @@ en:
           - Shelter Scotland
     controls:
       submit_label: Submit
+      re_start: Re-start the diagnostic
+      email: Email this to me
     messages:
       form_error: Invalid Form Values
     heading: Money Navigator Tool
@@ -412,10 +414,10 @@ en:
         title: Money and work
         H1: Managing your money when you’re self employed
         H2: Urgent help if you're self employed
-        H3: Preparing for redundancy 
+        H3: Preparing for redundancy
         H4: What to do if you`re unemployed
       S5:
-        title: Missed Payments
+        title: Staying on top of housing costs
         H1: If you`ve missed one mortgage or rent payment
         H2: If you’re worried about rent payments (renting privately)
         H3: If you’re worried about rent payments (social housing)
@@ -462,8 +464,8 @@ en:
       S10:
         title: Protecting your future
         subtitle:
-        H1: If you’re thinking about cancelling insurance 
+        H1: If you’re thinking about cancelling insurance
       S11:
         title: Money worries and mental health
         subtitle:
-        H1: If money worries are affecting your mental health 
+        H1: If money worries are affecting your mental health

--- a/config/locales/money_navigator_tool/money_navigator_tool.en.yml
+++ b/config/locales/money_navigator_tool/money_navigator_tool.en.yml
@@ -166,7 +166,6 @@ en:
       - code: Q6
         type: radio
         text: Are you behind with rent or mortgage payments?
-        note: 'Note: please answer "Yes" if you are on an agreed payment holiday/break'
         sort_order: 7
         responses:
           - code: A7

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,10 +14,6 @@ Rails.application.routes.draw do
   end
 
   get '/' => redirect('/en')
-  #Redirect All Welsh to English for the Money Navigator Tool
-  #TODO: Remove this once the welsh translation for the tool is available
-  get '/cy/tools/money-navigator-tool/*other', to: redirect('/en/tools/money-navigator-tool/%{other}')
-  get '/cy/tools/money-navigator-tool', to: redirect('/en/tools/money-navigator-tool')
 
   get '/robots', to: 'sitemap#robots'
 


### PR DESCRIPTION
This PR includes changes for [TP11469](https://maps.tpondemand.com/entity/11469-money-navigator-welsh-translation-files) & [TP11629](https://maps.tpondemand.com/entity/11629-remove-note-on-q6)

A new yaml file was created to accommodate the new Welsh translations implemented here. The note on question 6 was now removed from the english translations and kept the note functionality in the view. Other minor bugs regarding dynamic text were also fixed.
The existing redirect that was preveting access to the Welsh version of the tool was also removed from `routes.rb`.

**Note:** The text on the buttons is not dynamic as of this PR, welsh translations for them are now in place and the functionality will be implemented with [PR2233](https://github.com/moneyadviceservice/frontend/pull/2233)