### PR TITLE
[TP-11821] Money Navigator: updates copy on landing page

### DIFF
--- a/config/locales/money_navigator_tool/money_navigator_tool.cy.yml
+++ b/config/locales/money_navigator_tool/money_navigator_tool.cy.yml
@@ -13,7 +13,7 @@ cy:
         subheading: Gwybod beth i'w wneud nesaf
         text:
           paras:
-            - Mae'r mesurau cyfyngiadau coronafeirws yn cael eu llacio ond maent wedi effeithio miliynau o bobl. Bydd beth mae hyn yn ei olygu i'ch cyllid yn bersonol iawn i chi.
+            - Mae'r cyfyngiadau coronafeirws wedi effeithio ar filiynau o bobl ac mae pethau'n cymryd amser i wella. Bydd yr hyn y mae’n ei olygu i'ch cyllid yn bersonol iawn i chi.
             - Felly os ydych chi'n chwilio am arweiniad ariannol ond nad ydych yn gwybod ble i ddechrau, nid ydych ar eich pen eich hun.
       who-help:
         heading: Pwy allwn ni helpu

--- a/config/locales/money_navigator_tool/money_navigator_tool.en.yml
+++ b/config/locales/money_navigator_tool/money_navigator_tool.en.yml
@@ -13,7 +13,7 @@ en:
         subheading: Know what to do next
         text:
           paras:
-            - The coronavirus lockdown measures are relaxing but they’ve affected millions of people. What this means for your finances will be very personal to you.
+            - The coronavirus restrictions have affected millions of people and things are taking a while to recover. What this means for your finances will be very personal to you.
             - So if you’re looking for money guidance but don’t know where to start, you’re not alone.
       who-help:
         heading: Who we can help


### PR DESCRIPTION
[TP11821](https://maps.tpondemand.com/entity/11821-update-text-on-money-navigator-home)

This work updates the copy for the introduction section of the Money Navigator tool. 

**Current**

![image](https://user-images.githubusercontent.com/6080548/96613991-899e3100-12f7-11eb-84b0-759e9824d8b0.png)

**Updated**

![image](https://user-images.githubusercontent.com/6080548/96614012-8f941200-12f7-11eb-953a-8f643997f859.png)
