### PR TITLE
11487 - Search bar open by default on mobile site

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,107 +1,110 @@
 //= require require_config
 
-require(['common', 'jquery'], function(MAS, $) {
-  'use strict';
+require(["common", "jquery"], function (MAS, $) {
+  "use strict";
 
   if (MAS.fonts.loadWithJS && MAS.fonts.url && !MAS.fonts.localstorage) {
-    require(['jquery', 'common'], function($, MAS) {
-
-      MAS.log('FONTS: load via ajax');
+    require(["jquery", "common"], function ($, MAS) {
+      MAS.log("FONTS: load via ajax");
       $.ajax({
         url: MAS.fonts.url,
-        success: function(res) {
-          MAS.log('FONTS: ajax load success > stylesheet appended to page > load class added');
-          $('html').addClass(MAS.fonts.loadClass);
-          $('head').append('<style>' + res + '</style>');
+        success: function (res) {
+          MAS.log(
+            "FONTS: ajax load success > stylesheet appended to page > load class added"
+          );
+          $("html").addClass(MAS.fonts.loadClass);
+          $("head").append("<style>" + res + "</style>");
           if (MAS.supports.localstorage) {
-            MAS.log('FONTS: localstorage supported, fonts saved');
+            MAS.log("FONTS: localstorage supported, fonts saved");
             localStorage.setItem(MAS.fonts.cacheName, res);
           }
         },
-        dataType: 'text'
+        dataType: "text",
       });
     });
   }
 
   if (window.enableScrollTracking) {
-    require(['jquery', 'scrollTracking'], function($, scrollTracking) {
+    require(["jquery", "scrollTracking"], function ($, scrollTracking) {
       // Analytics scroll tracking on editorial pages
       scrollTracking({
-        el: '.editorial',
-        triggerPoints: [0.25, 0.5, 0.75, 1]
+        el: ".editorial",
+        triggerPoints: [0.25, 0.5, 0.75, 1],
       });
     });
   }
 
-  require(['jquery', 'collapsable'], function($, Collapsable) {
-    $(document).ready(function() {
+  require(["jquery", "collapsable"], function ($, Collapsable) {
+    $(document).ready(function () {
       // Mobile Search Button
       new Collapsable({
-        name: 'mobileSearch',
+        name: "mobileSearch",
         closeOffFocus: false,
         accordion: true,
-        triggerEl: '.mobile-nav__link--search',
-        targetType: 'href',
+        triggerEl: ".mobile-nav__link--search",
+        targetType: "href",
+        hideByDefault: true,
       });
 
       // Article Collapsables
       new Collapsable({
-        name: 'articleCollapsables',
+        name: "articleCollapsables",
         showOnlyFirst: true,
         showIcon: true,
-        useButton: true
+        useButton: true,
       });
 
       // Category Collapsables
       new Collapsable({
-        name: 'categoryCollapsables',
-        triggerEl: '.js-category-detail__toggle-view',
-        targetEl: '.js-category-detail__list--extended'
+        name: "categoryCollapsables",
+        triggerEl: ".js-category-detail__toggle-view",
+        targetEl: ".js-category-detail__list--extended",
       });
 
       // Debt Campaign Companies affected
       new Collapsable({
-        name: 'companiesAffected',
+        name: "companiesAffected",
         showIcon: true,
         useButton: true,
-        triggerEl: '.l-debtmanagement__companies-heading',
-        targetEl: '.l-debtmanagement__companies-list'
+        triggerEl: ".l-debtmanagement__companies-heading",
+        targetEl: ".l-debtmanagement__companies-list",
       });
 
-      if($(this).width() <= 720){
+      if ($(this).width() <= 720) {
         new Collapsable({
-          name: 'contactCollapsables',
+          name: "contactCollapsables",
           showIcon: true,
           useButton: true,
-          triggerEl: '.contact-detail__heading',
-          targetEl: '.contact-detail__content'
+          triggerEl: ".contact-detail__heading",
+          targetEl: ".contact-detail__content",
         });
       }
-
     });
   });
 
-  require(['jquery', 'ujs'], function($) {
-
-    $(document).ready(function() {
+  require(["jquery", "ujs"], function ($) {
+    $(document).ready(function () {
       // Cookie message
-      $('.js-cookie-message').on('ajax:success', function() {
-        $('.cookie-message').hide();
-        $('.footer-site-links__cookie-link').removeClass('is-on');
+      $(".js-cookie-message").on("ajax:success", function () {
+        $(".cookie-message").hide();
+        $(".footer-site-links__cookie-link").removeClass("is-on");
       });
     });
   });
 
   // Kick off component loader
   var engines = [];
-  $('[data-engine]').each(function() {
-    engines.push($(this).attr('data-engine') + 'Config');
+  $("[data-engine]").each(function () {
+    engines.push($(this).attr("data-engine") + "Config");
   });
 
-  require(engines, function() {
-    require(['componentLoader', 'eventsWithPromises'], function(componentLoader, eventsWithPromises) {
-      componentLoader.init($('body'));
-      eventsWithPromises.subscribe('component:contentChange', function(data) {
+  require(engines, function () {
+    require(["componentLoader", "eventsWithPromises"], function (
+      componentLoader,
+      eventsWithPromises
+    ) {
+      componentLoader.init($("body"));
+      eventsWithPromises.subscribe("component:contentChange", function (data) {
         componentLoader.init(data.$container);
       });
     });

--- a/app/assets/javascripts/modules/mas_collapsable.js
+++ b/app/assets/javascripts/modules/mas_collapsable.js
@@ -1,53 +1,60 @@
-define(['jquery', 'common'], function($, MAS) {
-  'use strict';
+define(["jquery", "common"], function ($, MAS) {
+  "use strict";
 
   var defaults = {
-    name: 'not set',
+    name: "not set",
 
     // Setup
-    triggerEl: '.collapsible',
-    targetEl: '.collapsible-section',
-    targetType: 'class', // class / href / data-attr
-    targetItems: '.item',
-    viewAllButton: '.view-all',
-    activeClass: 'is-on',
-    inactiveClass: 'is-off',
+    triggerEl: ".collapsible",
+    targetEl: ".collapsible-section",
+    targetType: "class", // class / href / data-attr
+    targetItems: ".item",
+    viewAllButton: ".view-all",
+    activeClass: "is-on",
+    inactiveClass: "is-off",
     numberItemsToDisplay: 6,
     closeOffFocus: false,
     parentWrapper: false,
     accordion: false,
     showOnlyFirst: false,
+    hideByDefault: false,
 
     // Display options
     showText: true,
     showIcon: false,
     headingIcon: '<span class="icon icon--toggle"></span>',
-    headingText: '<span class="visually-hidden js-collapsable-hidden">{{txt}}</span>',
+    headingText:
+      '<span class="visually-hidden js-collapsable-hidden">{{txt}}</span>',
     useButton: false,
 
     // Localised text strings
     textString: {
-      showThisSection: MAS.text.show || 'Show',
-      hideThisSection: MAS.text.hide || 'Hide'
+      showThisSection: MAS.text.show || "Show",
+      hideThisSection: MAS.text.hide || "Hide",
     },
 
     // Callbacks
     onSelect: false,
-    onFocusout: false
+    onFocusout: false,
   };
 
-  var Collapsible = function(opts) {
+  var Collapsible = function (opts) {
     this.o = $.extend({}, defaults, opts);
     this.sections = [];
     this.selected = false;
 
     var _this = this,
-        triggers = $(this.o.triggerEl),
-        l = triggers.length,
-        i = 0;
+      triggers = $(this.o.triggerEl),
+      l = triggers.length,
+      i = 0;
 
     if (l === 0) {
-      return MAS.warn && MAS.warn('mas_collapsible => no trigger elements in page: ' + this.o.triggerEl);
+      return (
+        MAS.warn &&
+        MAS.warn(
+          "mas_collapsible => no trigger elements in page: " + this.o.triggerEl
+        )
+      );
     }
 
     for (i; i < l; i++) {
@@ -58,78 +65,92 @@ define(['jquery', 'common'], function($, MAS) {
       this.$parent = $(this.o.parentWrapper);
 
       if (!this.o.parentWrapper || !this.$parent.length) {
-        MAS.warn && MAS.warn('options.parentWrapper should be set & valid for closeOffFocus to work');
+        MAS.warn &&
+          MAS.warn(
+            "options.parentWrapper should be set & valid for closeOffFocus to work"
+          );
         return;
       }
 
-      this.$parent.on('focusout', $.proxy(_this._delayDomCheck, _this));
+      this.$parent.on("focusout", $.proxy(_this._delayDomCheck, _this));
     }
   };
 
-  var _isHidden = function(target, opts) {
+  var _isHidden = function (target, opts) {
     if (target.hasClass(opts.inactiveClass)) return true;
     if (target.hasClass(opts.activeClass)) return false;
-    return target.is(':hidden');
+    return target.is(":hidden");
   };
 
-  var _getTarget = function($el, opts) {
+  var _getTarget = function ($el, opts) {
     switch (opts.targetType) {
-      case 'class':
+      case "class":
         var $immediateSibling = $el.next(opts.targetEl),
-            targetIsImmediateSibling = !!$immediateSibling.length;
-        return (targetIsImmediateSibling) ? $immediateSibling : $el.siblings(opts.targetEl);
-      case 'href':
-        var href = $el.attr('href'),
-            $t = $(href);
-        return ($t.length) ? $t : false;
+          targetIsImmediateSibling = !!$immediateSibling.length;
+        return targetIsImmediateSibling
+          ? $immediateSibling
+          : $el.siblings(opts.targetEl);
+      case "href":
+        var href = $el.attr("href"),
+          $t = $(href);
+        return $t.length ? $t : false;
       default:
         return false;
     }
   };
 
-  var _getItems = function($el, opt) {
+  var _getItems = function ($el, opt) {
     return $el.find(opt.targetItems);
   };
 
-  var _getViewAll = function($el, opt) {
+  var _getViewAll = function ($el, opt) {
     return $el.find(opt.viewAllButton);
   };
 
-  Collapsible.prototype._delayDomCheck = function() {
-    setTimeout($.proxy(function() {
-      if (this.$parent.find(document.activeElement).length === 0 && this.selected !== false) {
-        // Callback
-        if (typeof this.o.onFocusout === 'function') this.o.onFocusout(this);
-        // Action
-        this.hide(this.selected);
-      }
-    }, this), 300);
+  Collapsible.prototype._delayDomCheck = function () {
+    setTimeout(
+      $.proxy(function () {
+        if (
+          this.$parent.find(document.activeElement).length === 0 &&
+          this.selected !== false
+        ) {
+          // Callback
+          if (typeof this.o.onFocusout === "function") this.o.onFocusout(this);
+          // Action
+          this.hide(this.selected);
+        }
+      }, this),
+      300
+    );
   };
 
-  Collapsible.prototype._modifyButtonHTML = function(i) {
+  Collapsible.prototype._modifyButtonHTML = function (i) {
     var icon, txt;
     var trigger = this.sections[i].trigger;
 
     if (this.o.showText) {
-      txt = this.o.headingText.replace('{{txt}}', this.o.textString.showThisSection);
+      txt = this.o.headingText.replace(
+        "{{txt}}",
+        this.o.textString.showThisSection
+      );
     } else {
-      txt = '';
+      txt = "";
     }
 
     if (this.o.showIcon) {
       icon = this.o.headingIcon;
     } else {
-      icon = '';
+      icon = "";
     }
 
     if (this.o.useButton) {
       var buttonTitle = trigger.text();
 
-      if (trigger[0].nodeName === 'A') {
+      if (trigger[0].nodeName === "A") {
         // Anchor => replace elemnt
-        var newEl = $('<a></a>')
+        var newEl = $("<a></a>")
           .addClass(trigger[0].className)
-          .attr('id', trigger[0])
+          .attr("id", trigger[0])
           .text(icon + txt + buttonTitle);
         // add new
         trigger.after(newEl);
@@ -138,34 +159,43 @@ define(['jquery', 'common'], function($, MAS) {
         trigger = newEl;
       } else {
         // Anything else => insert button inside
-        trigger.html('<button class="unstyled-button">' + icon + txt + buttonTitle + '</button>');
+        trigger.html(
+          '<button class="unstyled-button">' +
+            icon +
+            txt +
+            buttonTitle +
+            "</button>"
+        );
       }
     } else {
       // Use aria-role
-      trigger.attr('aria-role', 'button');
-      trigger.attr('tabindex', '0');
+      trigger.attr("aria-role", "button");
+      trigger.attr("tabindex", "0");
       trigger.prepend(icon);
       trigger.prepend(txt);
     }
 
-    if (this.o.showIcon) this.sections[i].icon = trigger.find('.icon');
-    if (this.o.showText) this.sections[i].txt = trigger.find('.js-collapsable-hidden');
+    if (this.o.showIcon) this.sections[i].icon = trigger.find(".icon");
+    if (this.o.showText)
+      this.sections[i].txt = trigger.find(".js-collapsable-hidden");
   };
 
-  Collapsible.prototype._setupEach = function(i, el) {
+  Collapsible.prototype._setupEach = function (i, el) {
     var $el = $(el),
-        _this = this,
-        _target = _getTarget($el, _this.o),
-        _items = _getItems(_target, _this.o),
-        _viewAll = _getViewAll(_target, _this.o);
+      _this = this,
+      _target = _getTarget($el, _this.o),
+      _items = _getItems(_target, _this.o),
+      _viewAll = _getViewAll(_target, _this.o),
+      _hideDefault = _this.o.hideByDefault;
 
     this.sections[i] = {
       index: i,
-      items:  _items,
+      items: _items,
       trigger: $el,
       target: _target,
       viewAll: _viewAll,
-      hidden: _isHidden(_target, _this.o)
+      hidden: _isHidden(_target, _this.o),
+      hideDefault: _hideDefault,
     };
 
     // Dont modify or bind events if no target element
@@ -173,11 +203,15 @@ define(['jquery', 'common'], function($, MAS) {
 
     // Set show / hide states based on options
     if (this.o.showOnlyFirst) {
-      this.sections[i].hidden = (i === 0) ? false : true;
+      this.sections[i].hidden = i === 0 ? false : true;
     }
 
     // For accordions, if there is a selected item, hide other items
-    if (this.o.accordion && this.selected !== false && this.sections[i].hidden) {
+    if (
+      this.o.accordion &&
+      this.selected !== false &&
+      this.sections[i].hidden
+    ) {
       this.sections[i].hidden = true;
     }
 
@@ -185,13 +219,19 @@ define(['jquery', 'common'], function($, MAS) {
     this._modifyButtonHTML(i);
 
     // Set initial state
-    this.setVisibility(!this.sections[i].hidden, i);
+    if (this.sections[i].hideDefault) {
+      this.setVisibility(false, i);
+    } else {
+      this.setVisibility(!this.sections[i].hidden, i);
+    }
+    // this.setVisibility(!this.sections[i].hidden, i);
 
     // Bind events
-    this.sections[i].trigger.on('click', i, function(e) {
+    this.sections[i].trigger.on("click", i, function (e) {
       e.preventDefault();
       // Check for callbacks
-      if (typeof _this.o.onSelect === 'function') _this.o.onSelect(_this.sections[i]);
+      if (typeof _this.o.onSelect === "function")
+        _this.o.onSelect(_this.sections[i]);
       _this.setVisibility(_this.sections[i].hidden, i);
 
       if (_this.sections[i].items.length <= _this.o.numberItemsToDisplay) {
@@ -199,19 +239,19 @@ define(['jquery', 'common'], function($, MAS) {
       }
     });
 
-    this.sections[i].viewAll.on('click', i, function(e) {
+    this.sections[i].viewAll.on("click", i, function (e) {
       e.preventDefault();
       showElement(_this.sections[i].items, _this);
       hideElement(_this.sections[i].viewAll, _this);
     });
 
     // Accessibility support for spacebar
-    this.sections[i].trigger.on('keypress', function(e) {
+    this.sections[i].trigger.on("keypress", function (e) {
       if (e.which === 32) {
-        if (_this.sections[i].trigger[0].nodeName !== 'BUTTON') {
+        if (_this.sections[i].trigger[0].nodeName !== "BUTTON") {
           if (!_this.o.useButton) {
             e.preventDefault();
-            _this.sections[i].trigger.trigger('click');
+            _this.sections[i].trigger.trigger("click");
           }
         }
       }
@@ -219,39 +259,42 @@ define(['jquery', 'common'], function($, MAS) {
     return this;
   };
 
-  Collapsible.prototype.setVisibility = function(show, i) {
-    var method = (show) ? 'show' : 'hide';
+  Collapsible.prototype.setVisibility = function (show, i) {
+    var method = show ? "show" : "hide";
     this[method](i);
     return this;
   };
 
   function publishEvent(userInitiated, data) {
     if (userInitiated) {
-      data.module = 'collapsable';
-      MAS.publish('collapsable', data);
-      MAS.publish('analytics:trigger', data);
+      data.module = "collapsable";
+      MAS.publish("collapsable", data);
+      MAS.publish("analytics:trigger", data);
     }
   }
 
-  Collapsible.prototype.show = function(i, userInitiated) {
+  Collapsible.prototype.show = function (i, userInitiated) {
     publishEvent(userInitiated, {
       name: this.o.name,
       index: i,
-      action: 'show'
+      action: "show",
     });
 
     var section = this.sections[i];
     var itemsToDisplay = section.items.slice(0, this.o.numberItemsToDisplay);
 
-    section.trigger.removeClass(this.o.inactiveClass).addClass(this.o.activeClass);
+    section.trigger
+      .removeClass(this.o.inactiveClass)
+      .addClass(this.o.activeClass);
 
     showElement(section.target, this);
     showElement(itemsToDisplay, this);
     showElement(section.viewAll, this);
 
     section.hidden = false;
-    if (this.o.showText) section.txt.text(this.o.textString.hideThisSection + ' ');
-    if (this.o.accordion && (this.selected !== false && this.selected !== i)) {
+    if (this.o.showText)
+      section.txt.text(this.o.textString.hideThisSection + " ");
+    if (this.o.accordion && this.selected !== false && this.selected !== i) {
       this.hide(this.selected, false);
     }
     this.selected = i;
@@ -260,24 +303,26 @@ define(['jquery', 'common'], function($, MAS) {
 
   function hideElement(element, conf) {
     element.removeClass(conf.o.activeClass).addClass(conf.o.inactiveClass);
-    element.attr('aria-hidden', 'true');
+    element.attr("aria-hidden", "true");
   }
 
   function showElement(element, conf) {
     element.removeClass(conf.o.inactiveClass).addClass(conf.o.activeClass);
-    element.attr('aria-hidden', 'false');
+    element.attr("aria-hidden", "false");
   }
 
-  Collapsible.prototype.hide = function(i, userInitiated) {
+  Collapsible.prototype.hide = function (i, userInitiated) {
     publishEvent(userInitiated, {
       name: this.o.name,
       index: i,
-      action: 'hide'
+      action: "hide",
     });
 
     var section = this.sections[i];
     var items = section.items;
-    section.trigger.removeClass(this.o.activeClass).addClass(this.o.inactiveClass);
+    section.trigger
+      .removeClass(this.o.activeClass)
+      .addClass(this.o.inactiveClass);
 
     hideElement(section.target, this);
     hideElement(section.viewAll, this);
@@ -286,7 +331,7 @@ define(['jquery', 'common'], function($, MAS) {
     section.hidden = true;
 
     if (this.o.showText) {
-      section.txt.text(this.o.textString.showThisSection + ' ');
+      section.txt.text(this.o.textString.showThisSection + " ");
     }
 
     return this;


### PR DESCRIPTION
**Note: There are quite a lot of lines changes in this PR due to linting of both the modified files.**

[TP11487](https://maps.tpondemand.com/entity/11487-search-bar-open-by-default-on)

This PR aims to hide the search bar on a mobile view. To achieve this, a new default was implemented in the existing `Collapsible` module which was implemented to the search bar.

Other elements using this module such as the [Debt Campaign Companies](https://www.moneyadviceservice.org.uk/en/categories/debt-and-borrowing) view all button seem to be working as normal.

Karma tests are passing.