### PR TITLE
[Bugfix] Resolve broken tests in preview

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -190,7 +190,7 @@ group :test do
   gem 'cucumber-rails', '~> 2.1.0', require: false
   gem 'database_cleaner'
   gem 'email_spec', '< 2' # DelayedJob integration removed in 2.0.0
-  gem 'factory_bot'
+  gem 'factory_bot', '~> 4.10.0'
   gem 'faker'
   gem 'html_validation'
   gem 'poltergeist'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -505,8 +505,8 @@ GEM
     erubi (1.10.0)
     erubis (2.7.0)
     execjs (2.7.0)
-    factory_bot (5.2.0)
-      activesupport (>= 4.2.0)
+    factory_bot (4.10.0)
+      activesupport (>= 3.0.0)
     faker (2.2.1)
       i18n (>= 0.8)
     faraday (0.9.2)
@@ -962,7 +962,7 @@ DEPENDENCIES
   draper (< 3)
   ejs
   email_spec (< 2)
-  factory_bot
+  factory_bot (~> 4.10.0)
   faker
   faraday (= 0.9.2)
   faraday-conductivity


### PR DESCRIPTION
This addresses the issue of failing tests within our preview CI builds.

This was introduced when we accidentally upgraded FactoryBot to 5.2.0, from 4.10.0

The change pins FactoryBot to the previous version, so that we only update FactoryBot when we're ready to update the factory files.

The upgrade of FactoryBot happened here: https://github.com/moneyadviceservice/frontend/commit/fa628fa8be9cb4181c7ea5520a1977047c15d178#diff-89cade48462044ee1b672dc5f4c3ec250fbd29effcd8932096a23c1283c6731fR508