### PR TITLE
[TP-11721] Add SameSite=None whenever we have X-Syndicated-Tool header

### DIFF
--- a/app/middleware/partner_tools_cookies.rb
+++ b/app/middleware/partner_tools_cookies.rb
@@ -1,0 +1,30 @@
+class PartnerToolsCookies
+  COOKIE_SEPARATOR = "\n".freeze
+
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    status, headers, body = @app.call(env)
+
+    if (headers['X-Syndicated-Tool'].present? || env['HTTP_X_SYNDICATED_TOOL'].present?) &&
+      (headers['Set-Cookie'].present? || env['HTTP_SET_COOKIE'].present?) &&
+      Rack::Request.new(env).ssl?
+
+      cookie = headers['Set-Cookie'] || env['HTTP_SET_COOKIE']
+      cookies = cookie.split(COOKIE_SEPARATOR)
+
+      cookies.each do |cookie|
+        next if cookie.blank?
+        next if cookie =~ /;\s*secure/i
+
+        cookie << '; Secure; SameSite=None'
+      end
+
+      headers['Set-Cookie'] = cookies.join(COOKIE_SEPARATOR)
+    end
+
+    [status, headers, body]
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,6 +39,7 @@ module Frontend
     config.middleware.use 'OverrideHead' # convert HEAD requests to GET and return an empty body
     config.middleware.use 'RouteProbe' # respond to requests probing for a implemented route
     config.middleware.use 'VersionHeader' # add version of the running app to each response
+    config.middleware.insert_after 'ActionDispatch::Static', 'PartnerToolsCookies'
 
     config.assets.initialize_on_precompile = true
 

--- a/spec/middleware/partner_tools_cookies_spec.rb
+++ b/spec/middleware/partner_tools_cookies_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe PartnerToolsCookies do
+  include Rack::Test::Methods
+
+  def app
+    described_class.new(->(env) { [200, env, 'Hello'] })
+  end
+
+  describe "with no `X-Syndicated-Tool' header" do
+    before do
+      header 'Set-Cookie', 'v=1'
+      allow_any_instance_of(Rack::Request).to receive(:ssl?) { true }
+    end
+
+    it 'does not change any headers' do
+      get '/'
+      expect(last_response.headers['Set-Cookie']).to be_nil
+    end
+  end
+
+  describe "with a `X-Syndicated-Tool' has been set to `true'" do
+    before do
+      header 'X-Syndicated-Tool', 'true'
+      header 'Set-Cookie', 'v=1'
+      allow_any_instance_of(Rack::Request).to receive(:ssl?) { true }
+    end
+
+    it 'set secure and SameSite to None' do
+      get '/'
+      expect(last_response.headers['Set-Cookie']).to eq "v=1; Secure; SameSite=None"
+    end
+  end
+end


### PR DESCRIPTION
Using middleware instead of overriding `set_cookie_header` in `/action_dispatch/middleware/cookies.rb`. This way we can set it by default for syndicated tools only and the other parts we leave as is.

