### PR TITLE
[TP-11680] Fixes failing Unit test in `MoneyNavigatorQuestions_spec.js`

### DIFF
--- a/app/assets/javascripts/components/MoneyNavigatorQuestions.js
+++ b/app/assets/javascripts/components/MoneyNavigatorQuestions.js
@@ -23,7 +23,7 @@ define(['jquery', 'DoughBaseComponent'], function ($, DoughBaseComponent) {
     this.$submitBtn = this.$el.find('[data-submit]');
     this.$questions = this.$el.find('[data-question]');
     this.$multipleQuestions = this.$el.find('[data-question-multiple]');
-    this.banner = $(document).find('[data-banner]');
+    this.$banner = this.$el.siblings('[data-banner]');
     this.activeClass = 'question--active';
     this.hiddenClass = 'is-hidden';
     this.dataLayer = window.dataLayer;
@@ -297,11 +297,11 @@ define(['jquery', 'DoughBaseComponent'], function ($, DoughBaseComponent) {
       .text(progress + '% ' + this.i18nStrings.messages.completed);
 
     if (activeIndex == 0) {
-      this.banner.removeClass(
+      this.$banner.removeClass(
         'l-money_navigator__banner' + '--' + this.hiddenClass
       );
     } else {
-      this.banner.addClass(
+      this.$banner.addClass(
         'l-money_navigator__banner' + '--' + this.hiddenClass
       );
     }

--- a/spec/javascripts/tests/MoneyNavigatorQuestions_spec.js
+++ b/spec/javascripts/tests/MoneyNavigatorQuestions_spec.js
@@ -15,7 +15,7 @@ describe('MoneyNavigatorQuestions', function() {
           fixture.load('MoneyNavigatorQuestions.html');
           self.component = $(fixture.el).find('[data-dough-component="MoneyNavigatorQuestions"]');
           self.obj = new MoneyNavigatorQuestions(self.component);
-          self.banner = $('#fixture_container').find('[data-banner]'); 
+          self.banner = $(self.component).parents().find('[data-banner]'); 
           self.questions = self.component.find('[data-question]'); 
           self.activeClass = self.obj.activeClass; 
           self.hiddenClass = self.obj.hiddenClass; 
@@ -327,8 +327,7 @@ describe('MoneyNavigatorQuestions', function() {
       expect($(this.questions[2]).hasClass(this.activeClass)).to.be.false; 
     }); 
 
-    // TODO: Fix this test (in Tech Debt)
-    xit('Shows/hides the banner when active question is/not Q0', function() {
+    it('Shows/hides the banner when active question is/not Q0', function() {
       var hiddenClass = 'l-money_navigator__banner' + '--' + this.hiddenClass; 
 
       this.obj._updateDOM(); 


### PR DESCRIPTION
[TP-11680](https://maps.tpondemand.com/entity/11680-money-navigator-technical-debt-fix-failing)

This is part of the Technical Debt arising from the work on the Money Navigator tool. It fixes a Unit Test that was broken on the deployed version of the tool.

The test checks for the display state of the banner that appears at the start of the questions (see screenshot below) and is only required to be shown for the first question. 

The problem was that the test runner was unable to locate the element in the fixture because it is located outside of the component under test. This change makes the element available to the test. 

It also makes the element location within the DOM more specific in the component itself. That change is made more for consistency than necessity. 

![image](https://user-images.githubusercontent.com/6080548/91169712-b3f4b900-e6cf-11ea-9877-86c5dd68ced7.png)