### PR TITLE
11567 money navigator multiple questions enhanced ux

### DIFF
--- a/app/assets/javascripts/components/MoneyNavigatorQuestions.js
+++ b/app/assets/javascripts/components/MoneyNavigatorQuestions.js
@@ -5,7 +5,9 @@ define(['jquery', 'DoughBaseComponent'], function ($, DoughBaseComponent) {
     i18nStrings = {
       continue_btn: 'Continue',
       back_btn: 'Back',
-      submit_btn: 'Submit',
+      yes_btn: 'Yes',
+      no_btn: 'No',
+      submit_btn: 'Submit'
     };
 
   MoneyNavigatorQuestions = function ($el, config) {
@@ -16,7 +18,7 @@ define(['jquery', 'DoughBaseComponent'], function ($, DoughBaseComponent) {
     this.$submitBtn = this.$el.find('[data-submit]');
     this.$questions = this.$el.find('[data-question]');
     this.$multipleQuestions = this.$el.find('[data-question-multiple]');
-    this.banner = $(document).find('[data-banner]'); // this.$el.parents('[data-banner]');
+    this.banner = $(document).find('[data-banner]');
     this.activeClass = 'question--active';
     this.hiddenClass = 'is-hidden';
     this.dataLayer = window.dataLayer;
@@ -42,11 +44,10 @@ define(['jquery', 'DoughBaseComponent'], function ($, DoughBaseComponent) {
 
   MoneyNavigatorQuestions.componentName = 'MoneyNavigatorQuestions';
 
-  MoneyNavigatorQuestions.prototype.init = function (initialised) {
-    this._updateDOM(this.dataLayer);
-    this._setUpMultipleQuestions();
-    this._setUpValidation();
-    this._setUpJourneyLogic();
+  MoneyNavigatorQuestions.prototype.init = function(initialised) {
+    this._updateDOM(this.dataLayer); 
+    this._setUpMultipleQuestions(); 
+    this._setUpJourneyLogic(); 
     this._initialisedSuccess(initialised);
   };
 
@@ -105,61 +106,14 @@ define(['jquery', 'DoughBaseComponent'], function ($, DoughBaseComponent) {
     });
   };
 
-  MoneyNavigatorQuestions.prototype._setUpValidation = function () {
-    var _this = this;
-
-    this.$questions.each(function () {
-      var question = this;
-      var $inputs = $(question).find('input');
-
-      $inputs.on('change', function () {
-        var checkedInputs = [];
-
-        $inputs.each(function () {
-          if (this.checked) {
-            checkedInputs.push(this);
-          }
-        });
-
-        if (checkedInputs.length == 0) {
-          _this._handleValidation(question);
-        } else if ($(question).find('[data-error-message]').length > 0) {
-          _this._handleValidation(question, 'reset');
-        }
-      });
-    });
-  };
-
-  MoneyNavigatorQuestions.prototype._handleValidation = function (
-    question,
-    options
-  ) {
-    if (options == 'reset') {
-      $(question).find('[data-error-message]').remove();
-      $(question).find('[data-continue]').attr('disabled', false);
-    } else {
-      $(question)
-        .find('legend')
-        .after(
-          '<p class="question__error" data-error-message>Please answer this question before continuing</p>'
-        );
-      $(question).find('[data-continue]').attr('disabled', true);
-    }
-  };
-
-  MoneyNavigatorQuestions.prototype._updateAnalytics = function (
-    btn,
-    dataLayer
-  ) {
-    var question = $(btn).parents('[data-question-id]');
-    var eventAction = $(question).data('questionId').toUpperCase();
-    var eventLabel;
-    var eventResponse = '';
-    var inputs = $(btn)
-      .parents('[data-question-id]')
-      .find('input[type="radio"], input[type="checkbox"]');
-    var inputsCheckedValues = [];
-    var inputsCheckedText = [];
+  MoneyNavigatorQuestions.prototype._updateAnalytics = function(btn, dataLayer) {
+    var question = $(btn).parents('[data-question-id]'); 
+    var eventAction = $(question).data('questionId').toUpperCase(); 
+    var eventLabel; 
+    var eventResponse = ''; 
+    var inputs = $(btn).parents('[data-question-id]').find('input[type="radio"], input[type="checkbox"]'); 
+    var inputsCheckedValues = []; 
+    var inputsCheckedText = []; 
 
     for (var i = 0, length = inputs.length; i < length; i++) {
       if (inputs[i].checked) {
@@ -281,24 +235,30 @@ define(['jquery', 'DoughBaseComponent'], function ($, DoughBaseComponent) {
         _this._updateDisplay('prev');
         _this._scrollToTop();
       }
-    });
-  };
+    }); 
 
-  MoneyNavigatorQuestions.prototype._scrollToTop = function () {
-    $('html, body').animate(
-      {
-        scrollTop: $('#money_navigator__questions').offset().top,
-      },
-      250
-    );
-  };
+    buttons.each(function() {
+      if ($(this).parents('[data-question]').data('questionMultiple') == '') {
+        if ($(this).data('continue')) {
+          $(this).attr('disabled', true); 
+        }
+      }
+    }); 
+  }
 
-  MoneyNavigatorQuestions.prototype._updateDisplay = function (dir) {
-    var activeIndex,
-      progress,
-      totalQuestions,
-      questions = [],
-      questionClasses = [];
+  MoneyNavigatorQuestions.prototype._scrollToTop = function() {
+    $('html, body').animate({
+        scrollTop: $('#money_navigator__questions').offset().top
+      }, 250
+    );          
+  }; 
+
+  MoneyNavigatorQuestions.prototype._updateDisplay = function(dir) {
+    var activeIndex, 
+        progress, 
+        totalQuestions, 
+        questions = [], 
+        questionClasses = []; 
 
     this.$el.find('[data-question]').each(function () {
       if (!$(this).data('question-skip')) {
@@ -345,40 +305,116 @@ define(['jquery', 'DoughBaseComponent'], function ($, DoughBaseComponent) {
   MoneyNavigatorQuestions.prototype._setUpMultipleQuestions = function () {
     var _this = this;
 
-    this.$multipleQuestions.each(function () {
-      var inputs = $(this).find('input[type="checkbox"]');
+    this.$multipleQuestions.each(function() {
+      var inputs = $(this).find('input[type="checkbox"]'); 
+      var legend = $(this).find('legend'); 
+      var inputId = inputs[0].name.split('[')[1].split(']')[0]; 
+      var input = document.createElement('input'); 
+      var label = document.createElement('label'); 
+      var response_yes = document.createElement('div'); 
+      var response_no, input_no, input_yes;
 
-      $(inputs[0]).on('change', function (e) {
-        _this._updateMultipleQuestions(e.target);
-      });
 
-      for (var i = 0, length = inputs.length; i < length; i++) {
-        if (i > 0) {
-          inputs[i].disabled = true;
+      input.type = 'checkbox'; 
+      input.id = inputId + '_response_yes'; 
+      input.className = 'response__control'; 
+
+      label.htmlFor = inputId + '_response_yes';
+      label.className = 'response__text'; 
+      label.innerHTML = '<span>' + _this.i18nStrings.yes_btn + '</span>'; 
+
+      $(response_yes)
+        .attr('data-response', true)
+        .addClass('question__response button--yes')
+        .append(input)
+        .append(label); 
+
+      $(inputs).each(function() {
+        if ($(this).siblings('label').text().trim() == _this.i18nStrings.no_btn) {
+          response_no = $(this).parents('[data-response]'); 
+          
+          $(response_no).addClass('button--no')
+          $(legend)
+            .after(response_yes)
+            .after(response_no); 
+        }
+      }); 
+
+      input_no = response_no[0].getElementsByTagName('input')[0]; 
+      input_yes = response_yes.getElementsByTagName('input')[0]; 
+
+      input_no.checked = false; 
+      input_yes.checked = true; 
+
+      $(this).on('click', function(e) {
+        if ($(e.target).parents('[data-response]').hasClass('button--no') || $(e.target).parents('[data-response]').hasClass('button--yes')) {
+          if (e.target.checked == false) {
+            e.preventDefault(); 
+          }
+        }
+      }); 
+
+      $(this).on('change', function(e) {
+        _this._updateMultipleQuestion(e.target); 
+      }); 
+    }); 
+  }; 
+
+  MoneyNavigatorQuestions.prototype._updateMultipleQuestion = function(input) {
+    var question = $(input).parents('[data-question]'); 
+    var inputs = $(question).find('input[type="checkbox"]'); 
+    var continueBtn = $(question).find('[data-continue]'); 
+    var checkedInputs = 0; 
+
+    // Update state (checked/disabled) of inputs
+    for (var i = 0, length = inputs.length; i < length; i++) {
+      if (input == inputs[0]) {
+        // `No` is changed
+        if (input.checked) {
+          // `No` is checked
+          if (i == 1) {
+            inputs[i].checked = false; 
+          } 
+
+          if (i > 1) {
+            inputs[i].disabled = true;
+          }
+        }
+      } else if (input == inputs[1]) {
+        // `Yes` is changed
+        if (input.checked) {
+          // `Yes` is checked
+          if (i == 0) {
+            inputs[i].checked = false; 
+          } 
+
+          if (i > 1) {
+            inputs[i].disabled = false;
+          }
         }
       }
-    });
-  };
 
-  MoneyNavigatorQuestions.prototype._updateMultipleQuestions = function (
-    input
-  ) {
-    var responses = $(input)
-      .parents('[data-response]')
-      .siblings('[data-response]');
+      if (inputs[i].checked) {
+        checkedInputs++; 
+      }      
+    }
 
-    responses.each(function () {
-      $(this)
-        .find('input[type="checkbox"]')
-        .each(function () {
-          if (input.checked) {
-            this.disabled = true;
-          } else {
-            this.disabled = false;
-          }
-        });
-    });
-  };
+    if (inputs[0].checked == true) {
+      // if `No` is checked `Continue` is enabled
+      $(continueBtn[0]).attr('disabled', false); 
+    }
+
+    if (inputs[1].checked == true) {
+      // if `Yes` is checked
+        if (checkedInputs == 1) {
+        // - if 0 other options are checked `Continue` is disabled
+        $(continueBtn[0]).attr('disabled', true); 
+      } else {        
+        // - if 1 or more other options are checked `Continue` is enabled
+        $(continueBtn[0]).attr('disabled', false); 
+      }
+    }
+  }
 
   return MoneyNavigatorQuestions;
 });

--- a/app/assets/stylesheets/layout/page_specific/_money_navigator_questionnaire.scss
+++ b/app/assets/stylesheets/layout/page_specific/_money_navigator_questionnaire.scss
@@ -137,6 +137,41 @@
 		&.question--active {
 			display: block; 
 		}
+
+		&[data-question-multiple] {
+			.button--no, 
+			.button--yes {
+				display: inline-block;
+				margin: 0 $default-gutter * 2 0 0;
+
+				@include respond-to($mq-s) {
+					margin-right: $default-gutter * 1.5; 
+				}
+
+				@include respond-to($mq-m) {
+					margin-right: $default-gutter; 
+				}
+
+				.response__text {
+					@extend .button; 
+					padding: 0; 
+					text-align: left; 
+				}
+
+				.response__control {
+					@extend .visually-hidden; 
+
+					&:checked + .response__text {
+						color: $color-white; 
+						background: $color-green-secondary; 
+					}
+				}
+			}
+
+			.button--yes {
+				margin-right: 0;
+			}
+		}
 	}
 
 	.question__content--q0 {

--- a/config/locales/money_navigator_tool/money_navigator_tool.cy.yml
+++ b/config/locales/money_navigator_tool/money_navigator_tool.cy.yml
@@ -58,6 +58,8 @@ cy:
     controls:
       continue_btn: Parhau
       back_btn: Yn ôl
+      yes_btn: 'Ydw'
+      no_btn: 'Na'
       submit_btn: Anfon
       submit_label: Anfon
       re_start: Ail-gychwyn y diagnostig

--- a/config/locales/money_navigator_tool/money_navigator_tool.en.yml
+++ b/config/locales/money_navigator_tool/money_navigator_tool.en.yml
@@ -58,6 +58,8 @@ en:
     controls:
       continue_btn: Continue
       back_btn: Back
+      yes_btn: 'Yes'
+      no_btn: 'No'
       submit_btn: Submit
       submit_label: Submit
       re_start: Re-start the diagnostic

--- a/spec/javascripts/fixtures/MoneyNavigatorQuestions.html
+++ b/spec/javascripts/fixtures/MoneyNavigatorQuestions.html
@@ -60,16 +60,27 @@
 					<fieldset>
 						<legend>A multiple question</legend>
 
+						<p>Choose all that apply</p>
+
 						<div data-response>
-							<input type="checkbox" name="questions[q2][]" value="a1" checked>
+							<input type="checkbox" name="questions[q2][]" value="a1">
+							<label>
+								<span>A response</span>
+							</label>
 						</div>
 
 						<div data-response>
 							<input type="checkbox" name="questions[q2][]" value="a2">
+							<label>
+								<span>No</span>
+							</label>
 						</div>
 
 						<div data-response>
 							<input type="checkbox" name="questions[q2][]" value="a3">
+							<label>
+								<span>Another response</span>
+							</label>
 						</div>
 					</fieldset>
 				</div>


### PR DESCRIPTION
[TP11567](https://maps.tpondemand.com/entity/11567-money-navigator-enhanced-questions-ux-updates)

This work enhances the UI for some of the questions in the tool. It effects questions that are of the format that allows the user to select from multiple options, as shown below. This requires the user to deselect the 'No' option before the others are enabled, an experience that was proving confusing for many.

![image](https://user-images.githubusercontent.com/6080548/87327662-3c5a3880-c52c-11ea-85fb-f36515247bd6.png)

The UI is enhanced as described and illustrated below
- moves the 'No' option to the top of the section, directly below the question and above the text 'Choose all that apply'
- inserts a new option 'Yes' which is by default the selected option
- disables the 'Continue' button as the default state for the question
- adds logic to 
  - display the 'Yes' and 'No' options as mutually exclusive
  - enable/disable the other options dependant upon which of 'Yes' and 'No' is selected
  - enable/disable the 'Continue' button when either 'No' or at least one of the further options is selected

![image](https://user-images.githubusercontent.com/6080548/87328458-69f3b180-c52d-11ea-9b66-71fd148e1ccb.png)

Additionally 
- styles are updated to display the '' and '' options as buttons
- the client-side validation is removed as it was only relevant to this question and is no longer required now that the Continue button is disabled in circumstances that would allow the user to submit a blank value for a question. 

