### PR TITLE
TP 11926 mn update urgent debt advice logic

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from:
   - https://raw.githubusercontent.com/moneyadviceservice/mas-standards/master/.rubocop.yml
 Metrics/LineLength:
-  Max: 120
+  Max: 140
 Rails/UnknownEnv:
   Environments:
     - production

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,7 @@ Rails/UnknownEnv:
     - uat
     - qa
     - preview
+    - cultivate
 AllCops:
   Exclude:
     - 'Rakefile'

--- a/Gemfile
+++ b/Gemfile
@@ -55,16 +55,18 @@ gem 'nunes'
 gem 'opening_hours'
 gem 'postcode_anywhere-email_validation', '~> 0.2.0'
 gem 'psych', '>= 2.0.5' # https://www.ruby-lang.org/en/news/2014/03/29/heap-overflow-in-yaml-uri-escape-parsing-cve-2014-2525/
+gem 'rack', git: 'https://github.com/rails-lts/rack.git', branch: 'lts-1-6-stable'
 gem 'recaptcha', require: 'recaptcha/rails'
 gem 'redcarpet'
 gem 'rest-client', '~> 2.0'
 gem 'rouge'
-gem 'rubytree'
+gem 'rubytree', '~> 1'
 gem 'sass-rails'
 gem 'statsd-ruby'
 gem 'sucker_punch'
 gem 'turnout'
 gem 'whenever', require: false
+gem 'websocket-extensions', '>= 0.1.5'
 
 # MAS Gems
 # ========
@@ -72,11 +74,11 @@ gem 'whenever', require: false
 gem 'adal', git: 'git@github.com:moneyadviceservice/azure-activedirectory-library-for-ruby'
 gem 'cream', '2.1.8'
 gem 'dough-ruby', git: 'git@github.com:moneyadviceservice/dough.git', branch: '11691_DAL_Current-location-warning-message_v5.41', ref: 'a90d79d'
-gem 'mas-cms-client', '1.20.0'
+gem 'mas-cms-client', '1.20.1'
 gem 'site_search', '0.3.0'
 # Tools
 gem 'action_plans', '~> 5.5.0'
-gem 'advice_plans', '~> 4.1.0'
+gem 'advice_plans', '~> 4.1.1'
 gem 'agreements', '~> 2.5.0'
 gem 'budget_planner', '~> 5.7.1'
 gem 'car_cost_tool', '~> 1.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,6 +25,13 @@ GIT
       rails (>= 3.2, < 5.1.0)
       sass-rails
 
+GIT
+  remote: https://github.com/rails-lts/rack.git
+  revision: de472597cac8f3f222e7b6e90a07c2b991704b01
+  branch: lts-1-6-stable
+  specs:
+    rack (1.6.13)
+
 GEM
   remote: https://rubygems.org/
   remote: https://gems.railslts.com/
@@ -86,12 +93,12 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    advice_plans (4.1.0)
+    advice_plans (4.1.1)
       dough-ruby (~> 5.36)
       friendly_id (>= 5.1.0)
       hashie
       i18n-js (= 3.0.0.mas)
-      kaminari (~> 0.16.1)
+      kaminari (>= 1.2.1)
       meta-tags
       rails (>= 4, < 5)
       redcarpet (~> 3.2.0)
@@ -421,11 +428,20 @@ GEM
       sprockets-rails
     jshint_ruby (0.1)
       execjs
-    json (1.8.6)
+    json (2.4.0)
     jwt (1.5.6)
-    kaminari (0.16.3)
-      actionpack (>= 3.0.0)
-      activesupport (>= 3.0.0)
+    kaminari (1.2.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.1)
+      kaminari-activerecord (= 1.2.1)
+      kaminari-core (= 1.2.1)
+    kaminari-actionview (1.2.1)
+      actionview
+      kaminari-core (= 1.2.1)
+    kaminari-activerecord (1.2.1)
+      activerecord
+      kaminari-core (= 1.2.1)
+    kaminari-core (1.2.1)
     kgio (2.11.2)
     kss (0.5.0)
     launchy (2.4.3)
@@ -442,13 +458,13 @@ GEM
       activesupport (>= 3.1.0)
       rack (>= 1.4.0)
       rest-client
-    mas-cms-client (1.20.0)
+    mas-cms-client (1.20.1)
       activemodel (>= 4.2)
       activesupport (>= 4.2)
       faraday (~> 0.9.2)
       faraday-conductivity (~> 0.3.1)
       faraday_middleware (~> 0.12.2)
-      rubytree (~> 0.9.7)
+      rubytree (~> 1.0.0)
     mas-fonts (0.0.2.6)
       rails
     mas-mailer (0.3.2.15)
@@ -557,7 +573,6 @@ GEM
       formtastic-bootstrap (>= 2.1, < 3)
       friendly_id (>= 5.0)
       rails (>= 4, < 5)
-    rack (1.6.13)
     rack-accept (0.4.5)
       rack (>= 0.4)
     rack-livereload (0.3.17)
@@ -664,9 +679,9 @@ GEM
     ruby-progressbar (1.9.0)
     ruby_parser (3.13.1)
       sexp_processor (~> 4.9)
-    rubytree (0.9.7)
-      json (~> 1.8)
-      structured_warnings (~> 0.2)
+    rubytree (1.0.0)
+      json (~> 2.1)
+      structured_warnings (~> 0.3)
     rubyzip (1.3.0)
     safe_yaml (1.0.4)
     sass (3.2.19)
@@ -712,7 +727,7 @@ GEM
       sprockets (>= 2.8, < 4.0)
     sqlite3 (1.3.13)
     statsd-ruby (1.4.0)
-    structured_warnings (0.3.0)
+    structured_warnings (0.4.0)
     sucker_punch (2.1.1)
       concurrent-ruby (~> 1.0)
     syslog-logger (1.6.8)
@@ -776,7 +791,7 @@ GEM
       hashdiff
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.3)
+    websocket-extensions (0.1.5)
     whenever (0.10.0)
       chronic (>= 0.6.3)
     wpcc (2.8.3)
@@ -802,7 +817,7 @@ DEPENDENCIES
   activerecord-session_store
   activesupport!
   adal!
-  advice_plans (~> 4.1.0)
+  advice_plans (~> 4.1.1)
   aes!
   agreements (~> 2.5.0)
   algoliasearch
@@ -854,7 +869,7 @@ DEPENDENCIES
   link_header
   mail
   mailjet
-  mas-cms-client (= 1.20.0)
+  mas-cms-client (= 1.20.1)
   meta-tags (~> 2.4)
   mortgage_calculator (~> 3.16.0)
   mysql2 (= 0.4.9)
@@ -872,6 +887,7 @@ DEPENDENCIES
   pry-rescue
   psych (>= 2.0.5)
   quiz (~> 1.4.0)!
+  rack!
   rack-livereload
   rails (~> 4.2.11)!
   railslts-version!
@@ -886,7 +902,7 @@ DEPENDENCIES
   rspec-rails
   rspec_junit_formatter
   rubocop
-  rubytree
+  rubytree (~> 1)
   sass-rails
   savings_calculator (~> 1.10.2)
   sdoc
@@ -906,6 +922,7 @@ DEPENDENCIES
   universal_credit (~> 4.1.1)
   vcr
   webmock
+  websocket-extensions (>= 0.1.5)
   whenever
   wpcc (= 2.8.3)
 

--- a/app/assets/stylesheets/layout/page_specific/_money_navigator_questionnaire.scss
+++ b/app/assets/stylesheets/layout/page_specific/_money_navigator_questionnaire.scss
@@ -133,9 +133,6 @@
 		}
 	}
 
-	.question__response__hidden {
-		display: none;
-	}
 }
 
 // Component initialised
@@ -145,6 +142,10 @@
 
 		&.question--active {
 			display: block; 
+		}
+
+		.question__response--hidden {
+			display: none;
 		}
 
 		&[data-question-multiple] {
@@ -221,7 +222,7 @@
 						outline:none;
 					}
 				}
-	
+
 				.response__control {
 					&:checked + .response__text {
 						color: $color-white; 

--- a/app/assets/stylesheets/layout/page_specific/_money_navigator_questionnaire.scss
+++ b/app/assets/stylesheets/layout/page_specific/_money_navigator_questionnaire.scss
@@ -132,6 +132,10 @@
 			padding: 0 0 0 $baseline-unit * 4;
 		}
 	}
+
+	.question__response__hidden {
+		display: none;
+	}
 }
 
 // Component initialised

--- a/app/models/concerns/money_navigator/rules/urgent_action.rb
+++ b/app/models/concerns/money_navigator/rules/urgent_action.rb
@@ -15,7 +15,7 @@ class MoneyNavigator::Rules::UrgentAction
             {
               triggers: [
                 { q0: 'a1' },
-                { q4: %w[a1 a2], q6: %w[a4 a5 a6], q7: %w[a1 a2 a3 a4 a5 a6 a7 a8 a9]},
+                { q4: %w[a1 a2 a3 a4], q6: %w[a1 a2 a3 a4 a5 a6], q7: %w[a1 a2 a3 a4 a5 a6 a7 a8 a9], q9: %w[a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11]},
                 { q1: 'a2' }
               ],
               mask: [MASK_ALL + MASK_SOME + MASK_NONE, MASK_ALL + MASK_ALL + MASK_NONE],
@@ -24,7 +24,7 @@ class MoneyNavigator::Rules::UrgentAction
             {
               triggers: [
                 { q0: 'a2' },
-                { q4: %w[a1 a2], q6: %w[a4 a5 a6], q7: %w[a1 a2 a3 a4 a5 a6 a7 a8 a9]},
+                { q4: %w[a1 a2 a3 a4], q6: %w[a1 a2 a3 a4 a5 a6], q7: %w[a1 a2 a3 a4 a5 a6 a7 a8 a9], q9: %w[a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11]},
                 { q1: 'a2'}
               ],
               mask: [MASK_ALL + MASK_SOME + MASK_NONE, MASK_ALL + MASK_ALL + MASK_NONE],
@@ -33,7 +33,7 @@ class MoneyNavigator::Rules::UrgentAction
             {
               triggers: [
                 { q0: 'a3' },
-                { q4: %w[a1 a2], q6: %w[a4 a5 a6], q7: %w[a1 a2 a3 a4 a5 a6 a7 a8 a9]},
+                { q4: %w[a1 a2 a3 a4], q6: %w[a1 a2 a3 a4 a5 a6], q7: %w[a1 a2 a3 a4 a5 a6 a7 a8 a9], q9: %w[a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11]},
                 { q1: 'a2'}
               ],
               mask: [MASK_ALL + MASK_SOME + MASK_NONE, MASK_ALL + MASK_ALL + MASK_NONE],
@@ -42,7 +42,7 @@ class MoneyNavigator::Rules::UrgentAction
             {
               triggers: [
                 { q0: 'a4' },
-                { q4: %w[a1 a2], q6: %w[a4 a5 a6], q7: %w[a1 a2 a3 a4 a5 a6 a7 a8 a9]},
+                { q4: %w[a1 a2 a3 a4], q6: %w[a1 a2 a3 a4 a5 a6], q7: %w[a1 a2 a3 a4 a5 a6 a7 a8 a9], q9: %w[a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11]},
                 { q1: 'a2'}
               ],
               mask: [MASK_ALL + MASK_SOME + MASK_NONE, MASK_ALL + MASK_ALL + MASK_NONE],

--- a/app/models/concerns/money_navigator/rules/urgent_action.rb
+++ b/app/models/concerns/money_navigator/rules/urgent_action.rb
@@ -15,7 +15,7 @@ class MoneyNavigator::Rules::UrgentAction
             {
               triggers: [
                 { q0: 'a1' },
-                { q4: %w[a1 a2 a3 a4], q6: %w[a1 a2 a3 a4 a5 a6], q7: %w[a1 a2 a3 a4 a5 a6 a7 a8 a9], q9: %w[a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11]},
+                { q6: %w[a1 a2 a3 a4 a5 a6], q7: %w[a1 a2 a3 a4 a5 a6 a7 a8 a9], q9: %w[a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11]},
                 { q1: 'a2' }
               ],
               mask: [MASK_ALL + MASK_SOME + MASK_NONE, MASK_ALL + MASK_ALL + MASK_NONE],
@@ -24,7 +24,7 @@ class MoneyNavigator::Rules::UrgentAction
             {
               triggers: [
                 { q0: 'a2' },
-                { q4: %w[a1 a2 a3 a4], q6: %w[a1 a2 a3 a4 a5 a6], q7: %w[a1 a2 a3 a4 a5 a6 a7 a8 a9], q9: %w[a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11]},
+                { q6: %w[a1 a2 a3 a4 a5 a6], q7: %w[a1 a2 a3 a4 a5 a6 a7 a8 a9], q9: %w[a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11]},
                 { q1: 'a2'}
               ],
               mask: [MASK_ALL + MASK_SOME + MASK_NONE, MASK_ALL + MASK_ALL + MASK_NONE],
@@ -33,7 +33,7 @@ class MoneyNavigator::Rules::UrgentAction
             {
               triggers: [
                 { q0: 'a3' },
-                { q4: %w[a1 a2 a3 a4], q6: %w[a1 a2 a3 a4 a5 a6], q7: %w[a1 a2 a3 a4 a5 a6 a7 a8 a9], q9: %w[a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11]},
+                { q6: %w[a1 a2 a3 a4 a5 a6], q7: %w[a1 a2 a3 a4 a5 a6 a7 a8 a9], q9: %w[a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11]},
                 { q1: 'a2'}
               ],
               mask: [MASK_ALL + MASK_SOME + MASK_NONE, MASK_ALL + MASK_ALL + MASK_NONE],
@@ -42,7 +42,7 @@ class MoneyNavigator::Rules::UrgentAction
             {
               triggers: [
                 { q0: 'a4' },
-                { q4: %w[a1 a2 a3 a4], q6: %w[a1 a2 a3 a4 a5 a6], q7: %w[a1 a2 a3 a4 a5 a6 a7 a8 a9], q9: %w[a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11]},
+                { q6: %w[a1 a2 a3 a4 a5 a6], q7: %w[a1 a2 a3 a4 a5 a6 a7 a8 a9], q9: %w[a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11]},
                 { q1: 'a2'}
               ],
               mask: [MASK_ALL + MASK_SOME + MASK_NONE, MASK_ALL + MASK_ALL + MASK_NONE],

--- a/app/views/money_navigator_tool/questionnaire.html.erb
+++ b/app/views/money_navigator_tool/questionnaire.html.erb
@@ -62,7 +62,7 @@
                       <% question[:responses].each do |response| %>
                         <div 
                           <% if response[:hidden] %>
-                            class="question__response__hidden"
+                            class="question__response question__response--hidden"
                           <% else %>
                             class="question__response" 
                           <% end %>

--- a/app/views/money_navigator_tool/questionnaire.html.erb
+++ b/app/views/money_navigator_tool/questionnaire.html.erb
@@ -60,7 +60,14 @@
                       <% end %>
 
                       <% question[:responses].each do |response| %>
-                        <div class="question__response" data-response
+                        <div 
+                          <% if response[:hidden] %>
+                            class="question__response__hidden"
+                          <% else %>
+                            class="question__response" 
+                          <% end %>
+                      
+                        data-response
                           <% if response[:group] %>
                             data-response-group="<%= response[:group] %>"
                           <% end %>

--- a/config/locales/money_navigator_tool/money_navigator_tool.en.yml
+++ b/config/locales/money_navigator_tool/money_navigator_tool.en.yml
@@ -136,6 +136,7 @@ en:
             text: 'I am not self employed'
             default: true
             sort_order: 1
+            hidden: true
       - code: Q4
         type: radio
         custom: true

--- a/features/factories/money_navigator/urgent_cta_rules.rb
+++ b/features/factories/money_navigator/urgent_cta_rules.rb
@@ -8,18 +8,18 @@ FactoryBot.define do
     factory :S1_H3_self_employed_debt_advice, traits: [:country, :S1_H3_self_employed_debt_advice_answers]
     factory :S1_H4_urgent_pension_advice, traits: [:country, :S1_H4_pension_advice_answers]
 
-    # Any of these Q4A1, Q4A2, Q6A4, Q6A5, Q6A6, Q7A1-A9  BUT NOT IF HAVE SELECTED Q10A1 PLUS the regional variation
+    # Any of these Q4A1-A4, Q6A1-A6, Q7A1-A9, Q9A1-A11 BUT NOT IF HAVE SELECTED Q1A2 PLUS the regional variation
     trait :S1_H1_debt_advice_answers do
       q1 { answers_with_entropy('q1', ['a1'], [])  }
-      q2 { answers_with_entropy('q2', [], nil)  }
+      q2 { answers_with_entropy('q2', ['a2'], nil)  }
       q3 { answers_with_entropy('q3', [], nil)  }
-      q4 { answers_with_entropy('q4', ['a1', 'a2'], nil)  }
+      q4 { answers_with_entropy('q4', ['a1', 'a2', 'a3', 'a4'], nil)  }
       q5 { answers_with_entropy('q5', [], nil)  }
-      q6 { answers_with_entropy('q6', ['a4', 'a5', 'a6'], nil) }
+      q6 { answers_with_entropy('q6', ['a1', 'a2', 'a3', 'a4', 'a5', 'a6'], nil) }
       q7 { answers_with_entropy('q7', ['a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'a7', 'a8', 'a9'], nil) }
       q8 { answers_with_entropy('q8', [], nil)  }
-      q9 { answers_with_entropy('q9', [], nil)  }
-      q10 { answers_with_entropy('q10', ['a1'], nil) }
+      q9 { answers_with_entropy('q9', ['a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'a7', 'a8', 'a9', 'a10', 'a11'], nil)  }
+      q10 { answers_with_entropy('q10', [], nil) }
       q11 { answers_with_entropy('q11', [], nil)  }
       q12 { answers_with_entropy('q12', [], nil)  }
       q13 { answers_with_entropy('q13', [], nil)  }

--- a/features/factories/money_navigator/urgent_cta_rules.rb
+++ b/features/factories/money_navigator/urgent_cta_rules.rb
@@ -8,12 +8,12 @@ FactoryBot.define do
     factory :S1_H3_self_employed_debt_advice, traits: [:country, :S1_H3_self_employed_debt_advice_answers]
     factory :S1_H4_urgent_pension_advice, traits: [:country, :S1_H4_pension_advice_answers]
 
-    # Any of these Q4A1-A4, Q6A1-A6, Q7A1-A9, Q9A1-A11 BUT NOT IF HAVE SELECTED Q1A2 PLUS the regional variation
+    # Any of these Q6A1-A6, Q7A1-A9, Q9A1-A11 BUT NOT IF HAVE SELECTED Q1A2 PLUS the regional variation
     trait :S1_H1_debt_advice_answers do
       q1 { answers_with_entropy('q1', ['a1'], [])  }
       q2 { answers_with_entropy('q2', ['a2'], nil)  }
       q3 { answers_with_entropy('q3', [], nil)  }
-      q4 { answers_with_entropy('q4', ['a1', 'a2', 'a3', 'a4'], nil)  }
+      q4 { answers_with_entropy('q4', [], nil)  }
       q5 { answers_with_entropy('q5', [], nil)  }
       q6 { answers_with_entropy('q6', ['a1', 'a2', 'a3', 'a4', 'a5', 'a6'], nil) }
       q7 { answers_with_entropy('q7', ['a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'a7', 'a8', 'a9'], nil) }

--- a/lib/core/repository/categories/cms.rb
+++ b/lib/core/repository/categories/cms.rb
@@ -25,6 +25,8 @@ module Core::Repository
           raise Core::Repository::CMS::Resource301Error.new(response.headers['Location'])
         elsif response.status == 302
           raise Core::Repository::CMS::Resource302Error.new(response.headers['Location'])
+        elsif response.body.nil?
+          raise Core::Repository::Base::RequestError.new(response.headers['Location'])
         end
 
         response.body

--- a/spec/models/money_navigator/rules/urgent_cta_rules_spec.rb
+++ b/spec/models/money_navigator/rules/urgent_cta_rules_spec.rb
@@ -1,4 +1,3 @@
-
 RSpec.describe MoneyNavigator::Questions, type: :model do
   include MoneyNavigator::Symbols
 


### PR DESCRIPTION
[TP 11926](https://maps.tpondemand.com/entity/11926-money-navigator-update-urgent-debt-advice)

Alter logic and test such that when the user is not self-employed and any answer except No is given for Q6, Q7 Q9, the Urgent Debt Advice banner is triggered
Add a CSS class to allow hiding of individual answers
Hide the answer to Q3 which allows users to select "I am not self-employed" even if they have already said they are self employed in a previous question. 