### PR TITLE
[TP-11682] Fixes some small UI inconsistencies

### DIFF
--- a/app/assets/stylesheets/layout/page_specific/_money_navigator_questionnaire.scss
+++ b/app/assets/stylesheets/layout/page_specific/_money_navigator_questionnaire.scss
@@ -1,7 +1,7 @@
 .l-money_navigator {
 	.question__actions {
 		@extend %clearfix;
-		@include row(12); 
+
 		margin-top: $baseline-unit * 4; 
 
 		@include respond-to($mq-m) {
@@ -9,6 +9,10 @@
 				float: left;
 				clear: left;
 			}
+		}
+
+		@include respond-to($mq-l) {
+			@include row(12); 
 		}
 	}
 


### PR DESCRIPTION
[TP-11682](https://maps.tpondemand.com/entity/11682-money-navigator-technical-debt-fix-small)

This work fixes some small UI issues on the Money Navigator Questions page. These concern the `Continue` and `Back` buttons as they render on smaller viewports (see screenshots below). The problem is that their common container is responding wrongly to the viewport width. The solution is to change the width of the container at a wider breakpoint to allow the buttons to display at the same width as other elements. 

![image](https://user-images.githubusercontent.com/6080548/91329905-a23f0e80-e7c0-11ea-8c65-144670e2ee82.png)

![image](https://user-images.githubusercontent.com/6080548/91329925-a79c5900-e7c0-11ea-9737-da797b028348.png)
