### PR TITLE
Tp 11923 money navigator a11 y links

### DIFF
--- a/app/assets/stylesheets/layout/page_specific/_money_navigator_landing.scss
+++ b/app/assets/stylesheets/layout/page_specific/_money_navigator_landing.scss
@@ -11,6 +11,12 @@
 		}
 	}
 
+	.callout {
+		a {
+			text-decoration: underline;
+		}
+	}
+
 	.landing__actions {
 		@extend %clearfix;
 

--- a/app/assets/stylesheets/layout/page_specific/_money_navigator_results.scss
+++ b/app/assets/stylesheets/layout/page_specific/_money_navigator_results.scss
@@ -59,6 +59,10 @@ $transition-time: 0.4s;
 				margin-bottom: $baseline-unit * 2; 
 				padding: $baseline-unit 0; 
 
+				a {
+					text-decoration: underline;
+				}
+
 				& > p {
 					@include column(12); 
 
@@ -99,10 +103,6 @@ $transition-time: 0.4s;
 
 					p {
 						font-size: 1rem; 
-
-						a {
-							text-decoration: underline;
-						}
 					}
 
 					@include respond-to($mq-m) {


### PR DESCRIPTION
[TP-11923](https://maps.tpondemand.com/restui/board.aspx?#page=userstory/11923&appConfig=eyJhY2lkIjoiQTYyMEM3NTQ2MEJFN0E2NDk2Qzg0RDdERjcwNzkyRDAifQ==)

This work makes some simple updates to the CSS for the Landing and Results pages of the Money Navigator tool to ensure that all links within these pages that appear within block of text are rendered with an underline style. 

There is a reference in the TP Card for this work to the Cookies message. This is covered in a card ([TP-11958](https://maps.tpondemand.com/entity/11958-link-on-cookie-message-identified-only)) in the Feature for A11Y work on the main MAS site ([TP-11852](https://maps.tpondemand.com/entity/11852-mas-accessibility-fixes-post-audit)). 

Examples of links covered in this work. 

| ![image](https://user-images.githubusercontent.com/6080548/105523240-16310480-5cd6-11eb-82c4-d4b4321504a5.png) | ![image](https://user-images.githubusercontent.com/6080548/105523271-1df0a900-5cd6-11eb-9d2b-394445e3410b.png) | ![image](https://user-images.githubusercontent.com/6080548/105523313-26e17a80-5cd6-11eb-9d98-01e7814f90e4.png) |
| --- | --- | --- |
