### PR TITLE
[DEV APPROVED] 11966 clear english standard broken link

### DIFF
--- a/app/views/pace/_footer.html.erb
+++ b/app/views/pace/_footer.html.erb
@@ -36,7 +36,7 @@
       <div class="footer-primary__clear-english">
         <a
           class="footer-primary__clear-english-link"
-          href="https://www.clearest.co.uk/silver-standard"
+          href="https://www.clearest.co.uk/gold-standard"
           target="_blank"
         >
           <span class="icon icon--clear-english"></span>

--- a/app/views/shared/_footer_primary.html.erb
+++ b/app/views/shared/_footer_primary.html.erb
@@ -96,7 +96,7 @@
         <div class="footer-primary__clear-english">
           <a
             class="footer-primary__clear-english-link"
-            href="https://www.clearest.co.uk/silver-standard"
+            href="https://www.clearest.co.uk/gold-standard"
             target="_blank"
           >
             <span class="icon icon--clear-english"></span>


### PR DESCRIPTION
[TP11966](https://maps.tpondemand.com/entity/11966-broken-link-on-clear-english-standard)

This change updates a link in the footer that is currently leading to a 404 page. The link is for the Clear English Standard accreditation and appears in two locations within the MAS site: 
- the [MAS footer](https://www.moneyadviceservice.org.uk/en)
- the [PACE footer](https://www.moneyadviceservice.org.uk/en/moneyadvisernetwork)
and is set on the organisation's logo (see below). 

![image](https://user-images.githubusercontent.com/6080548/107031506-3074e300-67aa-11eb-99d5-eee829852fde.png)
