### PR TITLE
[TP-11686] Money-navigator_Improve-Questions-JS-Tests

### DIFF
--- a/spec/javascripts/tests/MoneyNavigatorQuestions_spec.js
+++ b/spec/javascripts/tests/MoneyNavigatorQuestions_spec.js
@@ -91,25 +91,15 @@ describe('MoneyNavigatorQuestions', function() {
       expect(this.updateGroupedQuestionsDisplaySpy.calledWith(inputs[2])).to.be.true; 
     }); 
 
-    it ('Checks that the correct method is called when the `reset` and `back` options are activated', function() {
+    it ('Checks that the correct method is called when the `reset` option is activated', function() {
       var responseCollections = $(this.groupedQuestion).find('[data-response-collection]'); 
       var resetBtn = $(responseCollections[0]).find('[data-reset]'); 
       var backBtn = $(this.groupedQuestion).find('[data-back]'); 
 
-      // Test Reset button
       $(resetBtn).trigger('click'); 
 
       expect(this.updateGroupedQuestionsDisplaySpy.calledOnce).to.be.true; 
       expect(this.updateGroupedQuestionsDisplaySpy.calledWith(resetBtn[0])).to.be.true; 
-
-      // Test Back button
-      // TODO in TP11686 when the test is added for the `_scrollToTop` method. 
-      // At the moment this test is dependant on that one being run.  
-
-      // $(backBtn).trigger('click'); 
-
-      // expect(this.updateGroupedQuestionsDisplaySpy.calledOnce).to.be.true; 
-      // expect(this.updateGroupedQuestionsDisplaySpy.calledWith(backBtn[0])).to.be.true; 
     }); 
   }); 
 


### PR DESCRIPTION
[TP11686](https://maps.tpondemand.com/entity/11686-money-navigator-technical-debt-improve-code)

This work aims to tidy up the Unit Tests associated with the Money Navigator Questions page component. The TP card lists a number of potential improvements to these tests but on further inspection I felt that the only tidying required was to remove the test for the `back` button in the `_setUpGroupedQuestions` method as that was already added and tested in the `_updateDOM` method. 
