### PR TITLE
TP-11992, Updates text for Investment Pathway link

### DIFF
--- a/config/locales/retirements.cy.yml
+++ b/config/locales/retirements.cy.yml
@@ -59,7 +59,7 @@ cy:
               url: "/cy/articles/yr-opsiynau-ar-gyfer-defnyddioch-cronfa-bensiwn"
             - text: Offeryn deall a chymharu blwydd-daliadau
               url: /cy/tools/annuities
-            - text: Offeryn deall a chymharu tynnu incwm i lawr
+            - text: Deall a chymharu eich opsiynau llwybr buddsoddi
               url: /cy/tools/drawdown-investment-pathways
       pensionwise:
         text: Trefnwch eich sesiwn ganllaw Pension Wise rhad ac am ddim
@@ -170,7 +170,7 @@ cy:
               url: /cy/articles/yr-opsiynau-ar-gyfer-defnyddioch-cronfa-bensiwn
             - text: Oedi cymryd eich cronfa bensiwn
               url: /cy/articles/oedi-cymryd-eich-cronfa-bensiwn
-            - text: Offeryn deall a chymharu tynnu incwm i lawr
+            - text: Deall a chymharu eich opsiynau llwybr buddsoddi
               url: /cy/tools/drawdown-investment-pathways
             - text: Sut i ddefnyddio’ch cronfa bensiwn i brynu blwydd-dal oes
               url: /cy/articles/sut-i-ddefnyddioch-cronfa-bensiwn-i-brynu-blwydd-dal-oes

--- a/config/locales/retirements.en.yml
+++ b/config/locales/retirements.en.yml
@@ -59,7 +59,7 @@ en:
               url: "/en/articles/options-for-using-your-pension-pot"
             - text: "Understand and compare annuities tool"
               url: /en/tools/annuities
-            - text: Understand and compare income drawdown tool
+            - text: Understand and compare your investment pathway options
               url: /en/tools/drawdown-investment-pathways
       pensionwise:
         text: Book your free Pension Wise guidance session
@@ -170,7 +170,7 @@ en:
               url: /en/articles/options-for-using-your-pension-pot
             - text: Delaying taking your pension pot
               url: /en/articles/delaying-taking-your-pension-pot
-            - text: Understand and compare income drawdown tool
+            - text: Understand and compare your investment pathway options
               url: /en/tools/drawdown-investment-pathways
             - text: Using your pension pot to buy a lifetime annuity
               url: /en/articles/using-your-pension-pot-to-buy-a-lifetime-annuity


### PR DESCRIPTION
[TP11992](https://maps.tpondemand.com/entity/11992-update-idd-link-text-on-pensions)

This work updates the text for the link to the new Investment Pathways Options tool from "Understand and compare income drawdown tool / Offeryn deall a chymharu tynnu incwm i lawr" to "Understand and compare your investment pathway options / Deall a chymharu eich opsiynau llwybr buddsoddi". 

This appears twice on the page, under the following headings, in both English and Welsh languages: 
- Your options / Eich opsiynau
- Retirement income choices / Dewisiadau incwm ymddeol

| | Production | This PR |
| --- | --- | --- |
| English | ![image](https://user-images.githubusercontent.com/6080548/107380098-7a7d0200-6ae5-11eb-88fb-66cb5b1a396f.png) | ![image](https://user-images.githubusercontent.com/6080548/107380153-88328780-6ae5-11eb-9985-05b8fc49cba6.png) |
| Welsh | ![image](https://user-images.githubusercontent.com/6080548/107380373-b87a2600-6ae5-11eb-9727-4c7541247e41.png) | ![image](https://user-images.githubusercontent.com/6080548/107380408-c2038e00-6ae5-11eb-9ae9-504fae16b826.png) |
| English | ![image](https://user-images.githubusercontent.com/6080548/107380964-4229f380-6ae6-11eb-9722-d8173fbb86aa.png) | ![image](https://user-images.githubusercontent.com/6080548/107380994-49e99800-6ae6-11eb-99f9-72fd000fdbae.png) |
| Welsh | ![image](https://user-images.githubusercontent.com/6080548/107380712-068f2980-6ae6-11eb-98fd-5bb8e70eaf16.png) | ![image](https://user-images.githubusercontent.com/6080548/107380777-1575dc00-6ae6-11eb-8b3a-aebf3ac7e08e.png) |