### PR TITLE
[TP-11691] Updates global nav style to fix knock-on problem on DAL

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ gem 'whenever', require: false
 # Dependencies
 gem 'adal', git: 'git@github.com:moneyadviceservice/azure-activedirectory-library-for-ruby'
 gem 'cream', '2.1.8'
-gem 'dough-ruby', git: 'git@github.com:moneyadviceservice/dough.git', branch: '11691_DAL_Current-location-warning-message_v5.41', ref: '7b257b9'
+gem 'dough-ruby', git: 'git@github.com:moneyadviceservice/dough.git', branch: '11691_DAL_Current-location-warning-message_v5.41', ref: 'a90d79d'
 gem 'mas-cms-client', '1.20.0'
 gem 'site_search', '0.3.0'
 # Tools

--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ gem 'whenever', require: false
 # Dependencies
 gem 'adal', git: 'git@github.com:moneyadviceservice/azure-activedirectory-library-for-ruby'
 gem 'cream', '2.1.8'
-gem 'dough-ruby', git: 'git@github.com:moneyadviceservice/dough.git', branch: '11393_Chat_Add-coronavirus-option_v5.40'
+gem 'dough-ruby', git: 'git@github.com:moneyadviceservice/dough.git', branch: '11691_DAL_Current-location-warning-message_v5.41', ref: '7b257b9'
 gem 'mas-cms-client', '1.20.0'
 gem 'site_search', '0.3.0'
 # Tools

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,10 +15,11 @@ GIT
 
 GIT
   remote: git@github.com:moneyadviceservice/dough.git
-  revision: 6ae1b74232e63674acb08e1198dc760e40906896
-  branch: 11393_Chat_Add-coronavirus-option_v5.40
+  revision: a90d79da058eb43f95d6afb77325b22fed539f07
+  ref: a90d79d
+  branch: 11691_DAL_Current-location-warning-message_v5.41
   specs:
-    dough-ruby (5.40.0)
+    dough-ruby (5.41.0)
       activemodel
       activesupport
       rails (>= 3.2, < 5.1.0)

--- a/app/assets/stylesheets/components/common/_global_subnav.scss
+++ b/app/assets/stylesheets/components/common/_global_subnav.scss
@@ -40,15 +40,14 @@ $global-nav-transition-duration: 300ms !default; // Defined in _global_nav.scss
       visibility: visible;
     }
   }
-}
 
-.is-hidden {
-  display: none;
-
-  @include respond-to($mq-m) {
-    display: block; 
+  .is-hidden {
+    @include respond-to($mq-m) {
+      display: block; 
+    }
   }
 }
+
 
 // nav not initialised --
 .global-nav:not([data-dough-global-nav-initialised="yes"]) {


### PR DESCRIPTION
[TP-11691](https://maps.tpondemand.com/entity/11691-bug-dalt-current-location-warning-message)

This update moves a `is-hidden` style in the global navigation to make it more specific to that component. This has recently been updated to make it less generic which in turn caused a problem with the error message that is shown on the Debt Advice Locator when the user's device is unable to get a location. 

The `is-hidden` style that is used both here and on the DAL tool is now a new style created in Dough. 

The change in the DAL repo that was required to be made is in [PR172](https://github.com/moneyadviceservice/debt-advice-locator/pull/172). 

The change in Dough that was required to be made is in [PR 340](https://github.com/moneyadviceservice/dough/pull/340). 