### PR TITLE
11798 money navigator step change update q10

### DIFF
--- a/config/locales/money_navigator_tool/money_navigator_tool.cy.yml
+++ b/config/locales/money_navigator_tool/money_navigator_tool.cy.yml
@@ -326,7 +326,7 @@ cy:
             sort_order: 12
       - code: Q10
         type: radio
-        text: A ydych wedi mynd ar ei hôl hi neu wedi cytuno ar egwyl taliad ar ymrwymiadau credyd neu filiau blaenoriaeth y cartref ers 28 Chwefror 2020?
+        text: A ydych wedi bod ar ddatrysiad dyled sydd wedi methu yn ystod y 12 mis diwethaf?
         sort_order: 11
         responses:
           - code: A1

--- a/config/locales/money_navigator_tool/money_navigator_tool.cy.yml
+++ b/config/locales/money_navigator_tool/money_navigator_tool.cy.yml
@@ -336,9 +336,6 @@ cy:
           - code: A2
             text: 'Na'
             sort_order: 2
-          - code: A3
-            text: Roeddwn mewn trafferthion ariannol cyn 28ain Chwefror
-            sort_order: 3
       - code: Q11
         type: radio
         text: A fydd yn rhaid i chi fenthyg arian ar gyfer taliadau hanfodol (rhent, bwyd, biliau)?

--- a/config/locales/money_navigator_tool/money_navigator_tool.en.yml
+++ b/config/locales/money_navigator_tool/money_navigator_tool.en.yml
@@ -330,11 +330,11 @@ en:
         sort_order: 11
         responses:
           - code: A1
-            text: 'Yes'
+            text: 'No'
             sort_order: 1
             default: true
           - code: A2
-            text: 'No'
+            text: 'Yes'
             sort_order: 2
       - code: Q11
         type: radio

--- a/config/locales/money_navigator_tool/money_navigator_tool.en.yml
+++ b/config/locales/money_navigator_tool/money_navigator_tool.en.yml
@@ -326,7 +326,7 @@ en:
             sort_order: 12
       - code: Q10
         type: radio
-        text: Have you fallen behind or agreed a payment break on credit commitments or priority household bills since 28th February 2020?
+        text: Have you been on a debt solution that has failed in the past 12 months?
         sort_order: 11
         responses:
           - code: A1

--- a/config/locales/money_navigator_tool/money_navigator_tool.en.yml
+++ b/config/locales/money_navigator_tool/money_navigator_tool.en.yml
@@ -336,9 +336,6 @@ en:
           - code: A2
             text: 'No'
             sort_order: 2
-          - code: A3
-            text: I was in financial difficulties before 28th February
-            sort_order: 3
       - code: Q11
         type: radio
         text: Will you have to borrow more money to manage essential payments (like rent, food and bills) in the next few months?


### PR DESCRIPTION
[TP11798](https://maps.tpondemand.com/entity/11798-update-q10-on-money-navigator-tool)

The work in this PR makes some changes to one of the questions to bring it into line with some criteria set by  StepChange. It updates the copy of Question 10 (which currently reads "Have you fallen behind or agreed a payment break on credit commitments or priority household bills since 28th February 2020?") and deletes one fo the options from the response. 

**Existing (production)**

![image](https://user-images.githubusercontent.com/6080548/95579451-91bfbc00-0a2d-11eb-8a82-0815b40d1782.png)

**Updates in this PR**

![image](https://user-images.githubusercontent.com/6080548/95579489-a734e600-0a2d-11eb-965e-e505635a05c6.png)
