### PR TITLE
[TP-11817] Money Navigator: copy update to Q7

### DIFF
--- a/config/locales/money_navigator_tool/money_navigator_tool.cy.yml
+++ b/config/locales/money_navigator_tool/money_navigator_tool.cy.yml
@@ -218,7 +218,7 @@ cy:
             sort_order: 1
             default: true
           - code: A1
-            text: Treth cyngor
+            text: Treth cyngor/Ardrethu domestig
             sort_order: 2
           - code: A2
             text: Nwy neu drydan

--- a/config/locales/money_navigator_tool/money_navigator_tool.en.yml
+++ b/config/locales/money_navigator_tool/money_navigator_tool.en.yml
@@ -218,7 +218,7 @@ en:
             sort_order: 1
             default: true
           - code: A1
-            text: Council tax
+            text: Council tax/Rates
             sort_order: 2
           - code: A2
             text: Gas or electric


### PR DESCRIPTION
[TP11817](https://maps.tpondemand.com/entity/11817-add-the-word-rates-to-money)

This work makes a small change to the copy of one of the questions. For reasons of clarity it updates the 'Council Tax' response in Q7.

**Current**

![image](https://user-images.githubusercontent.com/6080548/96595123-4043e680-12e3-11eb-91f9-f06a1728d358.png)

**Updated**

![image](https://user-images.githubusercontent.com/6080548/96595145-46d25e00-12e3-11eb-8ccc-12b8651287e6.png)
