### PR TITLE
[TP-11681] Refactors Questions view to remove unnecessary loop

### DIFF
--- a/app/views/money_navigator_tool/questionnaire.html.erb
+++ b/app/views/money_navigator_tool/questionnaire.html.erb
@@ -52,36 +52,32 @@
                   <% end %>
 
                   <% question[:responses].each do |response| %>
-                    <% if response[:default] %>
                       <div class="question__response" data-response>
                         <% if question[:type] == 'radio' %>
-                          <%= f.radio_button question[:code].downcase, response[:code].downcase, id: question[:code].downcase + '_' + response[:code].downcase, class: 'response__control', checked: true %>
+                          <%= f.radio_button question[:code].downcase, 
+                            response[:code].downcase, 
+                            id: question[:code].downcase + '_' + response[:code].downcase, 
+                            class: 'response__control', 
+                            checked: response[:default] 
+                          %>
                         <% elsif question[:type] == 'checkbox' %>
-                          <%= f.check_box question[:code].downcase, {multiple: true, id: question[:code].downcase + '_' + response[:code].downcase, class: 'response__control', checked: true}, response[:code].downcase, nil %>
+                          <%= f.check_box question[:code].downcase, 
+                            {
+                              multiple: true, 
+                              id: question[:code].downcase + '_' + response[:code].downcase, 
+                              class: 'response__control', 
+                              checked: response[:default], 
+                            }, 
+                            response[:code].downcase, 
+                            nil %>
                         <% end %>
 
                         <label for="<%= question[:code].downcase + "_" + response[:code].downcase %>" class="response__text">
                           <span><%= response[:text] %></span>
                         </label>
                       </div>
-                    <% end %>
                   <% end %>
 
-                  <% question[:responses].each do |response| %>
-                    <% if !response[:default] %>
-                      <div class="question__response" data-response>
-                        <% if question[:type] == 'radio' %>
-                          <%= f.radio_button question[:code].downcase, response[:code].downcase, id: question[:code].downcase + '_' + response[:code].downcase, class: 'response__control' %>
-                        <% elsif question[:type] == 'checkbox' %>
-                          <%= f.check_box question[:code].downcase, {multiple: true, id: question[:code].downcase + '_' + response[:code].downcase, class: 'response__control'}, response[:code].downcase, nil %>
-                        <% end %>
-
-                        <label for="<%= question[:code].downcase + "_" + response[:code].downcase %>" class="response__text">
-                          <span><%= response[:text] %></span>
-                        </label>
-                      </div>
-                    <% end %>
-                  <% end %>
                 </fieldset>
 
                 <% if question[:note] %>

--- a/config/locales/money_navigator_tool/money_navigator_tool.cy.yml
+++ b/config/locales/money_navigator_tool/money_navigator_tool.cy.yml
@@ -127,14 +127,14 @@ cy:
         responses:
           - code: A1
             text: 'Ydw'
-            sort_order: 1
+            sort_order: 2
           - code: A2
             text: 'Na'
-            sort_order: 2
+            sort_order: 3
           - code: A3
             text: 'Nid wyf yn hunangyflogedig'
             default: true
-            sort_order: 3
+            sort_order: 1
       - code: Q4
         type: radio
         custom: true
@@ -143,10 +143,10 @@ cy:
         responses:
           - code: A4
             text: Dim newid /wedi arbed arian
-            sort_order: 1
+            sort_order: 2
           - code: A1
             text: 'Gostyngiad tymor hir mewn incwm (ee: diswyddo neu gwaith wedi stopio am gyfnod amhenodol)'
-            sort_order: 2
+            sort_order: 1
             default: true
           - code: A2
             text: Gostyngiad dros dro ac yn poeni am fy niogelwch yn y dyfodol
@@ -161,14 +161,14 @@ cy:
         responses:
           - code: A1
             text: Cynllun cymhorthdal incwm hunangyflogaeth
-            sort_order: 2
+            sort_order: 1
             default: true
           - code: A2
             text: Cynllun ffyrlo
             sort_order: 3
           - code: A3
             text: 'Na'
-            sort_order: 1
+            sort_order: 2
       - code: Q6
         type: radio
         text: Ydych chi ar ei hôl hi gyda thaliadau rhent neu forgais? Atebwch "Ydw" os ydych  ar wyliau/egwyl talu y cytunwyd arno

--- a/config/locales/money_navigator_tool/money_navigator_tool.en.yml
+++ b/config/locales/money_navigator_tool/money_navigator_tool.en.yml
@@ -127,14 +127,14 @@ en:
         responses:
           - code: A1
             text: 'Yes'
-            sort_order: 1
+            sort_order: 2
           - code: A2
             text: 'No'
-            sort_order: 2
+            sort_order: 3
           - code: A3
             text: 'I am not self employed'
             default: true
-            sort_order: 3
+            sort_order: 1
       - code: Q4
         type: radio
         custom: true
@@ -143,10 +143,10 @@ en:
         responses:
           - code: A4
             text: No change/saved money
-            sort_order: 1
+            sort_order: 2
           - code: A1
             text: 'Long term drop in income (eg: redundancy, or work stopped indefinitely)'
-            sort_order: 2
+            sort_order: 1
             default: true
           - code: A2
             text: Temporary drop and worried about my future security
@@ -161,14 +161,14 @@ en:
         responses:
           - code: A1
             text: Self-employment income support scheme
-            sort_order: 2
+            sort_order: 1
             default: true
           - code: A2
             text: Furlough scheme
             sort_order: 3
           - code: A3
             text: 'No'
-            sort_order: 1
+            sort_order: 2
       - code: Q6
         type: radio
         text: Are you behind with rent or mortgage payments?


### PR DESCRIPTION
[TP-11681](https://maps.tpondemand.com/entity/11681-money-navigator-technical-debt-improve-the)

This is part of the Technical Debt arising from the work on the Money Navigator tool.

It refactors the view that generates the markup for the Questions page in order to remove an unnecessary loop through the response values. 

Originally this was necessary in order to render the value that would be checked by default as the first value of the list of responses to each question. We subsequently added a `sort_order` value that determined this ordering of responses. As a consequence of this the refactoring in this PR was made possible in order to cut out unnecessary code from the view. 