### PR TITLE
11521 money navigator results headings changes

### DIFF
--- a/config/locales/money_navigator_tool/money_navigator_tool.cy.yml
+++ b/config/locales/money_navigator_tool/money_navigator_tool.cy.yml
@@ -62,7 +62,7 @@ cy:
       no_btn: 'Na'
       submit_btn: Anfon
       submit_label: Anfon
-      re_start: Ail-gychwyn y diagnostig
+      re_start: Dechrau eto
       email: E-bostiwch hwn i mi
     messages:
       form_error: Invalid Form Values
@@ -407,7 +407,7 @@ cy:
         H3: Gwyliau talu cerdyn credyd
         H4: Gwyliau talu cerdyn siop
         H5: Gwyliau talu cyllid ceir
-        H6: Gwyliau talu prynu nawr talu yn nes ymlaen (ee Klarma)
+        H6: Gwyliau talu prynu nawr talu yn nes ymlaen
         H7: Gwyliau talu rhentu i brynu
         H8: Gwyliau talu benthyciad diwrnod cyflog
         H9: Gwyliau talu gwystlwr
@@ -425,8 +425,8 @@ cy:
       S5:
         title: Cadw i fyny gyda thaliadau tai
         H1: Os ydych wedi methu un taliad morgais neu rhent
-        H2: Os ydych yn poeni am daliadau rhent (rhentu preifat)
-        H3: Os ydych yn poeni am daliadau rhent (tai cymdeithasol)
+        H2: Os ydych yn poeni am daliadau rhent preifat
+        H3: Os ydych yn poeni am daliadau rhent tai cymdeithasol
         H4: Os ydych yn poeni am daliadau morgais
         H5: Os ydych yn mynd ar ei hôl hi gyda thaliadau rhent oherwydd COVID-19
         H6: Os ydych yn mynd ar ei hôl hi gyda thaliadau morgais oherwydd COVID-19
@@ -434,7 +434,7 @@ cy:
         title: Cadw i fyny gyda biliau blaenoriaeth
         subtitle: Beth i'w wneud os ydych yn poeni am filiau blaenoriaeth
         H1: Os ydych wedi methu un taliad
-        H2: Beth i'w wneud am dalu eich Treth Cyngor (Ardrethi Domestig yng Ngogledd Iwerddon)
+        H2: Beth i’w wneud am dalu’ch Treth Cyngor neu Ardrethu Domestig
         H3: Beth i'w wneud am dalu eich  bil nwy neu drydan
         H4: Beth i'w wneud am daliadau i DWP/CThEM
         H5: Beth i'w wneud am dalu eich trwydded teledu
@@ -442,7 +442,7 @@ cy:
         H7: Beth i'w wneud am dalu eich cynhaliaeth plant
         H8: Beth i'w wneud am dalu eich dirwyon llys
         H9: Beth i'w wneud am gytundebau hurbwrcas
-        H10: Beth i'w wneud am ddirwyon parcio ceir?
+        H10: Beth i’w wneud am ddirwyon parcio ceir
       S7:
         title: Cadw i fyny gyda biliau sydd ddim yn flaenoriaeth
         subtitle: Os ydych yn poeni am daliadau neu filiau eraill
@@ -452,7 +452,7 @@ cy:
         H4: Taliadau cerdyn credyd
         H5: Taliadau cerdyn siop
         H6: Taliadau cyllid ceir
-        H7: Taliadau prynu nawr talu yn nes ymlaen (ee Klarma)
+        H7: Taliadau prynu nawr talu wedyn
         H8: Taliadau rhentu i brynu
         H9: Talidau benthyciad diwrnod cyflog
         H10: Taliadau gwystlwr

--- a/config/locales/money_navigator_tool/money_navigator_tool.en.yml
+++ b/config/locales/money_navigator_tool/money_navigator_tool.en.yml
@@ -62,7 +62,7 @@ en:
       no_btn: 'No'
       submit_btn: Submit
       submit_label: Submit
-      re_start: Re-start the diagnostic
+      re_start: Start again
       email: Email this to me
     messages:
       form_error: Invalid Form Values
@@ -299,7 +299,7 @@ en:
             text: Car finance
             sort_order: 7
           - code: A7
-            text: Buy now pay later (eg Klarna)
+            text: Buy now pay later
             sort_order: 8
           - code: A8
             text: Rent to own
@@ -407,7 +407,7 @@ en:
         H3: Credit card payment holidays
         H4: Store card payment holidays
         H5: Car finance payment holidays
-        H6: Buy now pay later payment holidays (eg Klarma)
+        H6: Buy now pay later payment holidays
         H7: Rent to own payment holidays
         H8: Payday loan payment holidays
         H9: Pawnbroker payment holidays
@@ -421,38 +421,38 @@ en:
         H1: Managing your money when you’re self employed
         H2: Urgent help if you're self employed
         H3: Preparing for redundancy
-        H4: What to do if you`re unemployed
+        H4: What to do if you’re unemployed
       S5:
         title: Staying on top of housing costs
-        H1: If you`ve missed one mortgage or rent payment
-        H2: If you’re worried about rent payments (renting privately)
-        H3: If you’re worried about rent payments (social housing)
+        H1: If you’ve missed one mortgage or rent payment
+        H2: If you’re worried about private rental payments
+        H3: If you’re worried about social housing rent payments
         H4: If you’re worried about mortgage payments
         H5: If you’re behind with rent payments because of COVID-19
         H6: If you’re behind with mortgage payments because of COVID-19
       S6:
         title: Staying on top of priority bills
         subtitle: What to do if you're worried about priority bills
-        H1: If you`ve missed one payment
-        H2: What to do about paying your Council Tax (Domestic Rates Northern Ireland)
+        H1: If you have missed one payment
+        H2: What to do about paying your Council Tax or Domestic Rates
         H3: What to do about paying your gas or electricity bill
         H4: What to do about payments to DWP/HMRC
-        H5: What to do about paying your TV License
+        H5: What to do about paying your TV Licence
         H6: What to do about paying your Income Tax bill
         H7: What to do about paying your child maintenance
         H8: What to do about paying court fines
         H9: What to do about hire purchase agreements
-        H10: What to do about car parking fines?
+        H10: What to do about car parking fines
       S7:
         title: Staying on top of non-priority bills
-        subtitle: if you’re worried about other payments or bills
+        subtitle: If you’re worried about other payments or bills
         H1: Personal loan payments
         H2: Water bill
         H3: Mobile phone, TV or broadband
         H4: Credit card payments
         H5: Store card payments
         H6: Car finance payments
-        H7: Buy now pay later payments (eg Klarma)
+        H7: Buy now pay later payments
         H8: Rent to own payments
         H9: Payday loan payments
         H10: Pawnbroker payments
@@ -460,13 +460,13 @@ en:
       S8:
         title: Borrowing money
         subtitle:
-        H1: If you're thinking of borrowing money
+        H1: If you are thinking of borrowing money
       S9:
         title: Using pensions, equity and savings
         subtitle:
         H1: If you’re thinking about using your pension pot to pay off debts
         H2: If you’re thinking about using equity in your home to pay off debts
-        H3: If you're thinking of using your savings to pay off debts
+        H3: If you’re thinking of using your savings to pay off debts
       S10:
         title: Protecting your future
         subtitle:


### PR DESCRIPTION
[TP11521](https://maps.tpondemand.com/entity/11521-money-navigator-text-changes-to-results)

This work makes several small text changes to the Results page. 

Many of these are in content that is dependant on the journey the user takes through the tool and appear in the overlay section. 

There is also a further change to the button at the bottom of the tool that allows the user to go through the questions again. This appears in all instances and is shown below. 

**Current (English)**

![image](https://user-images.githubusercontent.com/6080548/88066701-f9204b00-cb65-11ea-956d-94e424a9db67.png)

**Current (Welsh)**

![image](https://user-images.githubusercontent.com/6080548/88066847-279e2600-cb66-11ea-8ddf-80e5d1c327e4.png)

**Updated (English)**

![image](https://user-images.githubusercontent.com/6080548/88066732-02111c80-cb66-11ea-839b-0955613041a1.png)

**Updated (Welsh)**

![image](https://user-images.githubusercontent.com/6080548/88066902-3ab0f600-cb66-11ea-853e-c0115817e898.png)
