### PR TITLE
Money navigator, font inconsistencies on the Results page overlays

### DIFF
--- a/app/assets/stylesheets/layout/page_specific/_money_navigator_results.scss
+++ b/app/assets/stylesheets/layout/page_specific/_money_navigator_results.scss
@@ -291,7 +291,6 @@ $transition-time: 0.4s;
 				margin-bottom: 0; 
 
 				p, a {
-					font-size: 0.875rem; 
 					margin: $baseline-unit 0;
 				}
 
@@ -302,6 +301,21 @@ $transition-time: 0.4s;
 					&:hover,
 					&:focus {
 						text-decoration: none;
+					}
+				}
+
+				ul {
+					list-style: none;
+
+					li:before {
+						content: '\2022';
+						color: #006a00;
+						display: block;
+						position: relative;
+						width: 0;
+						height: 0;
+						left: -20px;
+						top: -1px;
 					}
 				}
 
@@ -323,6 +337,54 @@ $transition-time: 0.4s;
 						border-style: solid;
 						border-width: 10px 0 0 10px;
 						border-color: transparent transparent transparent $color-article-cta;
+					}
+
+					h2:first-child {
+						margin-top: 0; 
+					}
+				}
+
+				.callout {
+					margin: $baseline-unit*5 0;
+					border: 2px solid;
+
+					p {
+						padding: $baseline-unit $baseline-unit*2;
+						font-size: 1rem; 
+						font-weight: 300; 
+						line-height: 1.5; 
+
+						@include respond-to($mq-l) {
+							font-size: 1.125rem;
+						}
+					}
+				}
+
+				.callout--tip, 
+				.callout--tool {
+					h1, h2, h3 {
+						text-indent: 2.25rem;
+						color: white;
+						margin: 0;
+						padding: 0.375rem;
+						font-size: 1.375rem;
+						line-height: 1.875rem;
+					}
+				}
+
+				.callout--tip {
+					border-color: #24afa8;
+
+					h1, h2, h3 {
+						background: #24afa8;
+					}
+				}
+
+				.callout--tool {
+					border-color: #f96e49;
+
+					h1, h2, h3 {
+						background: #f96e49;
 					}
 				}
 			}

--- a/app/views/money_navigator_tool/results.html.erb
+++ b/app/views/money_navigator_tool/results.html.erb
@@ -57,10 +57,10 @@
 												</h6>
 											</button>
 
-											<div class="heading__content mntpanel" data-heading-content>
-												<h3 class="heading__content__title">
+											<article class="heading__content mntpanel" data-heading-content>
+												<h1 class="heading__content__title">
 													<%= t("money_navigator_tool.results.#{result[:section_code]}.#{heading[:heading_code]}") %>
-												</h3>
+												</h1>
 
 												<%= heading[:content][:html].html_safe %>
 
@@ -71,7 +71,7 @@
 														class_name: 'overlay__hide__icon mntpanelclose' 
 													%>
 												</a>
-											</div>
+											</article>
 										</li>
 									<% end %>
 								</ul>


### PR DESCRIPTION
[TP11561](https://maps.tpondemand.com/entity/11561-review-font-sizes-in-action-callout)

There are a few inconsistencies in the rendering of text on the Results page of the Money Navigator tool when the user opens the overlays to view content. This is caused by the content being fetched from the CMS and thereby missing styles that would be available in the context of an article page. This work adds the missing styles to the Money Navigator stylesheet so that the display is consistent with the rest of the site.

Additionally, the overlay is updated to present its content within an `<article>` tag, which allows the content to be rendered more semantically and thereby better in terms of accessibility. 

The main visual differences are summarised below. 

The overlay heading becomes an `<h1>` within an `<article>` element that is better semantically and is aligned with a MAS article page
| Current | Updated |
|---|---|
| ![image](https://user-images.githubusercontent.com/6080548/98810820-acfc5d80-2417-11eb-8407-368f8ed3da5a.png) | ![image](https://user-images.githubusercontent.com/6080548/98810865-bede0080-2417-11eb-883f-5f340e82b139.png) |

The standard font size is updated to be consistent with a MAS article page
| Current | Updated |
|---|---|
| ![image](https://user-images.githubusercontent.com/6080548/98811418-ba661780-2418-11eb-82fe-767f4b0c15fd.png) | ![image](https://user-images.githubusercontent.com/6080548/98811438-c5b94300-2418-11eb-8255-6416aaee3fa1.png) |

The font sizing is made consistent within the `add-action` components
| Current | Updated |
|---|---|
| ![image](https://user-images.githubusercontent.com/6080548/98811813-53952e00-2419-11eb-8dc5-573c683d76d2.png) | ![image](https://user-images.githubusercontent.com/6080548/98811832-5c85ff80-2419-11eb-9401-39c57efdb9b4.png) |

Lists are styled to be consistent with a MAS article page
| Current | Updated |
|---|---|
| ![image](https://user-images.githubusercontent.com/6080548/98812027-aec72080-2419-11eb-9864-80c45449c92b.png) | ![image](https://user-images.githubusercontent.com/6080548/98812056-b8e91f00-2419-11eb-8c5e-5cebdb1e5f12.png) |


