### PR TITLE
Tp 11967 money navigator keyboard nav

### DIFF
--- a/app/assets/javascripts/components/MoneyNavigatorQuestions.js
+++ b/app/assets/javascripts/components/MoneyNavigatorQuestions.js
@@ -539,6 +539,20 @@ define(['jquery', 'DoughBaseComponent'], function ($, DoughBaseComponent) {
           .find('.question__content')
           .append(div);
       }
+
+      // Move default input if it is also hidden
+      var $responses = $(question).find('[data-response]');
+
+      $responses.each(function() {
+        if (this.dataset.responseHidden === 'true') {
+          var $thisResponse = $(this),
+              $nextResponse = $(this).next();
+
+          $thisResponse.find('input')[0].checked = false;
+          $nextResponse.find('input')[0].checked = true;
+          $thisResponse.css('display', 'none');
+        }
+      });
     }
 
     var buttons = this.$el.find('button');

--- a/app/assets/stylesheets/layout/page_specific/_money_navigator_questionnaire.scss
+++ b/app/assets/stylesheets/layout/page_specific/_money_navigator_questionnaire.scss
@@ -140,10 +140,6 @@
 			display: block; 
 		}
 
-		.question__response--hidden {
-			display: none;
-		}
-
 		&[data-question-multiple] {
 
 			.button--no, 

--- a/app/views/money_navigator_tool/questionnaire.html.erb
+++ b/app/views/money_navigator_tool/questionnaire.html.erb
@@ -62,15 +62,16 @@
 
                       <% question[:responses].each do |response| %>
                         <div 
-                          <% if response[:hidden] %>
-                            class="question__response question__response--hidden"
-                          <% else %>
-                            class="question__response" 
-                          <% end %>
+                          class="question__response" 
                       
-                        data-response
+                          data-response
+
                           <% if response[:group] %>
                             data-response-group="<%= response[:group] %>"
+                          <% end %>
+
+                          <% if response[:hidden] %>
+                            data-response-hidden="true"
                           <% end %>
                         >
                           <% if question[:type] == 'radio' %>

--- a/spec/javascripts/fixtures/MoneyNavigatorQuestions.html
+++ b/spec/javascripts/fixtures/MoneyNavigatorQuestions.html
@@ -136,7 +136,21 @@
 			<li data-question class="l-money_navigator__question" tabindex="0">
 				<p class="question__counter">Question 5 of 6</p>
 
-				<div class="question__content" data-question-id="q4"></div>
+				<div class="question__content" data-question-id="q4">
+					<fieldset>
+						<legend>A question</legend>
+
+						<div class="content__inner">
+							<div data-response data-response-hidden="true">
+								<input type="radio" name="questions[q4]" value="a1" id="q4_a1" checked>
+							</div>
+
+							<div data-response>
+								<input type="radio" name="questions[q4]" value="a2" id="q4_a2">
+							</div>
+						</div>
+					</fieldset>
+				</div>
 			</li>
 
 			<li data-question class="l-money_navigator__question" tabindex="0">

--- a/spec/javascripts/tests/MoneyNavigatorQuestions_spec.js
+++ b/spec/javascripts/tests/MoneyNavigatorQuestions_spec.js
@@ -723,6 +723,12 @@ describe('MoneyNavigatorQuestions', function() {
 
       expect($(multipleQuestion).find('[data-continue]')[0].disabled).to.be.true; 
       expect($(multipleQuestion).find('[data-back]')[0].disabled).to.be.false; 
+
+      // Ensure default (checked) responses are not hidden
+      expect($(this.questions[4]).find('input')[0].checked).to.be.false; 
+      expect($(this.questions[4]).find('input')[1].checked).to.be.true; 
+      expect(window.getComputedStyle($(this.questions[4]).find('[data-response]')[0]).display === 'none').to.be.true; 
+      expect(window.getComputedStyle($(this.questions[4]).find('[data-response]')[1]).display === 'none').to.be.false; 
     }); 
   }); 
 


### PR DESCRIPTION
[TP-11967](https://maps.tpondemand.com/entity/11967-money-navigator-a11y-question-3-options)

In a previous change to the UI on the question "If you are self-employed, do you know what your monthly income is now?" (accessed only by users who have previously indicated that their employment status is self-employed) we removed the option "I am not self employed" from the display so avoid slightly contradictory messaging. Because that option remains checked by default this causes a scenario whereby a keyboard user is unable to navigate to the inputs that remain displayed.

The agreed solution is to set a checked state on the next sibling of any input that is both checked by default and hidden. 

| The input that is checked by default is hidden | This means the remaining inputs cannot be accessed by keyboard users | The default input remains hidden and a checked state is added to its next sibling |
|---|---|---|
| ![image](https://user-images.githubusercontent.com/6080548/106921357-d91c3780-6703-11eb-89a7-2dabad32ff5d.png) | ![image](https://user-images.githubusercontent.com/6080548/106921410-e507f980-6703-11eb-8230-ba023fa67b57.png) | ![image](https://user-images.githubusercontent.com/6080548/106921819-4def7180-6704-11eb-80ee-2a8d29e34f47.png) |
