### PR TITLE
Corrects type in Landing page copy

### DIFF
--- a/config/locales/money_navigator_tool/money_navigator_tool.cy.yml
+++ b/config/locales/money_navigator_tool/money_navigator_tool.cy.yml
@@ -29,7 +29,7 @@ cy:
           - Mae ein teclyn Llywio Ariannol yn rhoi cynlluniau gweithredu i chi yn seiliedig ar eich sefyllfa chi.
           - 'Gwybod mewn 30 eiliad:'
         bullets:
-          - P materion ariannol y mae angen i chi fynd i'r afael â hwy'n gyntaf
+          - Y materion ariannol y mae angen i chi fynd i'r afael â hwy'n gyntaf
           - Sut i aros yn drefnus gyda biliau a thaliadau
           - Pa gymorth a chefnogaeth ychwanegol y mae gennych hawl iddo
           - Ble y gallwch gael cyngor am ddim ar ddyled, tai neu ddiswyddo


### PR DESCRIPTION
[TP11649](https://maps.tpondemand.com/entity/11649-typo-on-landing-page-in-welsh)

This work corrects a typographical error on the landing page of the Money Navigator tool. The current and updated content is shown below. 

**Current**

![image](https://user-images.githubusercontent.com/6080548/88037438-cada4580-cb3c-11ea-81e7-e4ae147433ab.png)

**Updated**

![image](https://user-images.githubusercontent.com/6080548/88037452-d3328080-cb3c-11ea-9492-b9b1a3552017.png)
