### PR TITLE
11559 money navigator results ux urgent cta

### DIFF
--- a/app/assets/stylesheets/layout/page_specific/_money_navigator_results.scss
+++ b/app/assets/stylesheets/layout/page_specific/_money_navigator_results.scss
@@ -1,6 +1,10 @@
 $transition-time: 0.4s;
 
 .l-money_navigator-results {
+	.results__subheading {
+		text-transform: uppercase;
+	}
+
 	.results__intro {
 		font-size: 1.125rem; 
 		font-weight: 700; 
@@ -15,9 +19,12 @@ $transition-time: 0.4s;
 			@include column(12); 
 
 			font-size: 1rem; 
-			text-transform: uppercase;
 			margin-top: $baseline-unit * 2; 
 			color: $color-black; 
+
+			.heading--strong {
+				text-transform: uppercase;
+			}
 		}
 
 		.urgent-actions__actions {
@@ -535,7 +542,7 @@ $transition-time: 0.4s;
 
 	// Enhanced print styles
 	@media print {
-		p, ul, li, a, h1, h2, h3, h4, h5 {
+		p, ul, li, a, h1, h2, h3, h4, h5, h6 {
 			font-size: 12pt !important; 
 		}
 

--- a/app/views/money_navigator_tool/results.html.erb
+++ b/app/views/money_navigator_tool/results.html.erb
@@ -9,10 +9,12 @@
 
 			<p class="results__intro"><%= t("money_navigator_tool.results.intro") %></p>
 
+    	<h2 class="results__subheading"><%= t("money_navigator_tool.results.subheading") %></h2>
+
       <% @results.select {|res| res[:section_code] == 'S1'}.each do |section| %>
         <section class="results__urgent-actions">
           <div class="urgent-actions__content">
-            <h2 class="urgent-actions__heading"><%= t('money_navigator_tool.results.S1.title') %></h2>
+            <h3 class="urgent-actions__heading"><%= t('money_navigator_tool.results.S1.title_html') %></h3>
 
             <ul class="urgent-actions__actions">
               <% section[:headings].each do |heading| %>
@@ -33,32 +35,32 @@
 				<ul class="sections__sections">
           <% @results.reject {|res| res[:section_code] == 'S1'}.each do |result| %>
 						<li class="sections__section" data-section>
-							<h3 class="section__title" data-section-title>
+							<h4 class="section__title" data-section-title>
 								<button class="mntreshead">
 									<span class="section__title__text">
 										<%= t("money_navigator_tool.results.#{result[:section_code]}.title") %>
 									</span>
 								</button>
-							</h3>
+							</h4>
 
 							<div class="section__content">
 								<% if I18n.exists?("money_navigator_tool.results.#{result[:section_code]}.subtitle") %>
-									<h4 class="section__subtitle"><%= t("money_navigator_tool.results.#{result[:section_code]}.subtitle") %></h4>
+									<h5 class="section__subtitle"><%= t("money_navigator_tool.results.#{result[:section_code]}.subtitle") %></h5>
 								<% end %>
 
 								<ul class="sections__headings">
 									<% result[:headings].each do |heading| %>
 										<li class="sections__heading" data-heading>
 											<button class="mntresult">
-												<h5 class="heading__title" data-heading-title>
+												<h6 class="heading__title" data-heading-title>
 													<%= t("money_navigator_tool.results.#{result[:section_code]}.#{heading[:heading_code]}") %>
-												</h5>
+												</h6>
 											</button>
 
 											<div class="heading__content mntpanel" data-heading-content>
-												<h2 class="heading__content__title">
+												<h3 class="heading__content__title">
 													<%= t("money_navigator_tool.results.#{result[:section_code]}.#{heading[:heading_code]}") %>
-												</h2>
+												</h3>
 
 												<%= heading[:content][:html].html_safe %>
 

--- a/config/locales/money_navigator_tool/money_navigator_tool.cy.yml
+++ b/config/locales/money_navigator_tool/money_navigator_tool.cy.yml
@@ -394,10 +394,11 @@ cy:
             sort_order: 3
     results:
       heading: Eich cynllun gweithredu Llywiwr Ariannol
+      subheading: Beth nesaf?
       intro: Yn seiliedig ar yr hyn rydych wedi'i ddweud wrthym, dyma ein barn arbenigol ar eich sefyllfa bersonol. Darganfyddwch fwy am gamau y mae'n rhaid i chi eu cymryd, lle gallwch gael help a chefnogaeth am ddim, ynghyd ag arweiniad ac awgrymiadau i'ch helpu i symud ymlaen gyda'ch arian.
       print_btn_text: Argraffu hwn
       S1:
-        title: Camau Brys
+        title_html: <span class="heading--strong">Camau Brys</span> &#8211; Beth ddylech ei wneud gyntaf
       S2:
         title: Gwyliau talu
         subtitle: Beth i'w wneud nawr bod eich gwyliau talu wedi dod i ben

--- a/config/locales/money_navigator_tool/money_navigator_tool.en.yml
+++ b/config/locales/money_navigator_tool/money_navigator_tool.en.yml
@@ -394,10 +394,11 @@ en:
             sort_order: 3
     results:
       heading: Your Money Navigator action plan
+      subheading: What’s next?
       intro: Based on what you’ve told us, here’s our expert view on your personal situation. Find out more about actions you need to take, where you can get free help and support, as well as guidance and tips to help you move forward with your money.
       print_btn_text: Print this
       S1:
-        title: Urgent actions
+        title_html: <span class="heading--strong">Urgent actions</span> &#8211; What you should do first
       S2:
         title: Payment holidays
         subtitle: What to do now your payment holiday has ended


### PR DESCRIPTION
[TP11559](https://maps.tpondemand.com/entity/11559-money-navigator-ux-improvement-on-urgent)

This work updates the heading of the 'Urgent Actions' section of the Money Navigator results page for increased prominence. 

**Current**

![image](https://user-images.githubusercontent.com/6080548/88695036-428a1080-d0f9-11ea-9b79-7a90b6b04922.png)

**Updated**

![image](https://user-images.githubusercontent.com/6080548/88695066-49b11e80-d0f9-11ea-9f87-534e469ce691.png)

