### PR TITLE
11822 money navigator grouped questions focus issues

### DIFF
--- a/app/assets/javascripts/components/MoneyNavigatorQuestions.js
+++ b/app/assets/javascripts/components/MoneyNavigatorQuestions.js
@@ -56,6 +56,7 @@ define(['jquery', 'DoughBaseComponent'], function ($, DoughBaseComponent) {
     this._updateDOM(this.dataLayer); 
     this._setUpMultipleQuestions(); 
     this._setUpGroupedQuestions(); 
+    this._setUpKeyboardEvents(); 
     this._setUpJourneyLogic(); 
     this._initialisedSuccess(initialised);
   };
@@ -69,14 +70,21 @@ define(['jquery', 'DoughBaseComponent'], function ($, DoughBaseComponent) {
     var _this = this; 
 
     this.$groupedQuestions.each(function() {
-      var $groupedResponses = $(this).find('[data-response-group], [data-response]'),
-          groups = {},
+      var el = $(this).find('[data-question-id]')[0],
+          computedStyle = window.getComputedStyle(el),
+          width = parseFloat(computedStyle.getPropertyValue('width')),
+          padding = parseFloat(computedStyle.getPropertyValue('padding-left')) * 2,
+          border = parseFloat(computedStyle.getPropertyValue('border-left-width')) * 2,
+          gutter = padding / (width - border) / 4 * 100,
+          $groupedResponses = $(this).find('[data-response-group], [data-response]'),
+          $fieldset = $(this).find('fieldset').detach(), 
+          name = $fieldset.find('input')[0].name,
           titles = $(this).data('question-grouped-group-titles'),
-          i = 0,
-          groupNum = 0,
-          questionResponses = document.createElement('div'); 
+          questionGroups = document.createElement('div'),
+          groups = {},
+          numGroups;
 
-      // Collect all responses into arrays and remove from DOM
+      // Collect all grouped responses into arrays and remove from DOM
       $groupedResponses.each(function() {
         if ($(this).data('response-group')) {
           var groupNum = $(this).data('response-group');  
@@ -93,26 +101,81 @@ define(['jquery', 'DoughBaseComponent'], function ($, DoughBaseComponent) {
         $(this).remove(); 
       }); 
 
-      groupNum = Object.keys(groups).length; 
+      numGroups = Object.keys(groups).length; 
 
-      $(questionResponses)
-        .addClass('response__controls')
-        .attr('data-response-controls', true)
-        .css('width', (1 / groupNum * 100) + '%'); 
+      $(questionGroups)
+        .addClass('question__groups')
+        .css('width', (100 + gutter) * 2 + '%');
+
+      $(this).find('.question__content').append(questionGroups);
 
       for(var num in groups) {
         if (num === 'default') {
-          $(questionResponses).prepend(groups[num].outerHTML); 
+          var div = document.createElement('div'); 
+
+          $fieldset
+            .find('.content__inner')
+              .prepend(groups[num]); 
+
+          $(div)
+            .addClass('response__controls')
+            .attr('data-response-controls', true)
+            .css('width', (100 - gutter) / 2 + '%')
+            .append($fieldset);
+
+          $(questionGroups).prepend(div);
         } else {
-          var response = document.createElement('div'), 
-              collection = document.createElement('div'), 
+          // Add collections and resets to the DOM
+          var collection = document.createElement('fieldset'), 
+              contentInner = document.createElement('div'), 
               reset = document.createElement('button'), 
+              legend = document.createElement('legend'), 
+              paraText = document.createTextNode(titles[num - 1]),
+              div = document.createElement('div'); 
+
+          legend.appendChild(paraText); 
+
+          $(legend).addClass('question__heading');
+
+          $(reset)
+            .addClass('button button--reset')
+            .attr({
+              'data-reset': true,
+              'tabindex': -1
+            })
+            .text(_this.i18nStrings.controls.reset); 
+
+          $(reset).on('click', function(e) {
+            e.preventDefault(); 
+            _this._updateGroupedQuestionsDisplay(e.target); 
+          }); 
+
+          $(contentInner)
+            .addClass('content__inner')
+            .append(groups[num])
+            .append(reset); 
+
+          $(collection)
+            .prepend(legend)
+            .append(contentInner); 
+  
+          $(div)
+            .addClass('question__response--collection question--inactive')
+            .attr('data-response-collection', num)
+            .css({
+              'marginLeft': (-100 + gutter) / 2 * (num - 1) + '%', 
+              'width': (100 - gutter) / 2 + '%'
+            })
+            .append(collection); 
+
+          $(questionGroups).append(div); 
+
+          // Add new inputs to the control group
+          var response = document.createElement('div'), 
               input = document.createElement('input'), 
               label = document.createElement('label'), 
               span = document.createElement('span'), 
-              para = document.createElement('p'), 
-              labelText = document.createTextNode(titles[i]), 
-              paraText = document.createTextNode(titles[i])
+              labelText = document.createTextNode(titles[num - 1]);
 
           span.appendChild(labelText); 
 
@@ -125,53 +188,23 @@ define(['jquery', 'DoughBaseComponent'], function ($, DoughBaseComponent) {
           input.id = 'control_' + num;
           input.value = ''; 
 
-          para.className = 'collection__title'; 
-          para.appendChild(paraText); 
-
-          // Add responses to the DOM
           response.setAttribute('data-response-group-control', num); 
           response.className = 'question__response question__response--control';
           response.appendChild(input); 
           response.appendChild(label); 
 
-          $(this).find('.content__inner').append(response); 
-
-          $(questionResponses).append(response); 
-
-          // Add collections and resets to the DOM
-          $(collection)
-            .addClass('question__response--collection question--inactive')
-            .attr('data-response-collection', num);
-
-          $(groups[num]).each(function() {
-            $(collection).append(groups[num]); 
-          }); 
-
-          $(reset)
-            .addClass('button button--reset')
-            .attr('data-reset', true)
-            .text(_this.i18nStrings.controls.reset); 
-
-          $(this).find('.content__inner').append(collection);
-          $(collection).prepend(para); 
-          $(collection).append(reset); 
-          $(collection).css({
-            'marginLeft': (1 / groupNum * -100 * i) + '%', 
-            'width': (1 / groupNum * 100) + '%'
-          }); 
-
-          $(reset).on('click', function(e) {
-            e.preventDefault(); 
-            _this._updateGroupedQuestionsDisplay(e.target); 
-          }); 
+          $fieldset.find('.content__inner').append(response); 
         }
+      }; 
 
-        i++; 
-      }
+      $(this).find('.question__content').prepend(questionGroups); 
 
-      $(this).find('.content__inner')
-        .prepend(questionResponses)
-        .css('width', (i * 100) + '%')
+      $(this).find('[data-response-controls]')
+        .on('change', function(e) {
+          _this._updateGroupedQuestionsDisplay(e.target); 
+        }); 
+
+      $(this).find('[data-response-collection]')
         .on('change', function(e) {
           _this._updateGroupedQuestionsDisplay(e.target); 
         }); 
@@ -179,21 +212,106 @@ define(['jquery', 'DoughBaseComponent'], function ($, DoughBaseComponent) {
   }; 
 
   /**
+   * A method that controls user navigation on the grouped question by keyboard
+   */
+  MoneyNavigatorQuestions.prototype._setUpKeyboardEvents = function() {
+    this.$groupedQuestions.each(function() {
+      // Set focus on keyboard events
+      $(this).keydown(function(e) {
+        var response = $(e.target).parent('[data-response], [data-response-group-control]')[0], 
+            $responses = $(response).parent('.content__inner'), 
+            nextInput, 
+            prevInput; 
+
+        switch (e.keyCode) {
+          // right or down arrows
+          case 39:
+          case 40:
+            // moves to next input unless current input is last
+            e.preventDefault(); 
+
+            if ($responses.find('[data-response], [data-response-group-control]').last()[0] === response) {
+              nextInput = $responses.find('[data-response], [data-response-group-control]').first().find('input')[0]; 
+            } else {
+              nextInput = $(response).next().find('input')[0];
+            }
+
+            nextInput.focus()
+            // nextInput.checked = true; 
+
+            break;
+
+          // left or up arrows
+          case 37:
+          case 38:
+            // moves to previous input unless current input is first
+            e.preventDefault(); 
+
+            if ($responses.find('[data-response], [data-response-group-control]').first()[0] === response) {
+              prevInput = $responses.find('[data-response], [data-response-group-control]').last().find('input')[0]; 
+            } else {
+              prevInput = $(response).prev().find('input')[0];
+            }
+
+            prevInput.focus()
+            // prevInput.checked = true; 
+
+            break;
+
+          // tab key
+          case 9:
+            // moves to `Continue` in control group
+            if ($(response).length > 0 && response.dataset.responseGroup === undefined) {
+              e.preventDefault(); 
+
+              $(this).find('[data-continue]')[0].focus(); 
+            }
+
+            break;
+        }
+      }); 
+    }); 
+  }; 
+
+  /**
    * A method that is called when the controls created by _setUpGroupedQuestions are activated
    */
   MoneyNavigatorQuestions.prototype._updateGroupedQuestionsDisplay = function(el) {
-    var $container = $(el).parents('.question__content').find('.content__inner');
+    var $container = $(el).parents('.question__content').find('.question__groups');
 
     if ($(el).data('reset') || $(el).data('back')) {
       $container.children('[data-response-controls]').removeClass(this.inactiveClass); 
       $container.children('[data-response-group-control]').removeClass(this.inactiveClass); 
       $container.children('[data-response-collection]').addClass(this.inactiveClass); 
+
+      if ($(el).data('reset')) {
+        $container.find('[data-reset]').attr('tabindex', -1); 
+        $container.children('[data-response-controls]').find('input[checked=checked]').focus(); 
+        $container.children('[data-response-collection]').find('input').attr('tabindex', -1); 
+      }
     } else if ($(el).parents('[data-response-controls]').length > 0) {
       var id = el.id.split('_')[1];
       var $responseControls = $container.children('[data-response-controls]'); 
 
       if (el.id.indexOf('control_') > -1) {
         $responseControls.addClass(this.inactiveClass)
+
+        $container.children('[data-response-collection]')
+          .addClass(this.inactiveClass)
+          .find('[data-reset]').attr('tabindex', -1); 
+
+        $container.children('[data-response-collection]')
+          .find('input').attr('tabindex', -1); 
+
+        $container.children('[data-response-collection="' + id + '"]')
+          .removeClass(this.inactiveClass)
+          .find('input')[0].focus(); 
+
+        $container.children('[data-response-collection="' + id + '"]')
+          .find('[data-reset]').attr('tabindex', 0);
+
+        $container.children('[data-response-collection="' + id + '"]')
+          .find('input').attr('tabindex', 0);
       }
 
       $responseControls.find('input').each(function() {
@@ -211,9 +329,6 @@ define(['jquery', 'DoughBaseComponent'], function ($, DoughBaseComponent) {
           }
         }
       }); 
-
-      $container.children('[data-response-collection]').addClass(this.inactiveClass); 
-      $container.children('[data-response-collection="' + id + '"]').removeClass(this.inactiveClass); 
     } else {
       el.checked = true; 
     }
@@ -225,7 +340,7 @@ define(['jquery', 'DoughBaseComponent'], function ($, DoughBaseComponent) {
 
     $inputs.each(function() {
       if (this.checked == true) {
-        if (this.name == '') {
+        if (this.value == '') {
           disabled = true; 
         } else {
           disabled = false; 

--- a/app/assets/stylesheets/layout/page_specific/_money_navigator_questionnaire.scss
+++ b/app/assets/stylesheets/layout/page_specific/_money_navigator_questionnaire.scss
@@ -76,10 +76,6 @@
 	list-style: none;
 	padding: 0;
 
-  &:focus {
-    @include focus-outline;
-  }
-
 	.question__counter {
 		color: $color-green-secondary;
 		font-weight: 700; 
@@ -88,11 +84,7 @@
 	.question__content {
 		border: solid 1px $color-grey-pale;	
 		padding: $baseline-unit * 4 $default-gutter * 2 $baseline-unit * 2; 
-
-		@include respond-to($mq-l) {
-			padding-left: $default-gutter;
-			padding-right: $default-gutter;
-		}
+		overflow: hidden;
 	}
 
 	.question__heading {
@@ -239,11 +231,9 @@
 		&[data-question-grouped] {
 			$transition-time: 0.5s;
 
-			fieldset {
-				overflow: hidden;
-			}
+			.question__groups {
+				@extend %clearfix;
 
-			.content__inner {
 				box-sizing: content-box;
 				padding: 0 $default-gutter * 2;
 				margin: 0 $default-gutter * -2;
@@ -251,7 +241,14 @@
 				.response__controls,
 				.question__response--collection {
 					float: left;
-					transition: transform $transition-time;
+					visibility: visible; 
+					transition-property: transform, visibility;
+					transition-duration: $transition-time, 0s;
+
+					input:focus + label, 
+					button:focus {
+						@include focus-outline;
+					}
 				}
 
 				.response__controls {
@@ -259,15 +256,19 @@
 					margin-right: $default-gutter;
 	
 					&.question--inactive {
-						transform: translateX(-100% - ($default-gutter * 3));
+						transform: translateX(-100% - ($default-gutter * 2));
+						visibility: hidden; 
+						transition-delay: 0s, $transition-time; 
 					}
 				}
 
 				.question__response--collection {
-					transform: translateX(-100% - ($default-gutter * 3));
+					transform: translateX(-100% - ($default-gutter * 2));
 
 					&.question--inactive {
 						transform: translateX(0%);
+						visibility: hidden; 
+						transition-delay: 0s, $transition-time; 
 					}
 				}
 			}

--- a/spec/javascripts/tests/MoneyNavigatorQuestions_spec.js
+++ b/spec/javascripts/tests/MoneyNavigatorQuestions_spec.js
@@ -34,6 +34,7 @@ describe('MoneyNavigatorQuestions', function() {
       var setUpMultipleQuestionsStub = sinon.stub(this.obj, '_setUpMultipleQuestions'); 
       var setUpGroupedQuestionsStub = sinon.stub(this.obj, '_setUpGroupedQuestions'); 
       var setUpJourneyLogicStub = sinon.stub(this.obj, '_setUpJourneyLogic'); 
+      var setUpKeyboardEventsStub = sinon.stub(this.obj, '_setUpKeyboardEvents'); 
       
       this.obj.init();
 
@@ -41,11 +42,13 @@ describe('MoneyNavigatorQuestions', function() {
       expect(setUpMultipleQuestionsStub.calledOnce).to.be.true; 
       expect(setUpGroupedQuestionsStub.calledOnce).to.be.true; 
       expect(setUpJourneyLogicStub.calledOnce).to.be.true; 
+      expect(setUpKeyboardEventsStub.calledOnce).to.be.true; 
 
       updateDOMStub.restore(); 
       setUpMultipleQuestionsStub.restore(); 
       setUpGroupedQuestionsStub.restore(); 
       setUpJourneyLogicStub.restore(); 
+      setUpKeyboardEventsStub.restore(); 
     });
   });
 
@@ -72,24 +75,55 @@ describe('MoneyNavigatorQuestions', function() {
       expect($(collections[1]).find('[data-response]').length).to.equal(2); 
     }); 
 
-    it ('Checks that the correct method is called when the `response-control` options are activated', function() {
+    it('Checks that the correct method is called when the `response-control` options are activated', function() {
       var responseControls = $(this.groupedQuestion).find('[data-response-controls]'); 
       var inputs = $(responseControls).find('input'); 
 
       $(inputs[0]).trigger('change'); 
-      expect(this.updateGroupedQuestionsDisplaySpy.calledOnce).to.be.true; 
+      expect(this.updateGroupedQuestionsDisplaySpy.callCount === 1).to.be.true; 
       expect(this.updateGroupedQuestionsDisplaySpy.calledWith(inputs[0])).to.be.true; 
+      expect(this.updateGroupedQuestionsDisplaySpy.calledWith(inputs[1])).to.be.false; 
 
       $(inputs[1]).trigger('change'); 
-      expect(this.updateGroupedQuestionsDisplaySpy.calledTwice).to.be.true; 
+      expect(this.updateGroupedQuestionsDisplaySpy.callCount === 2).to.be.true; 
       expect(this.updateGroupedQuestionsDisplaySpy.calledWith(inputs[1])).to.be.true; 
+      expect(this.updateGroupedQuestionsDisplaySpy.calledWith(inputs[2])).to.be.false; 
 
       $(inputs[2]).trigger('change'); 
-      expect(this.updateGroupedQuestionsDisplaySpy.calledThrice).to.be.true; 
+      expect(this.updateGroupedQuestionsDisplaySpy.callCount === 3).to.be.true; 
       expect(this.updateGroupedQuestionsDisplaySpy.calledWith(inputs[2])).to.be.true; 
     }); 
 
-    it ('Checks that the correct method is called when the `reset` option is activated', function() {
+    it('Checks that the correct method is called when the `response-collection` options are activated', function() {
+      var responseCollections = $(this.groupedQuestion).find('[data-response-collection]'); 
+      var inputs = $(responseCollections).find('input'); 
+
+      $(inputs[0]).trigger('change'); 
+      expect(this.updateGroupedQuestionsDisplaySpy.callCount === 1).to.be.true; 
+      expect(this.updateGroupedQuestionsDisplaySpy.calledWith(inputs[0])).to.be.true; 
+      expect(this.updateGroupedQuestionsDisplaySpy.calledWith(inputs[1])).to.be.false; 
+
+      $(inputs[1]).trigger('change'); 
+      expect(this.updateGroupedQuestionsDisplaySpy.callCount === 2).to.be.true; 
+      expect(this.updateGroupedQuestionsDisplaySpy.calledWith(inputs[1])).to.be.true; 
+      expect(this.updateGroupedQuestionsDisplaySpy.calledWith(inputs[2])).to.be.false; 
+
+      $(inputs[2]).trigger('change'); 
+      expect(this.updateGroupedQuestionsDisplaySpy.callCount === 3).to.be.true; 
+      expect(this.updateGroupedQuestionsDisplaySpy.calledWith(inputs[2])).to.be.true; 
+      expect(this.updateGroupedQuestionsDisplaySpy.calledWith(inputs[3])).to.be.false;
+
+      $(inputs[3]).trigger('change'); 
+      expect(this.updateGroupedQuestionsDisplaySpy.callCount === 4).to.be.true; 
+      expect(this.updateGroupedQuestionsDisplaySpy.calledWith(inputs[3])).to.be.true; 
+      expect(this.updateGroupedQuestionsDisplaySpy.calledWith(inputs[4])).to.be.false;
+
+      $(inputs[4]).trigger('change'); 
+      expect(this.updateGroupedQuestionsDisplaySpy.callCount === 5).to.be.true; 
+      expect(this.updateGroupedQuestionsDisplaySpy.calledWith(inputs[4])).to.be.true; 
+    }); 
+
+    it('Checks that the correct method is called when the `reset` option is activated', function() {
       var responseCollections = $(this.groupedQuestion).find('[data-response-collection]'); 
       var resetBtn = $(responseCollections[0]).find('[data-reset]'); 
       var backBtn = $(this.groupedQuestion).find('[data-back]'); 
@@ -110,7 +144,7 @@ describe('MoneyNavigatorQuestions', function() {
 
       // Controls
       var $controls = $(this.groupedQuestion).find('.response__controls'); 
-      this.control_default = $controls.children('[data-response]').find('input')[0];
+      this.control_default = $controls.find('[data-response]').find('input')[0];
       this.control_1 = $controls.find('#control_1')[0]; 
       this.control_2 = $controls.find('#control_2')[0]; 
 
@@ -123,8 +157,8 @@ describe('MoneyNavigatorQuestions', function() {
       this.collection_2_2 = $(collections[1]).find('input')[1]; 
 
       // Resets
-      this.collection_1_reset = $(collections[0]).find('[data-reset]'); 
-      this.collection_2_reset = $(collections[1]).find('[data-reset]'); 
+      this.collection_1_reset = $(collections[0]).find('[data-reset]')[0]; 
+      this.collection_2_reset = $(collections[1]).find('[data-reset]')[0]; 
 
       // Continue
       this.continue = $(this.groupedQuestion).find('[data-continue]'); 
@@ -203,6 +237,298 @@ describe('MoneyNavigatorQuestions', function() {
       this.collection_2_2.checked = true; 
       this.obj._updateGroupedQuestionsDisplay(this.collection_2_2); 
       expect(this.continue[0].disabled).to.be.false; 
+    }); 
+
+    it('Sets focus correctly for keyboard a11y when called', function() {
+      // Selecting control group input moves focus to relevant collection and sets input tabinex to 0
+      $(this.control_default).focus(); 
+
+      this.obj._updateGroupedQuestionsDisplay(this.control_1);
+      expect(this.collection_1_1 === document.activeElement).to.be.true; 
+      expect($(this.collection_1_1).attr('tabindex') == 0).to.be.true; 
+      expect(this.collection_2_1 === document.activeElement).to.be.false; 
+      expect($(this.collection_2_1).attr('tabindex') == -1).to.be.true; 
+
+      this.obj._updateGroupedQuestionsDisplay(this.control_2);
+      expect(this.collection_1_1 === document.activeElement).to.be.false; 
+      expect($(this.collection_1_1).attr('tabindex') == -1).to.be.true; 
+      expect(this.collection_2_1 === document.activeElement).to.be.true; 
+      expect($(this.collection_2_1).attr('tabindex') == 0).to.be.true; 
+
+      // Selecting reset on a collection returns focus to selected control input and sets input tabinex to -1
+      $(this.control_2).attr('checked', true); 
+      this.obj._updateGroupedQuestionsDisplay(this.collection_2_reset);
+      expect(this.control_2 === document.activeElement).to.be.true; 
+      expect($(this.collection_1_1).attr('tabindex') == -1).to.be.true;
+      expect($(this.collection_2_1).attr('tabindex') == -1).to.be.true; 
+
+      $(this.control_2).attr('checked', false); 
+      $(this.control_1).attr('checked', true); 
+      this.obj._updateGroupedQuestionsDisplay(this.collection_1_reset);
+      expect(this.control_1 === document.activeElement).to.be.true; 
+      expect($(this.collection_1_1).attr('tabindex') == -1).to.be.true;
+      expect($(this.collection_2_1).attr('tabindex') == -1).to.be.true; 
+    }); 
+
+    it('Updates tabindex value on Reset button when collection is active/inactive', function() {
+      $(this.control_default).focus(); 
+
+      this.obj._updateGroupedQuestionsDisplay(this.control_1);
+      expect($(this.collection_1_reset).attr('tabindex') == 0).to.be.true; 
+      expect($(this.collection_2_reset).attr('tabindex') == -1).to.be.true; 
+
+      this.obj._updateGroupedQuestionsDisplay(this.control_2);
+      expect($(this.collection_1_reset).attr('tabindex') == -1).to.be.true; 
+      expect($(this.collection_2_reset).attr('tabindex') == 0).to.be.true; 
+
+      this.obj._updateGroupedQuestionsDisplay(this.collection_2_reset);
+      expect($(this.collection_1_reset).attr('tabindex') == -1).to.be.true; 
+      expect($(this.collection_2_reset).attr('tabindex') == -1).to.be.true; 
+    }); 
+  });
+
+  describe('setUpKeyboardEvents method', function() {
+    var event = $.Event('keydown'),
+        keyCode; 
+
+    beforeEach(function() {
+      this.groupedQuestion = this.questions[3]; 
+
+      this.obj._updateDOM(); 
+      this.obj._setUpGroupedQuestions(); 
+      this.obj._setUpKeyboardEvents(); 
+
+      // Controls
+      var $controls = $(this.groupedQuestion).find('.response__controls'); 
+      this.control_default = $controls.find('[data-response]').find('input')[0];
+      this.control_1 = $controls.find('#control_1')[0]; 
+      this.control_2 = $controls.find('#control_2')[0];
+
+      // Collections
+      var collections = $(this.groupedQuestion).find('.question__response--collection'); 
+      this.collection_1_1 = $(collections[0]).find('input')[0]; 
+      this.collection_1_2 = $(collections[0]).find('input')[1]; 
+      this.collection_1_3 = $(collections[0]).find('input')[2]; 
+      this.collection_2_1 = $(collections[1]).find('input')[0]; 
+      this.collection_2_2 = $(collections[1]).find('input')[1]; 
+
+      // Continue
+      this.continue = $(this.groupedQuestion).find('[data-continue]')[0]; 
+    }); 
+
+    it('Moves focus correctly within the control group with down arrow key', function() {
+      keyCode = 40; 
+      event.keyCode = keyCode; 
+
+      $(this.control_default).focus();
+
+      $(this.control_default).trigger(event); 
+      expect(this.control_default === document.activeElement).to.be.false; 
+      expect(this.control_1 === document.activeElement).to.be.true; 
+
+      $(this.control_1).trigger(event); 
+      expect(this.control_1 === document.activeElement).to.be.false; 
+      expect(this.control_2 === document.activeElement).to.be.true; 
+
+      $(this.control_2).trigger(event); 
+      expect(this.control_2 === document.activeElement).to.be.false; 
+      expect(this.control_default === document.activeElement).to.be.true; 
+    }); 
+
+    it('Moves focus correctly within the control group with right arrow key', function() {
+      keyCode = 39; 
+      event.keyCode = keyCode; 
+
+      $(this.control_default).focus();
+
+      $(this.control_default).trigger(event); 
+      expect(this.control_default === document.activeElement).to.be.false; 
+      expect(this.control_1 === document.activeElement).to.be.true; 
+
+      $(this.control_1).trigger(event); 
+      expect(this.control_1 === document.activeElement).to.be.false; 
+      expect(this.control_2 === document.activeElement).to.be.true; 
+
+      $(this.control_2).trigger(event); 
+      expect(this.control_2 === document.activeElement).to.be.false; 
+      expect(this.control_default === document.activeElement).to.be.true; 
+    }); 
+
+    it('Moves focus correctly within the control group with up arrow key', function() {
+      keyCode = 38; 
+      event.keyCode = keyCode; 
+
+      $(this.control_2).focus();
+
+      $(this.control_2).trigger(event); 
+      expect(this.control_2 === document.activeElement).to.be.false; 
+      expect(this.control_1 === document.activeElement).to.be.true; 
+
+      $(this.control_1).trigger(event); 
+      expect(this.control_1 === document.activeElement).to.be.false; 
+      expect(this.control_default === document.activeElement).to.be.true; 
+
+      $(this.control_default).trigger(event); 
+      expect(this.control_default === document.activeElement).to.be.false; 
+      expect(this.control_2 === document.activeElement).to.be.true; 
+    }); 
+
+    it('Moves focus correctly within the control group with left arrow key', function() {
+      keyCode = 37; 
+      event.keyCode = keyCode; 
+
+      $(this.control_2).focus();
+
+      $(this.control_2).trigger(event); 
+      expect(this.control_2 === document.activeElement).to.be.false; 
+      expect(this.control_1 === document.activeElement).to.be.true; 
+
+      $(this.control_1).trigger(event); 
+      expect(this.control_1 === document.activeElement).to.be.false; 
+      expect(this.control_default === document.activeElement).to.be.true; 
+
+      $(this.control_default).trigger(event); 
+      expect(this.control_default === document.activeElement).to.be.false; 
+      expect(this.control_2 === document.activeElement).to.be.true; 
+    }); 
+
+    it('Moves focus correctly within the control group with tab key', function() {
+      keyCode = 9; 
+      event.keyCode = keyCode; 
+
+      $(this.control_default).focus();
+
+      $(this.control_default).trigger(event); 
+      expect(this.control_default === document.activeElement).to.be.false; 
+      expect(this.continue === document.activeElement).to.be.true; 
+
+      $(this.control_1).focus();
+
+      $(this.control_1).trigger(event); 
+      expect(this.control_1 === document.activeElement).to.be.false; 
+      expect(this.continue === document.activeElement).to.be.true; 
+
+      $(this.control_2).focus();
+
+      $(this.control_2).trigger(event); 
+      expect(this.control_2 === document.activeElement).to.be.false; 
+      expect(this.continue === document.activeElement).to.be.true; 
+    }); 
+
+    it('Moves focus within each collection with down arrow key', function() {
+      keyCode = 40; 
+      event.keyCode = keyCode; 
+
+      $(this.collection_1_1).focus();
+
+      $(this.collection_1_1).trigger(event); 
+      expect(this.collection_1_1 === document.activeElement).to.be.false; 
+      expect(this.collection_1_2 === document.activeElement).to.be.true; 
+
+      $(this.collection_1_2).trigger(event); 
+      expect(this.collection_1_2 === document.activeElement).to.be.false; 
+      expect(this.collection_1_3 === document.activeElement).to.be.true; 
+
+      $(this.collection_1_3).trigger(event); 
+      expect(this.collection_1_3 === document.activeElement).to.be.false; 
+      expect(this.collection_1_1 === document.activeElement).to.be.true; 
+
+      $(this.collection_2_1).focus();
+
+      $(this.collection_2_1).trigger(event); 
+      expect(this.collection_2_1 === document.activeElement).to.be.false; 
+      expect(this.collection_2_2 === document.activeElement).to.be.true; 
+
+      $(this.collection_2_2).trigger(event); 
+      expect(this.collection_2_2 === document.activeElement).to.be.false; 
+      expect(this.collection_2_1 === document.activeElement).to.be.true; 
+    }); 
+
+    it('Moves focus within each collection with right arrow key', function() {
+      keyCode = 39; 
+      event.keyCode = keyCode; 
+
+      $(this.collection_1_1).focus();
+
+      $(this.collection_1_1).trigger(event); 
+      expect(this.collection_1_1 === document.activeElement).to.be.false; 
+      expect(this.collection_1_2 === document.activeElement).to.be.true; 
+
+      $(this.collection_1_2).trigger(event); 
+      expect(this.collection_1_2 === document.activeElement).to.be.false; 
+      expect(this.collection_1_3 === document.activeElement).to.be.true; 
+
+      $(this.collection_1_3).trigger(event); 
+      expect(this.collection_1_3 === document.activeElement).to.be.false; 
+      expect(this.collection_1_1 === document.activeElement).to.be.true; 
+
+      $(this.collection_2_1).focus();
+
+      $(this.collection_2_1).trigger(event); 
+      expect(this.collection_2_1 === document.activeElement).to.be.false; 
+      expect(this.collection_2_2 === document.activeElement).to.be.true; 
+
+      $(this.collection_2_2).trigger(event); 
+      expect(this.collection_2_2 === document.activeElement).to.be.false; 
+      expect(this.collection_2_1 === document.activeElement).to.be.true; 
+    }); 
+
+    it('Moves focus within each collection with up arrow key', function() {
+      keyCode = 38; 
+      event.keyCode = keyCode; 
+
+      $(this.collection_1_3).focus();
+
+      $(this.collection_1_3).trigger(event); 
+      expect(this.collection_1_3 === document.activeElement).to.be.false; 
+      expect(this.collection_1_2 === document.activeElement).to.be.true; 
+
+      $(this.collection_1_2).trigger(event); 
+      expect(this.collection_1_2 === document.activeElement).to.be.false; 
+      expect(this.collection_1_1 === document.activeElement).to.be.true; 
+
+      $(this.collection_1_1).trigger(event); 
+      expect(this.collection_1_1 === document.activeElement).to.be.false; 
+      expect(this.collection_1_3 === document.activeElement).to.be.true; 
+
+      $(this.collection_2_2).focus();
+
+      $(this.collection_2_2).trigger(event); 
+      expect(this.collection_2_2 === document.activeElement).to.be.false; 
+      expect(this.collection_2_1 === document.activeElement).to.be.true; 
+
+      $(this.collection_2_1).trigger(event); 
+      expect(this.collection_2_1 === document.activeElement).to.be.false; 
+      expect(this.collection_2_2 === document.activeElement).to.be.true; 
+    }); 
+
+    it('Moves focus within each collection with left arrow key', function() {
+      keyCode = 37; 
+      event.keyCode = keyCode; 
+
+      $(this.collection_1_3).focus();
+
+      $(this.collection_1_3).trigger(event); 
+      expect(this.collection_1_3 === document.activeElement).to.be.false; 
+      expect(this.collection_1_2 === document.activeElement).to.be.true; 
+
+      $(this.collection_1_2).trigger(event); 
+      expect(this.collection_1_2 === document.activeElement).to.be.false; 
+      expect(this.collection_1_1 === document.activeElement).to.be.true; 
+
+      $(this.collection_1_1).trigger(event); 
+      expect(this.collection_1_1 === document.activeElement).to.be.false; 
+      expect(this.collection_1_3 === document.activeElement).to.be.true; 
+
+      $(this.collection_2_2).focus();
+
+      $(this.collection_2_2).trigger(event); 
+      expect(this.collection_2_2 === document.activeElement).to.be.false; 
+      expect(this.collection_2_1 === document.activeElement).to.be.true; 
+
+      $(this.collection_2_1).trigger(event); 
+      expect(this.collection_2_1 === document.activeElement).to.be.false; 
+      expect(this.collection_2_2 === document.activeElement).to.be.true; 
     }); 
   }); 
 


### PR DESCRIPTION
[TP-11822](https://maps.tpondemand.com/entity/11822-money-navigator-focus-styles-on-grouped)

This work improves the experience for a keyboard user on the enhanced UI for the 2 stage question ("Are you behind with rent or mortgage payments?"). This currently does not properly display focus styles and breaks badly on the second stage (see screenshots below). 

| Initial stage | Second stage |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/6080548/106499067-04aae200-64b8-11eb-9571-eb4a5f6615fb.png) | ![image](https://user-images.githubusercontent.com/6080548/106499139-1ee4c000-64b8-11eb-9c40-811868830dd2.png) |

The solution is to refactor the markup a little to aid the natural keyboard navigation and to dynamically set focus styles on keyboard events to allow navigation by a combination of the tab and arrow keys based on this WebAim [Keyboard Accessibility](https://webaim.org/techniques/keyboard/) specification.
