### PR TITLE
[TP-12012] Updates assets pipeline for mas_cookieController

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -30,6 +30,7 @@ Rails.application.configure do
                                    modules/i18n.js
                                    modules/log.js
                                    modules/mas_collapsable.js
+                                   modules/mas_cookieController.js
                                    modules/mas_pubsub.js
                                    modules/mas_scrollTracking.js
                                    components/*.js


### PR DESCRIPTION
This is a small update to [PR2312](https://github.com/moneyadviceservice/frontend/pull/2312) to fix a problem with the assets pipeline configuration 