### PR TITLE
TP-11667 Money Navigator A11Y back button

### DIFF
--- a/app/assets/javascripts/components/MoneyNavigatorQuestions.js
+++ b/app/assets/javascripts/components/MoneyNavigatorQuestions.js
@@ -512,6 +512,12 @@ define(['jquery', 'DoughBaseComponent'], function ($, DoughBaseComponent) {
       .find('.question__counter')
       .text(progress + '% ' + this.i18nStrings.messages.completed);
 
+    if (dir === 'prev') {
+      if (activeIndex >= 0) {
+        questions[activeIndex].focus(); 
+      }
+    }
+
     if (activeIndex == 0) {
       this.$banner.removeClass(
         'l-money_navigator__banner' + '--' + this.hiddenClass

--- a/app/assets/stylesheets/layout/page_specific/_money_navigator_questionnaire.scss
+++ b/app/assets/stylesheets/layout/page_specific/_money_navigator_questionnaire.scss
@@ -76,6 +76,10 @@
 	list-style: none;
 	padding: 0;
 
+  &:focus {
+    @include focus-outline;
+  }
+
 	.question__counter {
 		color: $color-green-secondary;
 		font-weight: 700; 

--- a/app/views/money_navigator_tool/questionnaire.html.erb
+++ b/app/views/money_navigator_tool/questionnaire.html.erb
@@ -28,6 +28,7 @@
           <% t("money_navigator_tool.questions").each_with_index do |question, index| %>
             <li
               class="l-money_navigator__question"
+              tabindex="0"
               data-question
               <% if question[:type] == 'checkbox' %>
                 data-question-multiple

--- a/spec/javascripts/fixtures/MoneyNavigatorQuestions.html
+++ b/spec/javascripts/fixtures/MoneyNavigatorQuestions.html
@@ -3,7 +3,7 @@
 
 	<form data-dough-component="MoneyNavigatorQuestions">
 		<ul>
-			<li data-question class="l-money_navigator__question">
+			<li data-question class="l-money_navigator__question" tabindex="0">
 				<p class="question__counter">Question 1 of 6</p>
 
 				<div class="question__content" data-question-id="q0">
@@ -25,7 +25,7 @@
 				</div>
 			</li>
 
-			<li data-question class="l-money_navigator__question">
+			<li data-question class="l-money_navigator__question" tabindex="0">
 				<p class="question__counter">Question 2 of 6</p>
 
 				<div class="question__content" data-question-id="q1" data-question-custom>
@@ -57,7 +57,7 @@
 				</div>
 			</li>
 
-			<li data-question data-question-multiple class="l-money_navigator__question">
+			<li data-question data-question-multiple class="l-money_navigator__question" tabindex="0">
 				<p class="question__counter">Question 3 of 6</p>
 
 				<div class="question__content" data-question-id="q2">
@@ -96,6 +96,7 @@
 				data-question data-question-grouped 
 				data-question-grouped-group-titles="['No, but I\'m worried', 'Yes']"
 				class="l-money_navigator__question"
+				tabindex="0"
 			>
 				<p class="question__counter">Question 4 of 6</p>
 
@@ -132,13 +133,13 @@
 				</div>
 			</li>
 
-			<li data-question class="l-money_navigator__question">
+			<li data-question class="l-money_navigator__question" tabindex="0">
 				<p class="question__counter">Question 5 of 6</p>
 
 				<div class="question__content" data-question-id="q4"></div>
 			</li>
 
-			<li data-question class="l-money_navigator__question">
+			<li data-question class="l-money_navigator__question" tabindex="0">
 				<p class="question__counter">Question 6 of 6</p>		
 
 				<div class="question__content" data-question-id="q5">

--- a/spec/javascripts/tests/MoneyNavigatorQuestions_spec.js
+++ b/spec/javascripts/tests/MoneyNavigatorQuestions_spec.js
@@ -7,13 +7,11 @@ describe('MoneyNavigatorQuestions', function() {
   beforeEach(function(done) {
     var self = this;
 
-    fixture.setBase('spec/javascripts/fixtures');
-
     requirejs(
         ['jquery', 'MoneyNavigatorQuestions'],
         function($, MoneyNavigatorQuestions) {
-          fixture.load('MoneyNavigatorQuestions.html');
-          self.component = $(fixture.el).find('[data-dough-component="MoneyNavigatorQuestions"]');
+          self.$html = $(window.__html__['spec/javascripts/fixtures/MoneyNavigatorQuestions.html']).appendTo('body');
+          self.component = self.$html.find('[data-dough-component="MoneyNavigatorQuestions"]');
           self.obj = new MoneyNavigatorQuestions(self.component);
           self.banner = $(self.component).parents().find('[data-banner]'); 
           self.questions = self.component.find('[data-question]'); 
@@ -474,7 +472,7 @@ describe('MoneyNavigatorQuestions', function() {
       expect($(this.questions[0]).hasClass(this.activeClass)).to.be.true; 
       expect($(this.questions[1]).hasClass(this.activeClass)).to.be.false; 
 
-      // Q1 is skipped
+      // Q2 is skipped
       $(this.questions[1]).data('question-skip', true); 
 
       this.obj._updateDisplay('next'); 
@@ -488,22 +486,35 @@ describe('MoneyNavigatorQuestions', function() {
       expect($(this.questions[2]).hasClass(this.activeClass)).to.be.false; 
     }); 
 
+    it('Adds focus to correct element when `back` button is clicked', function() {
+      $(this.questions[4]).addClass(this.activeClass); 
+
+      this.obj._updateDisplay('prev'); 
+      expect($(this.questions[3])[0] === document.activeElement).to.be.true; 
+
+      // Q3 is skipped
+      $(this.questions[2]).data('question-skip', true); 
+      this.obj._updateDisplay('prev'); 
+      expect($(this.questions[2])[0] === document.activeElement).to.be.false; 
+      expect($(this.questions[1])[0] === document.activeElement).to.be.true; 
+    }); 
+
     it('Shows/hides the banner when active question is/not Q0', function() {
       var hiddenClass = 'l-money_navigator__banner' + '--' + this.hiddenClass; 
 
       this.obj._updateDOM(); 
 
       this.obj._updateDisplay('next');
-      expect(this.banner.hasClass(hiddenClass)).to.be.true; 
+      expect(this.$html.find('[data-banner]')[0].className.indexOf(hiddenClass)).to.be.above(-1); 
 
       this.obj._updateDisplay('next');
-      expect(this.banner.hasClass(hiddenClass)).to.be.true; 
+      expect(this.$html.find('[data-banner]')[0].className.indexOf(hiddenClass)).to.be.above(-1); 
 
       this.obj._updateDisplay('prev');
-      expect(this.banner.hasClass(hiddenClass)).to.be.true; 
+      expect(this.$html.find('[data-banner]')[0].className.indexOf(hiddenClass)).to.be.above(-1); 
 
       this.obj._updateDisplay('prev');
-      expect(this.banner.hasClass(hiddenClass)).to.be.false; 
+      expect(this.$html.find('[data-banner]')[0].className.indexOf(hiddenClass)).to.equal(-1); 
     }); 
 
     it('Updates the counter to the correct value for the active question', function() {


### PR DESCRIPTION
[TP-11667](https://maps.tpondemand.com/entity/11667-money-navigator-accessibility-on-back-button)

This work updates the logic that deals with the display of individual questions on the Money Navigator tool as the user navigates through the questions by keyboard via the `back` button. It ensures that focus is moved to the top of the previous question so that the flow for the keyboard user remains intuitive.

It also adds a Unit Tests for the new functionality which in turn required an update to the existing tests for the component because a clash occurred with other tests when trying to obtain a value for `document.activeElement`. This update in turn required a small change in an existing test. All now run OK. 

| When the back button on a question is activated | Focus is moved to the first input element of the previous question |
| :--- | :--- |
| ![image](https://user-images.githubusercontent.com/6080548/105173359-ce18b300-5b18-11eb-978b-4123883382b6.png) | ![image](https://user-images.githubusercontent.com/6080548/105173384-d7a21b00-5b18-11eb-81b8-1070aa3897b4.png) |