### PR TITLE
11590 money navigator grouped questions

### DIFF
--- a/app/assets/javascripts/components/MoneyNavigatorQuestions.js
+++ b/app/assets/javascripts/components/MoneyNavigatorQuestions.js
@@ -8,7 +8,8 @@ define(['jquery', 'DoughBaseComponent'], function ($, DoughBaseComponent) {
         back_btn: 'Back',
         yes_btn: 'Yes',
         no_btn: 'No',
-        submit_btn: 'Submit'
+        submit_btn: 'Submit', 
+        reset: 'Reset'
       }, 
       messages: {
         completed: 'completed'        
@@ -23,8 +24,10 @@ define(['jquery', 'DoughBaseComponent'], function ($, DoughBaseComponent) {
     this.$submitBtn = this.$el.find('[data-submit]');
     this.$questions = this.$el.find('[data-question]');
     this.$multipleQuestions = this.$el.find('[data-question-multiple]');
+    this.$groupedQuestions = this.$el.find('[data-question-grouped]');
     this.banner = $(document).find('[data-banner]');
     this.activeClass = 'question--active';
+    this.inactiveClass = 'question--inactive'; 
     this.hiddenClass = 'is-hidden';
     this.dataLayer = window.dataLayer;
     this.skipQuestions = [
@@ -52,9 +55,166 @@ define(['jquery', 'DoughBaseComponent'], function ($, DoughBaseComponent) {
   MoneyNavigatorQuestions.prototype.init = function(initialised) {
     this._updateDOM(this.dataLayer); 
     this._setUpMultipleQuestions(); 
+    this._setUpGroupedQuestions(); 
     this._setUpJourneyLogic(); 
     this._initialisedSuccess(initialised);
   };
+
+  /**
+   *  A method to set up grouped questions
+   *  These are questions that combine its responses into distinct groups for UX purposes
+   *  This method updates the DOM to group the reponses and add a control option for each
+   */
+  MoneyNavigatorQuestions.prototype._setUpGroupedQuestions = function() {
+    var _this = this; 
+
+    this.$groupedQuestions.each(function() {
+      var $groupedResponses = $(this).find('[data-response-group], [data-response]'); 
+      var groups = {}; 
+      var titles = $(this).data('question-grouped-group-titles'); 
+      var i = 0; 
+      var groupNum = 0; 
+      var questionResponses = document.createElement('div'); 
+
+      // Collect all responses into arrays and remove from DOM
+      $groupedResponses.each(function() {
+        if ($(this).data('response-group')) {
+          var groupNum = $(this).data('response-group');  
+          
+          if (!groups[groupNum]) {
+            groups[groupNum] = []; 
+          }
+
+          groups[groupNum].push(this); 
+        } else {
+          groups['default'] = this; 
+        }
+
+        $(this).remove(); 
+      }); 
+
+      groupNum = Object.keys(groups).length; 
+
+      $(questionResponses)
+        .addClass('response__controls')
+        .attr('data-response-controls', true)
+        .css('width', (1 / groupNum * 100) + '%'); 
+
+      for(var num in groups) {
+        if (num === 'default') {
+          $(questionResponses).prepend(groups[num].outerHTML); 
+        } else {
+          var response = document.createElement('div'); 
+          var collection = document.createElement('div'); 
+          var reset = document.createElement('button'); 
+
+          // Add responses to the DOM
+          $(response)
+            .append('<input class="response__control" id="control_' + num + '" type="checkbox" value=""><label for="control_' + num + '" class="response__text"><span>' + titles[i] + '</span></label></div>')
+            .attr('data-response-group-control', num)
+            .addClass('question__response question__response--control'); 
+
+          $(this).find('.content__inner').append(response); 
+
+          $(questionResponses).append(response); 
+
+          // Add collections and resets to the DOM
+          $(collection)
+            .addClass('question__response--collection question--inactive')
+            .attr('data-response-collection', num);
+
+          $(groups[num]).each(function() {
+            $(collection).append(groups[num]); 
+          }); 
+
+          $(reset)
+            .addClass('button button--reset')
+            .attr('data-reset', true)
+            .text(_this.i18nStrings.controls.reset); 
+
+          $(this).find('.content__inner').append(collection);
+          $(collection).prepend('<p class="collection__title">' + titles[i] + '</p>'); 
+          $(collection).append(reset); 
+          $(collection).css({
+            'marginLeft': (1 / groupNum * -100 * i) + '%', 
+            'width': (1 / groupNum * 100) + '%'
+          }); 
+
+          $(reset).on('click', function(e) {
+            e.preventDefault(); 
+            _this._updateGroupedQuestionsDisplay(e.target); 
+          }); 
+        }
+
+        i++; 
+      }
+
+      $(this).find('.content__inner')
+        .prepend(questionResponses)
+        .css('width', (i * 100) + '%')
+        .on('change', function(e) {
+          _this._updateGroupedQuestionsDisplay(e.target); 
+        }); 
+    }); 
+  }; 
+
+  /**
+   * A method that is called when the controls created by _setUpGroupedQuestions are activated
+   */
+  MoneyNavigatorQuestions.prototype._updateGroupedQuestionsDisplay = function(el) {
+    var $container = $(el).parents('.question__content').find('.content__inner');
+
+    if ($(el).data('reset') || $(el).data('back')) {
+      $container.children('[data-response-controls]').removeClass(this.inactiveClass); 
+      $container.children('[data-response-group-control]').removeClass(this.inactiveClass); 
+      $container.children('[data-response-collection]').addClass(this.inactiveClass); 
+    } else if ($(el).parents('[data-response-controls]').length > 0) {
+      var id = el.id.split('_')[1];
+      var $responseControls = $container.children('[data-response-controls]'); 
+
+      if (el.id.indexOf('control_') > -1) {
+        $responseControls.addClass(this.inactiveClass)
+      }
+
+      $responseControls.find('input').each(function() {
+        if (el.id.indexOf('control_') > -1) {
+          if (this.id == 'control_' + id) {
+            this.checked = true; 
+          } else {
+            this.checked = false; 
+          }
+        } else {
+          if (this.id.indexOf('control_') == -1) {
+            this.checked = true; 
+          } else {
+            this.checked = false; 
+          }
+        }
+      }); 
+
+      $container.children('[data-response-collection]').addClass(this.inactiveClass); 
+      $container.children('[data-response-collection="' + id + '"]').removeClass(this.inactiveClass); 
+    } else {
+      el.checked = true; 
+    }
+
+    // set state of `Continue`
+    var $continueBtn = $container.parents('[data-question-id]').find('[data-continue]'); 
+    var $inputs = $container.find('input');
+    var disabled = false; 
+
+    $inputs.each(function() {
+      if (this.checked == true) {
+        if (this.name == '') {
+          disabled = true; 
+        } else {
+          disabled = false; 
+        }
+      }
+    });
+
+    $continueBtn.attr('disabled', disabled); 
+  }; 
 
   /**
    *  This method sets up customised journeys through the questions
@@ -239,6 +399,7 @@ define(['jquery', 'DoughBaseComponent'], function ($, DoughBaseComponent) {
         e.preventDefault();
         _this._updateDisplay('prev');
         _this._scrollToTop();
+        _this._updateGroupedQuestionsDisplay(e.target); 
       }
     }); 
 
@@ -312,7 +473,7 @@ define(['jquery', 'DoughBaseComponent'], function ($, DoughBaseComponent) {
 
     this.$multipleQuestions.each(function() {
       var inputs = $(this).find('input[type="checkbox"]'); 
-      var legend = $(this).find('legend'); 
+      var inner = $(this).find('.content__inner'); 
       var inputId = inputs[0].name.split('[')[1].split(']')[0]; 
       var input = document.createElement('input'); 
       var label = document.createElement('label'); 
@@ -340,9 +501,9 @@ define(['jquery', 'DoughBaseComponent'], function ($, DoughBaseComponent) {
           response_no = $(this).parents('[data-response]'); 
           
           $(response_no).addClass('button--no')
-          $(legend)
-            .after(response_yes)
-            .after(response_no); 
+          $(inner)
+            .prepend(response_yes)
+            .prepend(response_no); 
         }
       }); 
 

--- a/app/assets/stylesheets/layout/page_specific/_money_navigator_questionnaire.scss
+++ b/app/assets/stylesheets/layout/page_specific/_money_navigator_questionnaire.scss
@@ -222,6 +222,103 @@
 				}
 			}			
 		}
+
+		&[data-question-grouped] {
+			$transition-time: 0.5s;
+
+			fieldset {
+				overflow: hidden;
+			}
+
+			.content__inner {
+				box-sizing: content-box;
+				padding: 0 $default-gutter * 2;
+				margin: 0 $default-gutter * -2;
+
+				.response__controls,
+				.question__response--collection {
+					float: left;
+					transition: transform $transition-time;
+				}
+
+				.response__controls {
+					transform: translateX(0%);
+					margin-right: $default-gutter;
+	
+					&.question--inactive {
+						transform: translateX(-100% - ($default-gutter * 3));
+					}
+				}
+
+				.question__response--collection {
+					transform: translateX(-100% - ($default-gutter * 3));
+
+					&.question--inactive {
+						transform: translateX(0%);
+					}
+				}
+			}
+
+			.question__response--control {
+				label {
+					span:after {
+						content: '\A0\2026';
+					}
+				}
+			}
+
+			.question__response--collection {
+				.collection__title {
+					font-size: 1.125rem; 
+					margin-top: 0; 
+
+					&:after {
+						content: '\A0\2026';						
+					}
+				}
+
+				label {
+					span {
+						span {
+							white-space: normal;
+
+							&:before {
+								content: '\2026\A0'; 
+							}
+
+							&:first-child {
+								display: none; 
+							}
+						}
+					}
+				}
+
+				.button--reset {
+					background: $color-white;
+					border: solid 1px;
+				}
+			}
+		}
+	}
+
+	.question__content--q0, 
+	[data-question-grouped] {
+		.response__text {
+			@extend .button; 
+			padding: 0; 
+			width: 100%;
+			text-align: left; 
+		}
+
+		.response__control {
+			@extend .visually-hidden; 
+
+			&[type="radio"]:checked + .response__text, 
+			&[type="checkbox"]:checked + .response__text {
+				color: $color-white; 
+				background: $color-green-secondary; 
+			}
+		}
 	}
 
 	.question__content--q0 {
@@ -277,12 +374,7 @@
 		}
 
 		.response__control {
-			@extend .visually-hidden; 
-
 			&:checked + .response__text {
-				color: $color-white; 
-				background: $color-green-secondary; 
-
 				@include respond-to($mq-l) {
 					color: $color-green-secondary !important;
 					background: $color-green-pale !important;

--- a/app/views/money_navigator_tool/questionnaire.html.erb
+++ b/app/views/money_navigator_tool/questionnaire.html.erb
@@ -32,6 +32,10 @@
               <% if question[:type] == 'checkbox' %>
                 data-question-multiple
               <% end %>
+              <% if question[:grouped] %>
+                data-question-grouped
+                data-question-grouped-group-titles="<%= question[:group_titles] %>"
+              <% end %>
             >
               <% if index > 0 %>
                 <p class="question__counter"><%= t("money_navigator_tool.counter", number: index, total: t("money_navigator_tool.questions").length - 1) %></p>
@@ -47,41 +51,58 @@
                 <fieldset>
                   <legend class="question__heading"><%= question[:text] %></legend>
 
-                  <% if question[:explainer] %>
-                    <p class="question__explainer"><%= question[:explainer] %></p>
-                  <% end %>
-
-                  <% question[:responses].each do |response| %>
-                    <% if response[:default] %>
-                      <div class="question__response" data-response>
-                        <% if question[:type] == 'radio' %>
-                          <%= f.radio_button question[:code].downcase, response[:code].downcase, id: question[:code].downcase + '_' + response[:code].downcase, class: 'response__control', checked: true %>
-                        <% elsif question[:type] == 'checkbox' %>
-                          <%= f.check_box question[:code].downcase, {multiple: true, id: question[:code].downcase + '_' + response[:code].downcase, class: 'response__control', checked: true}, response[:code].downcase, nil %>
-                        <% end %>
-
-                        <label for="<%= question[:code].downcase + "_" + response[:code].downcase %>" class="response__text">
-                          <span><%= response[:text] %></span>
-                        </label>
-                      </div>
+                  <div class="content__inner">
+                    <% if question[:explainer] %>
+                      <p class="question__explainer"><%= question[:explainer] %></p>
                     <% end %>
-                  <% end %>
 
-                  <% question[:responses].each do |response| %>
-                    <% if !response[:default] %>
-                      <div class="question__response" data-response>
-                        <% if question[:type] == 'radio' %>
-                          <%= f.radio_button question[:code].downcase, response[:code].downcase, id: question[:code].downcase + '_' + response[:code].downcase, class: 'response__control' %>
-                        <% elsif question[:type] == 'checkbox' %>
-                          <%= f.check_box question[:code].downcase, {multiple: true, id: question[:code].downcase + '_' + response[:code].downcase, class: 'response__control'}, response[:code].downcase, nil %>
-                        <% end %>
+                    <% question[:responses].each do |response| %>
+                      <% if response[:default] %>
+                        <div class="question__response" data-response
+                          <% if response[:group] %>
+                            data-response-group="<%= response[:group] %>"
+                          <% end %>
+                        >
+                          <% if question[:type] == 'radio' %>
+                            <%= f.radio_button question[:code].downcase, response[:code].downcase, id: question[:code].downcase + '_' + response[:code].downcase, class: 'response__control', checked: true %>
+                          <% elsif question[:type] == 'checkbox' %>
+                            <%= f.check_box question[:code].downcase, {multiple: true, id: question[:code].downcase + '_' + response[:code].downcase, class: 'response__control', checked: true}, response[:code].downcase, nil %>
+                          <% end %>
 
-                        <label for="<%= question[:code].downcase + "_" + response[:code].downcase %>" class="response__text">
-                          <span><%= response[:text] %></span>
-                        </label>
-                      </div>
+                          <label for="<%= question[:code].downcase + "_" + response[:code].downcase %>" class="response__text">
+                            <span><%= response[:text] %></span>
+                          </label>
+                        </div>
+                      <% end %>
                     <% end %>
-                  <% end %>
+
+                    <% question[:responses].each do |response| %>
+                      <% if !response[:default] %>
+                        <div class="question__response" data-response
+                          <% if response[:group] %>
+                            data-response-group="<%= response[:group] %>"
+                          <% end %>
+                        >
+                          <% if question[:type] == 'radio' %>
+                            <%= f.radio_button question[:code].downcase, response[:code].downcase, id: question[:code].downcase + '_' + response[:code].downcase, class: 'response__control' %>
+                          <% elsif question[:type] == 'checkbox' %>
+                            <%= f.check_box question[:code].downcase, {multiple: true, id: question[:code].downcase + '_' + response[:code].downcase, class: 'response__control'}, response[:code].downcase, nil %>
+                          <% end %>
+
+                          <label for="<%= question[:code].downcase + "_" + response[:code].downcase %>" class="response__text">
+                            <span>
+                              <% if response[:text].is_a? Array %>
+                                <span><%= response[:text][0] %></span>
+                                <span><%= response[:text][1] %></span>
+                              <% else %>
+                                <%= response[:text] %>
+                              <% end %>
+                            </span>
+                          </label>
+                        </div>
+                      <% end %>
+                    <% end %>
+                   </div>
                 </fieldset>
 
                 <% if question[:note] %>

--- a/config/locales/money_navigator_tool/money_navigator_tool.cy.yml
+++ b/config/locales/money_navigator_tool/money_navigator_tool.cy.yml
@@ -64,6 +64,7 @@ cy:
       submit_label: Anfon
       re_start: Dechrau eto
       email: E-bostiwch hwn i mi
+      reset: Ailosod
     messages:
       form_error: Invalid Form Values
       completed: wedi'i gwblhau
@@ -171,6 +172,10 @@ cy:
             sort_order: 1
       - code: Q6
         type: radio
+        grouped: true
+        group_titles: 
+          - Na, ond rwyf yn poeni
+          - Ydw
         text: Ydych chi ar ei hôl hi gyda thaliadau rhent neu forgais? Atebwch "Ydw" os ydych  ar wyliau/egwyl talu y cytunwyd arno
         sort_order: 7
         responses:
@@ -179,23 +184,29 @@ cy:
             sort_order: 1
             default: true
           - code: A1
-            text: Na, ond rwyf yn poeni efallai y byddaf yn mynd ar ei hôl hi gyda rhent (rhentu preifat)
+            text: ['Na, ond rwyf yn poeni', 'efallai y byddaf yn mynd ar ei hôl hi gyda rhent (rhentu preifat)']
             sort_order: 2
+            group: 1
           - code: A2
-            text: Na, ond rwyf yn poeni efallai y byddaf yn mynd ar ei hôl hi gyda rhent (Tai cyngor/cymdeithasol)
+            text: ['Na, ond rwyf yn poeni', 'efallai y byddaf yn mynd ar ei hôl hi gyda rhent (Tai cyngor/cymdeithasol)']
             sort_order: 3
+            group: 1
           - code: A3
-            text: Na, ond rwyf yn poeni efallai y byddaf yn mynd ar ei hôl hi gyda thaliadau morgais
+            text: ['Na, ond rwyf yn poeni', 'efallai y byddaf yn mynd ar ei hôl hi gyda thaliadau morgais']
             sort_order: 4
+            group: 1
           - code: A4
-            text: Ydw, rwyf ar ei hôl hi gyda fy rhent oherwydd coronafeirws
+            text: ['Ydw,', 'rwyf ar ei hôl hi gyda fy rhent oherwydd coronafeirws']
             sort_order: 5
+            group: 2
           - code: A5
-            text: Ydw, rwyf ar ei hôl hi gyda fy nhaliadau morgais oherwydd coronafeirws
+            text: ['Ydw,', 'rwyf ar ei hôl hi gyda fy nhaliadau morgais oherwydd coronafeirws']
             sort_order: 6
+            group: 2
           - code: A6
-            text: Ydw, ond maent yn ôl-ddyledion sydd ddim yn gysylltiedig â choronafeirws
+            text: ['Ydw,', 'ond maent yn ôl-ddyledion sydd ddim yn gysylltiedig â choronafeirws']
             sort_order: 7
+            group: 2
       - code: Q7
         type: checkbox
         text: Ydych chi ar ei hôl hi gydag unrhyw un o'r biliau hyn?

--- a/config/locales/money_navigator_tool/money_navigator_tool.en.yml
+++ b/config/locales/money_navigator_tool/money_navigator_tool.en.yml
@@ -64,6 +64,7 @@ en:
       submit_label: Submit
       re_start: Start again
       email: Email this to me
+      reset: Reset
     messages:
       form_error: Invalid Form Values
       completed: completed
@@ -171,6 +172,10 @@ en:
             sort_order: 1
       - code: Q6
         type: radio
+        grouped: true
+        group_titles: 
+          - No, but I'm worried
+          - 'Yes'
         text: Are you behind with rent or mortgage payments?
         sort_order: 7
         responses:
@@ -179,23 +184,29 @@ en:
             sort_order: 1
             default: true
           - code: A1
-            text: No, but I am worried that I might fall behind on rent (private renting)
+            text: ['No, but I am worried', 'that I might fall behind on rent (private renting)']
             sort_order: 2
+            group: 1
           - code: A2
-            text: No, but I am worried that I might fall behind on rent (council/social housing)
+            text: ['No, but I am worried', 'that I might fall behind on rent (council/social housing)']
             sort_order: 3
+            group: 1
           - code: A3
-            text: No, but I am worried that I might fall behind on mortgage payments
+            text: ['No, but I am worried', 'that I might fall behind on mortgage payments']
             sort_order: 4
+            group: 1
           - code: A4
-            text: Yes, I am behind with my rent because of coronavirus
+            text: ['Yes,', 'I am behind with my rent because of coronavirus']
             sort_order: 5
+            group: 2
           - code: A5
-            text: Yes, I am behind with my mortgage because of coronavirus
+            text: ['Yes,', 'I am behind with my mortgage because of coronavirus']
             sort_order: 6
+            group: 2
           - code: A6
-            text: Yes, but they are arrears unrelated to coronavirus
+            text: ['Yes,', 'but they are arrears unrelated to coronavirus']
             sort_order: 7
+            group: 2
       - code: Q7
         type: checkbox
         text: Are you behind on any of these bills?

--- a/spec/javascripts/fixtures/MoneyNavigatorQuestions.html
+++ b/spec/javascripts/fixtures/MoneyNavigatorQuestions.html
@@ -8,16 +8,18 @@
 
 				<div class="question__content" data-question-id="q0">
 					<fieldset>
-						<div data-response>
-							<input type="radio" name="questions[q0]" value="a1" checked>
-						</div>
+						<div class="content__inner">
+							<div data-response>
+								<input type="radio" name="questions[q0]" value="a1" checked>
+							</div>
 
-						<div data-response>
-							<input type="radio" name="questions[q0]" value="a2">
-						</div>
+							<div data-response>
+								<input type="radio" name="questions[q0]" value="a2">
+							</div>
 
-						<div data-response>
-							<input type="radio" name="questions[q0]" value="a3">
+							<div data-response>
+								<input type="radio" name="questions[q0]" value="a3">
+							</div>
 						</div>
 					</fieldset>
 				</div>
@@ -30,24 +32,26 @@
 					<fieldset>
 						<legend>A custom question</legend>
 
-						<div data-response>
-							<input type="radio" name="questions[q1]" value="a1" checked>
-							<label>A custom response</label>
-						</div>
+						<div class="content__inner">
+							<div data-response>
+								<input type="radio" name="questions[q1]" value="a1" checked>
+								<label>A custom response</label>
+							</div>
 
-						<div data-response>
-							<input type="radio" name="questions[q1]" value="a2">
-							<label>Another custom response</label>
-						</div>
+							<div data-response>
+								<input type="radio" name="questions[q1]" value="a2">
+								<label>Another custom response</label>
+							</div>
 
-						<div data-response>
-							<input type="radio" name="questions[q1]" value="a3">
-							<label>Yet another custom response</label>
-						</div>
+							<div data-response>
+								<input type="radio" name="questions[q1]" value="a3">
+								<label>Yet another custom response</label>
+							</div>
 
-						<div data-response>
-							<input type="radio" name="questions[q1]" value="a4">
-							<label>Not really a meaningful response at all</label>
+							<div data-response>
+								<input type="radio" name="questions[q1]" value="a4">
+								<label>Not really a meaningful response at all</label>
+							</div>
 						</div>
 					</fieldset>
 				</div>
@@ -60,47 +64,69 @@
 					<fieldset>
 						<legend>A multiple question</legend>
 
-						<p>Choose all that apply</p>
+						<div class="content__inner">
+							<p>Choose all that apply</p>
 
-						<div data-response>
-							<input type="checkbox" name="questions[q2][]" value="a1">
-							<label>
-								<span>A response</span>
-							</label>
-						</div>
+							<div data-response>
+								<input type="checkbox" name="questions[q2][]" value="a1">
+								<label>
+									<span>A response</span>
+								</label>
+							</div>
 
-						<div data-response>
-							<input type="checkbox" name="questions[q2][]" value="a2">
-							<label>
-								<span>No</span>
-							</label>
-						</div>
+							<div data-response>
+								<input type="checkbox" name="questions[q2][]" value="a2">
+								<label>
+									<span>No</span>
+								</label>
+							</div>
 
-						<div data-response>
-							<input type="checkbox" name="questions[q2][]" value="a3">
-							<label>
-								<span>Another response</span>
-							</label>
+							<div data-response>
+								<input type="checkbox" name="questions[q2][]" value="a3">
+								<label>
+									<span>Another response</span>
+								</label>
+							</div>
 						</div>
 					</fieldset>
 				</div>
 			</li>
 
-			<li data-question class="l-money_navigator__question">
+			<li 
+				data-question data-question-grouped 
+				data-question-grouped-group-titles="['No, but I\'m worried', 'Yes']"
+				class="l-money_navigator__question"
+			>
 				<p class="question__counter">Question 4 of 6</p>
 
 				<div class="question__content" data-question-id="q3">
 					<fieldset>
-						<div data-response>
-							<input type="radio" name="questions[q3]" value="a1" checked>
-						</div>
+						<legend>A grouped question</legend>
 
-						<div data-response>
-							<input type="radio" name="questions[q3]" value="a2">
-						</div>
+						<div class="content__inner">
+							<div data-response>
+								<input type="radio" name="questions[q3]" value="a1" id="q3_a1" checked>
+							</div>
 
-						<div data-response>
-							<input type="radio" name="questions[q3]" value="a3">
+							<div data-response data-response-group="1">
+								<input type="radio" name="questions[q3]" value="a2" id="q3_a2">
+							</div>
+
+							<div data-response data-response-group="1">
+								<input type="radio" name="questions[q3]" value="a3" id="q3_a3">
+							</div>
+
+							<div data-response data-response-group="2">
+								<input type="radio" name="questions[q3]" value="a4" id="q3_a4">
+							</div>
+
+							<div data-response data-response-group="2">
+								<input type="radio" name="questions[q3]" value="a5" id="q3_a5">
+							</div>
+
+							<div data-response data-response-group="1">
+								<input type="radio" name="questions[q3]" value="a6" id="q3_a6">
+							</div>
 						</div>
 					</fieldset>
 				</div>
@@ -117,8 +143,10 @@
 
 				<div class="question__content" data-question-id="q5">
 					<fieldset>
-						<div data-response>
-							<input type="radio" name="questions[q5]" value="a1" checked>
+						<div class="content__inner">
+							<div data-response>
+								<input type="radio" name="questions[q5]" value="a1" checked>
+							</div>
 						</div>
 					</fieldset>
 				</div>


### PR DESCRIPTION
[TP11590](https://maps.tpondemand.com/entity/11590-money-navigator-enhanced-questions-ux-updates)

This work enhances the UX of a particular subset of questions by creating a generic `Grouped Questions` element. This updates the DOM fairly substantially for any instances of this subset of question by 
- grouping together all responses except the default one and removing those from the view
- adding new `control` options that show/hide the grouped responses when clicked
The initial state of the question as it currently exists and in its updated form is displayed in the screenshots below. 

**Current**

![image](https://user-images.githubusercontent.com/6080548/89669009-a15c4080-d8d6-11ea-9ce2-8cbcda99988d.png)

**Updated**

![image](https://user-images.githubusercontent.com/6080548/89669022-a7522180-d8d6-11ea-92f8-5d5476f78fd6.png)

Logic is added to this initial state to allow the grouped responses to be shown as appropriate, as shown below. 

**On clicking `No, but I'm worried ...`**

![image](https://user-images.githubusercontent.com/6080548/89669552-8938f100-d8d7-11ea-824f-e10aa1a80f70.png)

**On clicking `Yes ...`**

![image](https://user-images.githubusercontent.com/6080548/89669573-8fc76880-d8d7-11ea-9748-20699b802909.png)

In either case clicking `Reset` returns the question to the initial state. 
