### PR TITLE
TP12006 - TP12005 - TP12007 - Rebrand Registration Screens

### DIFF
--- a/app/assets/javascripts/components/MoneyNavigatorQuestions.js
+++ b/app/assets/javascripts/components/MoneyNavigatorQuestions.js
@@ -56,6 +56,7 @@ define(['jquery', 'DoughBaseComponent'], function ($, DoughBaseComponent) {
     this._updateDOM(this.dataLayer); 
     this._setUpMultipleQuestions(); 
     this._setUpGroupedQuestions(); 
+    this._setUpKeyboardEvents(); 
     this._setUpJourneyLogic(); 
     this._initialisedSuccess(initialised);
   };
@@ -69,14 +70,21 @@ define(['jquery', 'DoughBaseComponent'], function ($, DoughBaseComponent) {
     var _this = this; 
 
     this.$groupedQuestions.each(function() {
-      var $groupedResponses = $(this).find('[data-response-group], [data-response]'),
-          groups = {},
+      var el = $(this).find('[data-question-id]')[0],
+          computedStyle = window.getComputedStyle(el),
+          width = parseFloat(computedStyle.getPropertyValue('width')),
+          padding = parseFloat(computedStyle.getPropertyValue('padding-left')) * 2,
+          border = parseFloat(computedStyle.getPropertyValue('border-left-width')) * 2,
+          gutter = padding / (width - border) / 4 * 100,
+          $groupedResponses = $(this).find('[data-response-group], [data-response]'),
+          $fieldset = $(this).find('fieldset').detach(), 
+          name = $fieldset.find('input')[0].name,
           titles = $(this).data('question-grouped-group-titles'),
-          i = 0,
-          groupNum = 0,
-          questionResponses = document.createElement('div'); 
+          questionGroups = document.createElement('div'),
+          groups = {},
+          numGroups;
 
-      // Collect all responses into arrays and remove from DOM
+      // Collect all grouped responses into arrays and remove from DOM
       $groupedResponses.each(function() {
         if ($(this).data('response-group')) {
           var groupNum = $(this).data('response-group');  
@@ -93,26 +101,81 @@ define(['jquery', 'DoughBaseComponent'], function ($, DoughBaseComponent) {
         $(this).remove(); 
       }); 
 
-      groupNum = Object.keys(groups).length; 
+      numGroups = Object.keys(groups).length; 
 
-      $(questionResponses)
-        .addClass('response__controls')
-        .attr('data-response-controls', true)
-        .css('width', (1 / groupNum * 100) + '%'); 
+      $(questionGroups)
+        .addClass('question__groups')
+        .css('width', (100 + gutter) * 2 + '%');
+
+      $(this).find('.question__content').append(questionGroups);
 
       for(var num in groups) {
         if (num === 'default') {
-          $(questionResponses).prepend(groups[num].outerHTML); 
+          var div = document.createElement('div'); 
+
+          $fieldset
+            .find('.content__inner')
+              .prepend(groups[num]); 
+
+          $(div)
+            .addClass('response__controls')
+            .attr('data-response-controls', true)
+            .css('width', (100 - gutter) / 2 + '%')
+            .append($fieldset);
+
+          $(questionGroups).prepend(div);
         } else {
-          var response = document.createElement('div'), 
-              collection = document.createElement('div'), 
+          // Add collections and resets to the DOM
+          var collection = document.createElement('fieldset'), 
+              contentInner = document.createElement('div'), 
               reset = document.createElement('button'), 
+              legend = document.createElement('legend'), 
+              paraText = document.createTextNode(titles[num - 1]),
+              div = document.createElement('div'); 
+
+          legend.appendChild(paraText); 
+
+          $(legend).addClass('question__heading');
+
+          $(reset)
+            .addClass('button button--reset')
+            .attr({
+              'data-reset': true,
+              'tabindex': -1
+            })
+            .text(_this.i18nStrings.controls.reset); 
+
+          $(reset).on('click', function(e) {
+            e.preventDefault(); 
+            _this._updateGroupedQuestionsDisplay(e.target); 
+          }); 
+
+          $(contentInner)
+            .addClass('content__inner')
+            .append(groups[num])
+            .append(reset); 
+
+          $(collection)
+            .prepend(legend)
+            .append(contentInner); 
+  
+          $(div)
+            .addClass('question__response--collection question--inactive')
+            .attr('data-response-collection', num)
+            .css({
+              'marginLeft': (-100 + gutter) / 2 * (num - 1) + '%', 
+              'width': (100 - gutter) / 2 + '%'
+            })
+            .append(collection); 
+
+          $(questionGroups).append(div); 
+
+          // Add new inputs to the control group
+          var response = document.createElement('div'), 
               input = document.createElement('input'), 
               label = document.createElement('label'), 
               span = document.createElement('span'), 
-              para = document.createElement('p'), 
-              labelText = document.createTextNode(titles[i]), 
-              paraText = document.createTextNode(titles[i])
+              labelText = document.createTextNode(titles[num - 1]);
 
           span.appendChild(labelText); 
 
@@ -125,53 +188,23 @@ define(['jquery', 'DoughBaseComponent'], function ($, DoughBaseComponent) {
           input.id = 'control_' + num;
           input.value = ''; 
 
-          para.className = 'collection__title'; 
-          para.appendChild(paraText); 
-
-          // Add responses to the DOM
           response.setAttribute('data-response-group-control', num); 
           response.className = 'question__response question__response--control';
           response.appendChild(input); 
           response.appendChild(label); 
 
-          $(this).find('.content__inner').append(response); 
-
-          $(questionResponses).append(response); 
-
-          // Add collections and resets to the DOM
-          $(collection)
-            .addClass('question__response--collection question--inactive')
-            .attr('data-response-collection', num);
-
-          $(groups[num]).each(function() {
-            $(collection).append(groups[num]); 
-          }); 
-
-          $(reset)
-            .addClass('button button--reset')
-            .attr('data-reset', true)
-            .text(_this.i18nStrings.controls.reset); 
-
-          $(this).find('.content__inner').append(collection);
-          $(collection).prepend(para); 
-          $(collection).append(reset); 
-          $(collection).css({
-            'marginLeft': (1 / groupNum * -100 * i) + '%', 
-            'width': (1 / groupNum * 100) + '%'
-          }); 
-
-          $(reset).on('click', function(e) {
-            e.preventDefault(); 
-            _this._updateGroupedQuestionsDisplay(e.target); 
-          }); 
+          $fieldset.find('.content__inner').append(response); 
         }
+      }; 
 
-        i++; 
-      }
+      $(this).find('.question__content').prepend(questionGroups); 
 
-      $(this).find('.content__inner')
-        .prepend(questionResponses)
-        .css('width', (i * 100) + '%')
+      $(this).find('[data-response-controls]')
+        .on('change', function(e) {
+          _this._updateGroupedQuestionsDisplay(e.target); 
+        }); 
+
+      $(this).find('[data-response-collection]')
         .on('change', function(e) {
           _this._updateGroupedQuestionsDisplay(e.target); 
         }); 
@@ -179,21 +212,106 @@ define(['jquery', 'DoughBaseComponent'], function ($, DoughBaseComponent) {
   }; 
 
   /**
+   * A method that controls user navigation on the grouped question by keyboard
+   */
+  MoneyNavigatorQuestions.prototype._setUpKeyboardEvents = function() {
+    this.$groupedQuestions.each(function() {
+      // Set focus on keyboard events
+      $(this).keydown(function(e) {
+        var response = $(e.target).parent('[data-response], [data-response-group-control]')[0], 
+            $responses = $(response).parent('.content__inner'), 
+            nextInput, 
+            prevInput; 
+
+        switch (e.keyCode) {
+          // right or down arrows
+          case 39:
+          case 40:
+            // moves to next input unless current input is last
+            e.preventDefault(); 
+
+            if ($responses.find('[data-response], [data-response-group-control]').last()[0] === response) {
+              nextInput = $responses.find('[data-response], [data-response-group-control]').first().find('input')[0]; 
+            } else {
+              nextInput = $(response).next().find('input')[0];
+            }
+
+            nextInput.focus()
+            // nextInput.checked = true; 
+
+            break;
+
+          // left or up arrows
+          case 37:
+          case 38:
+            // moves to previous input unless current input is first
+            e.preventDefault(); 
+
+            if ($responses.find('[data-response], [data-response-group-control]').first()[0] === response) {
+              prevInput = $responses.find('[data-response], [data-response-group-control]').last().find('input')[0]; 
+            } else {
+              prevInput = $(response).prev().find('input')[0];
+            }
+
+            prevInput.focus()
+            // prevInput.checked = true; 
+
+            break;
+
+          // tab key
+          case 9:
+            // moves to `Continue` in control group
+            if ($(response).length > 0 && response.dataset.responseGroup === undefined) {
+              e.preventDefault(); 
+
+              $(this).find('[data-continue]')[0].focus(); 
+            }
+
+            break;
+        }
+      }); 
+    }); 
+  }; 
+
+  /**
    * A method that is called when the controls created by _setUpGroupedQuestions are activated
    */
   MoneyNavigatorQuestions.prototype._updateGroupedQuestionsDisplay = function(el) {
-    var $container = $(el).parents('.question__content').find('.content__inner');
+    var $container = $(el).parents('.question__content').find('.question__groups');
 
     if ($(el).data('reset') || $(el).data('back')) {
       $container.children('[data-response-controls]').removeClass(this.inactiveClass); 
       $container.children('[data-response-group-control]').removeClass(this.inactiveClass); 
       $container.children('[data-response-collection]').addClass(this.inactiveClass); 
+
+      if ($(el).data('reset')) {
+        $container.find('[data-reset]').attr('tabindex', -1); 
+        $container.children('[data-response-controls]').find('input[checked=checked]').focus(); 
+        $container.children('[data-response-collection]').find('input').attr('tabindex', -1); 
+      }
     } else if ($(el).parents('[data-response-controls]').length > 0) {
       var id = el.id.split('_')[1];
       var $responseControls = $container.children('[data-response-controls]'); 
 
       if (el.id.indexOf('control_') > -1) {
         $responseControls.addClass(this.inactiveClass)
+
+        $container.children('[data-response-collection]')
+          .addClass(this.inactiveClass)
+          .find('[data-reset]').attr('tabindex', -1); 
+
+        $container.children('[data-response-collection]')
+          .find('input').attr('tabindex', -1); 
+
+        $container.children('[data-response-collection="' + id + '"]')
+          .removeClass(this.inactiveClass)
+          .find('input')[0].focus(); 
+
+        $container.children('[data-response-collection="' + id + '"]')
+          .find('[data-reset]').attr('tabindex', 0);
+
+        $container.children('[data-response-collection="' + id + '"]')
+          .find('input').attr('tabindex', 0);
       }
 
       $responseControls.find('input').each(function() {
@@ -211,9 +329,6 @@ define(['jquery', 'DoughBaseComponent'], function ($, DoughBaseComponent) {
           }
         }
       }); 
-
-      $container.children('[data-response-collection]').addClass(this.inactiveClass); 
-      $container.children('[data-response-collection="' + id + '"]').removeClass(this.inactiveClass); 
     } else {
       el.checked = true; 
     }
@@ -225,7 +340,7 @@ define(['jquery', 'DoughBaseComponent'], function ($, DoughBaseComponent) {
 
     $inputs.each(function() {
       if (this.checked == true) {
-        if (this.name == '') {
+        if (this.value == '') {
           disabled = true; 
         } else {
           disabled = false; 
@@ -424,6 +539,20 @@ define(['jquery', 'DoughBaseComponent'], function ($, DoughBaseComponent) {
           .find('.question__content')
           .append(div);
       }
+
+      // Move default input if it is also hidden
+      var $responses = $(question).find('[data-response]');
+
+      $responses.each(function() {
+        if (this.dataset.responseHidden === 'true') {
+          var $thisResponse = $(this),
+              $nextResponse = $(this).next();
+
+          $thisResponse.find('input')[0].checked = false;
+          $nextResponse.find('input')[0].checked = true;
+          $thisResponse.css('display', 'none');
+        }
+      });
     }
 
     var buttons = this.$el.find('button');
@@ -511,6 +640,12 @@ define(['jquery', 'DoughBaseComponent'], function ($, DoughBaseComponent) {
       .addClass(this.activeClass)
       .find('.question__counter')
       .text(progress + '% ' + this.i18nStrings.messages.completed);
+
+    if (dir === 'prev') {
+      if (activeIndex >= 0) {
+        questions[activeIndex].focus(); 
+      }
+    }
 
     if (activeIndex == 0) {
       this.$banner.removeClass(

--- a/app/assets/javascripts/modules/mas_cookieController.js
+++ b/app/assets/javascripts/modules/mas_cookieController.js
@@ -1,0 +1,142 @@
+var defaults = {
+  theme: 'light', 
+  optionalCookies: [],
+  text: {}, 
+  branding: {}
+};
+
+var CookieController = function (opts) {
+  this.config = Object.assign(defaults, opts);
+
+  // TODO: replace locale and textStrings with the existing i18n module
+  // This appears to be not functioning as it should right now
+  // It should be fixed though it may be that it has never functioned as it should
+  // Alternaively the locale object provided by this module could be used instead
+  // this.locale = MAS.bootstrap.i18nLocale;
+  this.locale = document.querySelector('html').lang; 
+  this.textStrings = {
+    'en': {
+      'optionalCookies': {
+        'analytics': {
+        'label': 'Analytics Cookies',
+        'description': 'These cookies allow us to collect anonymised data about how our website is being used, helping us to make improvements to the services we provide to you.'
+        }
+      },
+      'text': {
+        'title': 'Cookies on Money Advice Service',
+        'intro':
+          '<span>Cookies are files saved on your phone, tablet or computer when you visit a website.</span>' +
+          '<span>We use cookies to store information about how you use the Money Advice Service website, such as the pages you visit.</span>' +
+          '<span>For more information visit our <a href="/en/corporate/cookie_notice_en">Cookie Policy</a> and <a href="/en/corporate/privacy">Privacy Policy</a>.</span>',
+        'acceptSettings': 'Accept all cookies',
+        'closeLabel': 'Save preferences', 
+        'on': 'On', 
+        'off': 'Off', 
+        'necessaryTitle': 'Necessary Cookies', 
+        'necessaryDescription': 'Some cookies are essential for the site to function correctly, such as those remembering your progress through our tools, or using our webchat service.', 
+        'notifyTitle': 'Tell us whether you accept cookies', 
+        'notifyDescription': 
+          '<span>We use <a href="/en/corporate/cookie_notice_en">cookies to collect information</a> about how you use this website.</span>' +
+          '<span>We use this information to make the site work as well as possible and improve our services.</span>', 
+        'accept': 'Accept all cookies', 
+        'settings': 'Set preferences'
+      },
+      'branding': {
+        'removeAbout': true, 
+        'fontFamily': "'museo_sans', 'Helvetica Neue', Helvetica, Arial, sans-serif", 
+        'fontSize': '1rem'
+      }
+    },
+    'cy': {
+      'optionalCookies': {
+        'analytics': {
+        'label': 'Cwcis dadansoddi',
+        'description': 'Mae&#8217;r cwcis hyn yn caniatáu i ni gasglu data dienw am sut mae ein gwefan yn cael ei defnyddio, gan ein helpu i wneud gwelliannau i&#8217;r gwasanaethau rydym yn eu darparu i chi.'
+        }
+      },
+      'text': {
+        'title': 'Cwcis ar Gwasanaeth Cynghori Ariannol',
+        'intro':
+          '<span>Mae cwcis yn ffeiliau a arbedir ar eich ffôn, llechen neu gyfrifiadur pan ymwelwch â gwefan.</span>' +
+          '<span>Rydym yn defnyddio cwcis i storio gwybodaeth am sut rydych yn defnyddio Gwasanaeth Cynghori Ariannol, fel y tudalennau rydych chi&#8217;n ymweld â nhw.</span>' +
+          '<span>I gael mwy o wybodaeth, ymwelwch â&#8217;n <a href="/cy/corporate/sut-yr-ydym-yn-defnyddio-cwcis">Polisi Cwcis</a> a&#8217;n <a href="/cy/corporate/polisipreifatrwydd">Polisi Preifatrwydd</a>.</span>',
+        'acceptSettings': 'Derbyn pob cwci',
+        'closeLabel': 'Arbed dewisiadau', 
+        'on': 'Ymlaen', 
+        'off': 'I ffwrdd', 
+        'necessaryTitle': 'Cwcis sydd eu hangen',
+        'necessaryDescription': 'Mae rhai cwcis yn hanfodol er mwyn i&#8217;r wefan weithredu&#8217; gywir, fel y rhai sy&#8217;n cofio&#8217;ch datbliygad trwy ein teclynnau, neu ddefnyddio ein gwasanaeth gwe-sgwrs.', 
+        'notifyTitle': 'Dywedwch wrthym os ydych yn derbyn cwcis', 
+        'notifyDescription': 
+          '<span>Rydym yn defnyddio <a href="/cy/corporate/sut-yr-ydym-yn-defnyddio-cwcis">cwcis i gasglu gwybodaeth</a> am sut rydych yn defnyddio Gwasanaeth Cynghori Ariannol.</span>' +
+          '<span>Rydym yn defnyddio&#8217;r wybodaeth hon i wneud i&#8217;r wefan weithio cystal â phosibl a gwella ein gwasanaethau.</span>', 
+        'closeLabel': 'Arbed dewisiadau', 
+        'accept': 'Derbyn pob cwci', 
+        'settings': 'Gosod dewisiadau'
+      },
+      'branding': {
+        'removeAbout': true, 
+        'fontFamily': "'museo_sans', 'Helvetica Neue', Helvetica, Arial, sans-serif", 
+        'fontSize': '1rem'
+      }
+    }
+  }
+
+  this.addOptionalCookies();
+  this.addText();
+  this.addBranding();
+};
+
+CookieController.prototype.addBranding = function() {
+  var textStrings = this.textStrings[this.locale];
+  var brandingObj = this.config.branding;
+  var brandingContent = textStrings.branding;
+
+  for (var content in brandingContent) {
+    brandingObj[content] = brandingContent[content];
+  }
+}
+
+CookieController.prototype.addText = function() {
+  var textStrings = this.textStrings[this.locale];
+  var textObj = this.config.text;
+  var textContent = textStrings.text;
+
+  for (var content in textContent) {
+    textObj[content] = textContent[content];
+  }
+}
+
+CookieController.prototype.addOptionalCookies = function() {
+  var textStrings = this.textStrings[this.locale]; 
+  var analytics = {
+    name: 'analytics',
+    recommendedState: true,
+    lawfulBasis: 'legitimate interest',
+    cookies: ['_ga', '_gid', '_gat', '__utma', '__utmt', '__utmb', '__utmc', '__utmz', '__utmv'],
+    label: textStrings.optionalCookies.analytics.label,
+    description: textStrings.optionalCookies.analytics.description,
+
+    onAccept: function() {
+      window.dataLayer = window.dataLayer || [];
+
+      window.dataLayer.push({
+        'event': 'civicConsentResponse'
+      });
+    },
+
+    onRevoke: function() {
+      window.dataLayer = window.dataLayer || [];
+
+      window.dataLayer.push({
+        'event': 'civicConsentResponse'
+      });
+    }
+  };
+
+  this.config.optionalCookies.push(analytics);
+}
+
+CookieController.prototype.loadModule = function() {
+  CookieControl.load(this.config);
+}

--- a/app/assets/javascripts/translations/cy.js
+++ b/app/assets/javascripts/translations/cy.js
@@ -2,6 +2,32 @@ define([], function() {
   'use strict';
 
   return {
-    'hide': 'hide'
+    'hide': 'hide', 
+		'cookieController': {
+			'optionalCookies': {
+				'analytics': {
+				'label': 'Cwcis dadansoddi',
+				'description': 'Mae&#8217;r cwcis hyn yn caniatáu i ni gasglu data dienw am sut mae ein gwefan yn cael ei defnyddio, gan ein helpu i wneud gwelliannau i&#8217;r gwasanaethau rydym yn eu darparu i chi.'
+				}
+			},
+			'text': {
+				'title': 'Cwcis ar Gwasanaeth Cynghori Ariannol',
+				'intro':
+					'<span>Mae cwcis yn ffeiliau a arbedir ar eich ffôn, llechen neu gyfrifiadur pan ymwelwch â gwefan.</span>' +
+					'<span>Rydym yn defnyddio cwcis i storio gwybodaeth am sut rydych yn defnyddio Gwasanaeth Cynghori Ariannol, fel y tudalennau rydych chi&#8217;n ymweld â nhw.</span>' +
+					'<span>I gael mwy o wybodaeth, ymwelwch â&#8217;n <a href="/cy/corporate/sut-yr-ydym-yn-defnyddio-cwcis">Polisi Cwcis</a> a&#8217;n <a href="/cy/corporate/polisipreifatrwydd">Polisi Preifatrwydd</a>.</span>',
+				'acceptSettings': 'Derbyn pob cwci',
+				'closeLabel': 'Arbed dewisiadau', 
+				'on': 'Ymlaen', 
+				'off': 'I ffwrdd', 
+				'necessaryTitle': 'Cwcis sydd eu hangen',
+				'necessaryDescription': 'Mae rhai cwcis yn hanfodol er mwyn i&#8217;r wefan weithredu&#8217; gywir, fel y rhai sy&#8217;n cofio&#8217;ch datbliygad trwy ein teclynnau, neu ddefnyddio ein gwasanaeth gwe-sgwrs.'
+			}, 
+			'branding': {
+				'removeAbout': true, 
+				'fontFamily': "'museo_sans', 'Helvetica Neue', Helvetica, Arial, sans-serif", 
+				'fontSize': '1rem'
+			}
+		}
   };
 });

--- a/app/assets/javascripts/translations/en.js
+++ b/app/assets/javascripts/translations/en.js
@@ -2,6 +2,32 @@ define([], function() {
   'use strict';
 
   return {
-    'hide': 'hide'
+    'hide': 'hide',
+		'cookieController': {
+			'optionalCookies': {
+				'analytics': {
+				'label': 'Analytics Cookies',
+				'description': 'These cookies allow us to collect anonymised data about how our website is being used, helping us to make improvements to the services we provide to you.'
+				}
+			},
+			'text': {
+				'title': 'Cookies on Money Advice Service',
+				'intro':
+					'<span>Cookies are files saved on your phone, tablet or computer when you visit a website.</span>' +
+					'<span>We use cookies to store information about how you use the Money Advice Service website, such as the pages you visit.</span>' +
+					'<span>For more information visit our <a href="/en/corporate/cookie_notice_en">Cookie Policy</a> and <a href="/en/corporate/privacy">Privacy Policy</a>.</span>',
+				'acceptSettings': 'Accept all cookies',
+				'closeLabel': 'Save preferences', 
+				'on': 'On', 
+				'off': 'Off', 
+				'necessaryTitle': 'Necessary Cookies', 
+				'necessaryDescription': 'Some cookies are essential for the site to function correctly, such as those remembering your progress through our tools, or using our webchat service.'
+			}, 
+			'branding': {
+				'removeAbout': true, 
+				'fontFamily': "'museo_sans', 'Helvetica Neue', Helvetica, Arial, sans-serif", 
+				'fontSize': '1rem'
+			}
+		}
   };
 });

--- a/app/assets/stylesheets/components/common/_cookie_controller.scss
+++ b/app/assets/stylesheets/components/common/_cookie_controller.scss
@@ -1,0 +1,87 @@
+#ccc {
+	#ccc-content {
+		&.ccc-content--light {
+			color: $color-black;
+			fill: $color-black;
+			background: $color-white;
+		  padding: $baseline-unit $baseline-unit*2;
+
+			span {
+				color: $color-grey-dark;
+				fill: $color-grey-dark;
+			}
+
+			p, 
+			.ccc-intro, 
+			#ccc-necessary-description {
+				margin: 0 0 $baseline-unit * 2;
+
+				& > span {
+					display: block; 
+					margin: 0 0 $baseline-unit * 2;
+				}
+			}
+
+			h3, 
+			#ccc-title {
+				font-size: 1.5rem;
+				margin: 0 0 $baseline-unit * 2;
+				padding: 0;
+			}
+
+			hr {
+				background: $color-black; 
+			}
+
+		  .ccc-panel {
+		  	top: $baseline-unit * 2;
+		  	left: $baseline-unit * 2;
+		  	right: $baseline-unit * 2;
+
+				#ccc-necessary-title, 
+				.optional-cookie-header {
+					font-size: 1.2rem; 	  		
+					margin: 0 0 $baseline-unit * 2;
+				}
+
+				#ccc-recommended-settings, 
+				#ccc-dismiss-button {
+					@extend .mas-button; 
+					@extend .button--primary;
+
+					span {
+						color: inherit;
+						background: inherit;
+						font-weight: inherit;
+					}
+				}
+
+				.checkbox-toggle--light {
+					.checkbox-toggle-label {
+						.checkbox-toggle-off, 
+						.checkbox-toggle-on {
+							color: $color-white;
+							opacity: 100%; 
+						}
+					}
+				}
+		  }
+		}
+	}
+
+	#ccc-icon {
+		&.ccc-icon--light {
+			fill: $color-grey-medium;
+		}
+	}
+
+	#ccc-notify {
+		.ccc-notify-text {
+			p {
+				& > span {
+					display: block; 
+				}
+			}
+		}
+	}
+}

--- a/app/assets/stylesheets/components/money-navigator-reskin/all.scss
+++ b/app/assets/stylesheets/components/money-navigator-reskin/all.scss
@@ -1,12 +1,10 @@
-
 // -- Apply these styles only within the following divs --
-    .l-money_navigator,
-    .l-money_navigator-results,
-    .l-money_navigator-landing {
-
-        @import 'moneyhelper_variables';
-        // @import 'moneyhelper_styling_common';
-        @import 'moneyhelper_styling_common_compromise';
-        @import 'moneyhelper_styling_money_navigator';
-
-    }
+.l-money_navigator,
+.l-money_navigator-results,
+.l-money_navigator-landing,
+.l-registration {
+  @import "moneyhelper_variables";
+  // @import 'moneyhelper_styling_common';
+  @import "moneyhelper_styling_common_compromise";
+  @import "moneyhelper_styling_money_navigator";
+}

--- a/app/assets/stylesheets/components/money-navigator-reskin/moneyhelper_styling_common_compromise.scss
+++ b/app/assets/stylesheets/components/money-navigator-reskin/moneyhelper_styling_common_compromise.scss
@@ -1,191 +1,207 @@
 // -- Headers ----------------------------------------------------------------------
-    h1,h2,h3,h4,h5,h6{
-        font-family: 'Roobert-Bold', sans-serif !important;
-        font-style: normal;
-        font-weight: bold;
-    }
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: "Roobert-Bold", sans-serif !important;
+  font-style: normal;
+  font-weight: bold;
+}
 
-    h1{ color: $blue_primary; }
-    h2{ color: $blue_primary; }
-    h3{ color: $text_secondary; }
-    // -- *Note H4 restricted to footer links - out of scope for reskin tools --
-    h5{ color: $text_secondary; }
-    h6{ color: $text_secondary; }
+h1 {
+  color: $blue_primary;
+}
+h2 {
+  color: $blue_primary;
+}
+h3 {
+  color: $text_secondary;
+}
+// -- *Note H4 restricted to footer links - out of scope for reskin tools --
+h5 {
+  color: $text_secondary;
+}
+h6 {
+  color: $text_secondary;
+}
 // ---------------------------------------------------------------------------------
-
 
 // -- Paragraphs -------------------------------------------------------------------
-    p{
-        font-family: 'Roobert-Regular', sans-serif !important;
-        font-style: normal;
-        font-weight: normal;
-        font-size: 16px;
-        line-height: 23px;
-        color: $text_secondary;
-        &.callout{
-            background-color: $light_grey;
-            border-radius: $border_radius;
-            padding: 10px;
-        }
-    }
+p {
+  font-family: "Roobert-Regular", sans-serif !important;
+  font-style: normal;
+  font-weight: normal;
+  font-size: 16px;
+  line-height: 23px;
+  color: $text_secondary;
+  &.callout {
+    background-color: $light_grey;
+    border-radius: $border_radius;
+    padding: 10px;
+  }
+}
 // ---------------------------------------------------------------------------------
-
 
 // -- Buttons ----------------------------------------------------------------------
-    .button{
-        box-sizing: border-box;
-        /*font-family: 'Roobert-Regular', sans-serif;*/
-        font-family: 'Roobert-SemiBold', sans-serif !important;
-        &:active, &:focus, &:hover{
-            outline: none!important;
-        }
-        &.button--primary{
-            background: $magenta_primary;
-            color: $white;
-            font-size: 16px;
-            border: 3px solid $magenta_primary;
-            border-radius: $border_radius;
-            box-shadow: 0px 3px 0px rgba(0, 11, 59, 0.25);
-            padding: 8px 16px;  
-            &:hover{
-                background: $magenta_dark;
-                border: 3px solid $magenta_dark;
-            }
-            &:focus{
-                background-color: $yellow_secondary;
-                border: 3px solid $support_focus;
-                color: $text_secondary;
-            }
-            &:active{
-                background: $magenta_darker;
-                color: $white;
-                border: 3px solid $yellow_secondary;
-                box-shadow: 0px 3px 0px $white, inset 0px 5px 2px rgba(0, 11, 59, 0.25);
-            }
-            &:disabled{
-                background: $light_grey;
-                color: $input_border;
-                box-shadow: none;
-                border: 1px solid $support_hr;
-            }
-        }
+.button {
+  box-sizing: border-box;
+  /*font-family: 'Roobert-Regular', sans-serif;*/
+  font-family: "Roobert-SemiBold", sans-serif !important;
+  &:active,
+  &:focus,
+  &:hover {
+    outline: none !important;
+  }
+  &.button--primary {
+    background: $magenta_primary;
+    color: $white;
+    font-size: 16px;
+    border: 3px solid $magenta_primary;
+    border-radius: $border_radius;
+    box-shadow: 0px 3px 0px rgba(0, 11, 59, 0.25);
+    padding: 8px 16px;
+    &:hover {
+      background: $magenta_dark;
+      border: 3px solid $magenta_dark;
     }
-    a.button {
-        text-decoration: none;    
+    &:focus {
+      background-color: $yellow_secondary;
+      border: 3px solid $support_focus;
+      color: $text_secondary;
     }
-   
-    .js{
-        .popup-tip__button{
-            background-color: #F3F1F3;
-            color: #C82A87;
-            border: 3px solid #C82A87;
-            &:focus{
-                background-color: #F0F05A;
-                border-color: #8200D1;
-                color: #8200D1;
-                outline: none;
-            }
-            @media print{
-                display: none;
-            }
-            span{
-                display: block;
-                margin-top: -2px;
-            }
-        }
-        .popup-tip__container{
-            border: 1px solid #aeb0bd;
-        }
+    &:active {
+      background: $magenta_darker;
+      color: $white;
+      border: 3px solid $yellow_secondary;
+      box-shadow: 0px 3px 0px $white, inset 0px 5px 2px rgba(0, 11, 59, 0.25);
     }
+    &:disabled {
+      background: $light_grey;
+      color: $input_border;
+      box-shadow: none;
+      border: 1px solid $support_hr;
+    }
+  }
+}
+a.button {
+  text-decoration: none;
+}
+
+.js {
+  .popup-tip__button {
+    background-color: #f3f1f3;
+    color: #c82a87;
+    border: 3px solid #c82a87;
+    &:focus {
+      background-color: #f0f05a;
+      border-color: #8200d1;
+      color: #8200d1;
+      outline: none;
+    }
+    @media print {
+      display: none;
+    }
+    span {
+      display: block;
+      margin-top: -2px;
+    }
+  }
+  .popup-tip__container {
+    border: 1px solid #aeb0bd;
+  }
+}
 // ---------------------------------------------------------------------------------
 
-
 // -- Form elements ----------------------------------------------------------------
-    label{
-        font-family: 'Roobert-Bold', sans-serif;
-        font-size: 16px;
-        font-weight: bold;
-        color: $text_secondary;
+label {
+  font-family: "Roobert-Bold", sans-serif;
+  font-size: 16px;
+  font-weight: bold;
+  color: $text_secondary;
+}
+input[type="text"],
+input[type="number"],
+input[type="email"],
+input[type="password"] {
+  width: 285px;
+  height: 40px;
+  font-family: "Roobert-Regular", sans-serif;
+  box-sizing: border-box;
+  background-color: $white;
+  border: 1px solid $input_border;
+  border-radius: $border_radius;
+  padding: 9px 12px 9px 12px;
+  &:focus {
+    border: 2px solid $support_focus;
+    border-radius: 0;
+    background-color: $yellow_secondary;
+    outline: 0;
+  }
+}
+input[type="radio"] {
+  width: auto !important;
+  height: auto !important;
+  margin-right: 10px;
+  &:focus,
+  &:hover {
+    outline-color: $support_focus;
+  }
+  + label {
+    cursor: pointer;
+    vertical-align: text-bottom;
+    margin-right: 30px;
+  }
+}
+input[type="checkbox"] {
+  &:focus,
+  &:hover {
+    outline-color: $support_focus;
+  }
+}
+select {
+  width: 285px;
+  background-color: $white;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  padding: 7px 12px 7px 12px;
+  height: auto;
+  border-radius: $border_radius;
+  &:focus {
+    border: 2px solid $support_focus;
+    border-radius: 0;
+    background-color: $yellow_secondary;
+    outline: 0;
+  }
+}
+fieldset {
+  legend {
+    font-family: "Roobert-Bold", sans-serif;
+    font-size: 22px;
+    font-weight: 700;
+  }
+}
+.form__row.is-errored {
+  border-color: $red_error;
+  border-width: 4px;
+  label {
+    color: $text_secondary;
+  }
+  input[type="text"],
+  input[type="number"] {
+    border: 2px solid $red_error;
+  }
+  select {
+    border: 2px solid $red_error;
+    color: $text_secondary;
+  }
+  .js-inline-error {
+    p {
+      color: $red_error;
+      font-size: 16px;
+      line-height: 23px;
     }
-    input[type=text],
-    input[type=number]{
-        width: 285px;
-        height: 40px;
-        font-family: 'Roobert-Regular', sans-serif;
-        box-sizing: border-box;
-        background-color: $white;
-        border: 1px solid $input_border;
-        border-radius: $border_radius;
-        padding: 9px 12px 9px 12px;
-        &:focus{
-            border: 2px solid $support_focus;
-            border-radius: 0;
-            background-color: $yellow_secondary;
-            outline: 0;
-        }
-    }
-    input[type=radio]{
-        width: auto!important;
-        height: auto!important;
-        margin-right: 10px;
-        &:focus,
-        &:hover{
-            outline-color: $support_focus;
-        }
-        + label{
-            cursor: pointer;
-            vertical-align: text-bottom;
-            margin-right: 30px;
-        }
-    }
-    input[type=checkbox]{
-        &:focus,
-        &:hover{
-            outline-color: $support_focus;
-        }
-    }
-    select{
-        width: 285px;
-        background-color: $white;
-        -webkit-appearance: none;
-        -moz-appearance: none;
-        padding: 7px 12px 7px 12px;
-        height: auto;
-        border-radius: $border_radius;
-        &:focus{
-            border: 2px solid $support_focus;
-            border-radius: 0;
-            background-color: $yellow_secondary;
-            outline: 0;
-        }
-    }
-    fieldset{
-        legend{
-            font-family: 'Roobert-Bold', sans-serif;
-            font-size: 22px;
-            font-weight: 700;
-        }
-    }
-    .form__row.is-errored{
-        border-color: $red_error;
-        border-width: 4px;
-        label{
-            color: $text_secondary;
-        }
-        input[type=text],
-        input[type=number]{
-            border: 2px solid $red_error;
-        }
-        select{
-            border: 2px solid $red_error;
-            color: $text_secondary;
-        }
-        .js-inline-error{
-            p{
-                color: $red_error;
-                font-size: 16px;
-                line-height: 23px;
-            }
-        }
-    }
+  }
+}
 // ---------------------------------------------------------------------------------

--- a/app/assets/stylesheets/layout/page_specific/_money_navigator_landing.scss
+++ b/app/assets/stylesheets/layout/page_specific/_money_navigator_landing.scss
@@ -11,6 +11,12 @@
 		}
 	}
 
+	.callout {
+		a {
+			text-decoration: underline;
+		}
+	}
+
 	.landing__actions {
 		@extend %clearfix;
 

--- a/app/assets/stylesheets/layout/page_specific/_money_navigator_questionnaire.scss
+++ b/app/assets/stylesheets/layout/page_specific/_money_navigator_questionnaire.scss
@@ -84,11 +84,7 @@
 	.question__content {
 		border: solid 1px $color-grey-pale;	
 		padding: $baseline-unit * 4 $default-gutter * 2 $baseline-unit * 2; 
-
-		@include respond-to($mq-l) {
-			padding-left: $default-gutter;
-			padding-right: $default-gutter;
-		}
+		overflow: hidden;
 	}
 
 	.question__heading {
@@ -112,7 +108,6 @@
 	.question__explainer {
 		font-size: 0.875rem; 
 		font-weight: 700; 
-		margin-top:55px;
 	}
 
 	.question__response {
@@ -144,102 +139,47 @@
 			display: block; 
 		}
 
-		.question__response--hidden {
-			display: none;
-		}
-
 		&[data-question-multiple] {
-
 			.button--no, 
 			.button--yes {
 				display: inline-block;
 				margin: 0 $default-gutter * 2 0 0;
-				margin-right: 52px; 
-			
+
+				@include respond-to($mq-s) {
+					margin-right: $default-gutter * 1.5; 
+				}
+
 				@include respond-to($mq-m) {
-					margin-right: 52px;
-				}	
-
-				[type="checkbox"]:not(:checked) + label,
-				[type="checkbox"]:checked + label {
-					padding-left: 1.95em;
-				}
-
-				/* checkbox aspect */
-				[type="checkbox"]:not(:checked) + label:before,
-				[type="checkbox"]:checked + label:before {
-					content: '';
-					position: absolute;
-					left: 0; top: 0;
-					@extend .button; 
-					padding: 0; 
-					text-align: left;
-					min-width:70px;
-					min-height:50px;	
-				}
-
-				[type="checkbox"]:not(:checked) + label:after,
-				[type="checkbox"]:checked + label:after {
-					content:'';
-					position: absolute;
-					top: 0em; left: 0;
-					padding: 12px 22px;
-					border-radius: 4px;
-					min-width:70px;
-					min-height:50px;
-				}
-
-				[type="checkbox"]:checked + label:after {
-					background: $color-green-secondary; 
-					border-bottom: 3px solid #929494;
+					margin-right: $default-gutter; 
 				}
 
 				.response__text {
-					cursor:pointer;
-				}
-
-				span {
-					display:block;
-					position: absolute;
-					top: 50%;
-					left:70%;
-					font-weight: 300;
-					z-index:999;	
-
-					@include respond-to($mq-m) {
-						left:60%;
-					}
-				}
-
-				/* accessibility */
-				[type="checkbox"]:checked:focus + label:before,
-				[type="checkbox"]:not(:checked):focus + label:before {
-					outline: solid 0.1875rem $color-input-focus-border-color;
-				}
-
-				.question__response {
-					.response__control {
-						outline:none;
-					}
+					@extend .button; 
+					padding: 0; 
+					text-align: left; 
 				}
 
 				.response__control {
+					@extend .visually-hidden; 
+
 					&:checked + .response__text {
 						color: $color-white; 
 						background: $color-green-secondary; 
 					}
+
+					&:focus + label {
+						@include focus-outline;
+					}
 				}
-			}			
+			}
 		}
 
 		&[data-question-grouped] {
 			$transition-time: 0.5s;
 
-			fieldset {
-				overflow: hidden;
-			}
+			.question__groups {
+				@extend %clearfix;
 
-			.content__inner {
 				box-sizing: content-box;
 				padding: 0 $default-gutter * 2;
 				margin: 0 $default-gutter * -2;
@@ -247,7 +187,9 @@
 				.response__controls,
 				.question__response--collection {
 					float: left;
-					transition: transform $transition-time;
+					visibility: visible; 
+					transition-property: transform, visibility;
+					transition-duration: $transition-time, 0s;
 				}
 
 				.response__controls {
@@ -255,15 +197,19 @@
 					margin-right: $default-gutter;
 	
 					&.question--inactive {
-						transform: translateX(-100% - ($default-gutter * 3));
+						transform: translateX(-100% - ($default-gutter * 2));
+						visibility: hidden; 
+						transition-delay: 0s, $transition-time; 
 					}
 				}
 
 				.question__response--collection {
-					transform: translateX(-100% - ($default-gutter * 3));
+					transform: translateX(-100% - ($default-gutter * 2));
 
 					&.question--inactive {
 						transform: translateX(0%);
+						visibility: hidden; 
+						transition-delay: 0s, $transition-time; 
 					}
 				}
 			}
@@ -326,6 +272,19 @@
 			&[type="checkbox"]:checked + .response__text {
 				color: $color-white; 
 				background: $color-green-secondary; 
+			}
+
+			&:checked + .response__text {
+				color: $color-white; 
+				background: $color-green-secondary; 
+			}
+
+			&:focus + label {
+				@include focus-outline;
+			}
+
+			.button--yes {
+				margin-right: 0;
 			}
 		}
 	}

--- a/app/assets/stylesheets/layout/page_specific/_money_navigator_results.scss
+++ b/app/assets/stylesheets/layout/page_specific/_money_navigator_results.scss
@@ -59,6 +59,10 @@ $transition-time: 0.4s;
 				margin-bottom: $baseline-unit * 2; 
 				padding: $baseline-unit 0; 
 
+				a {
+					text-decoration: underline;
+				}
+
 				& > p {
 					@include column(12); 
 
@@ -99,10 +103,6 @@ $transition-time: 0.4s;
 
 					p {
 						font-size: 1rem; 
-
-						a {
-							text-decoration: underline;
-						}
 					}
 
 					@include respond-to($mq-m) {

--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -246,5 +246,42 @@
 
 <%= yield :javascripts %>
 
+<% unless syndicated_tool_request? %>
+  <%= javascript_include_tag 'https://cc.cdn.civiccomputing.com/9/cookieControl-9.x.min.js' %>
+  <%= javascript_include_tag 'modules/mas_cookieController.js' %>
+
+  <script>
+    // Cookie controller
+    // Implementation of the Cookie Control module from Civic
+    // Documentation: https://www.civicuk.com/cookie-control/documentation
+    // require(['require_config'], function() {
+    //   require(['cookieController'], function(cookieController) {
+        document.addEventListener('DOMContentLoaded', function() {
+          
+        // })
+        // $(document).ready(function() {
+          var cookieControllerModule = new CookieController({
+            apiKey: '3c057064262937c6354d3ec3809ea099e4a83c23', 
+            product: 'PRO_MULTISITE',
+            mode: 'GDPR',
+            consentCookieExpiry: '360',
+            initialState: 'notify',
+            rejectButton: false,
+            layout: 'slideout',
+            position: 'left',
+            setInnerHTML: true,
+            notifyDismissButton: false,
+            closeOnGlobalChange: true,
+            closeStyle: 'button',
+            subDomains: true
+          });
+
+          cookieControllerModule.loadModule(); 
+        });
+    //   }); 
+    // });
+  </script>
+<% end %>
+
 </body>
 </html>

--- a/app/views/money_navigator_tool/questionnaire.html.erb
+++ b/app/views/money_navigator_tool/questionnaire.html.erb
@@ -28,6 +28,7 @@
           <% t("money_navigator_tool.questions").each_with_index do |question, index| %>
             <li
               class="l-money_navigator__question"
+              tabindex="0"
               data-question
               <% if question[:type] == 'checkbox' %>
                 data-question-multiple
@@ -61,15 +62,16 @@
 
                       <% question[:responses].each do |response| %>
                         <div 
-                          <% if response[:hidden] %>
-                            class="question__response question__response--hidden"
-                          <% else %>
-                            class="question__response" 
-                          <% end %>
+                          class="question__response" 
                       
-                        data-response
+                          data-response
+
                           <% if response[:group] %>
                             data-response-group="<%= response[:group] %>"
+                          <% end %>
+
+                          <% if response[:hidden] %>
+                            data-response-hidden="true"
                           <% end %>
                         >
                           <% if question[:type] == 'radio' %>

--- a/app/views/shared/_cookie_message.erb
+++ b/app/views/shared/_cookie_message.erb
@@ -1,0 +1,14 @@
+<% if cookies_not_accepted? %>
+  <% unless hide_elements_irrelevant_for_third_parties? %>
+    <div class="cookie-message">
+      <div class="l-constrained">
+        <%= form_tag main_app.cookie_notice_acceptance_path, remote: true, authenticity_token: true, class: 'js-cookie-message' do %>
+          <p class="cookie-message__content">
+            <button class="cookie-message__close-button button"><%= t('footer.cookie_message.close_button') %></button>
+            <%= t('footer.cookie_message.body_html', url: t('footer.cookie_guide_link')) %>
+          </p>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/shared/_footer_secondary.html.erb
+++ b/app/views/shared/_footer_secondary.html.erb
@@ -85,17 +85,7 @@
   </div>
 </div>
 
-<% if cookies_not_accepted? %>
-<% unless hide_elements_irrelevant_for_third_parties? %>
-<div class="cookie-message">
-  <div class="l-constrained">
-    <%= form_tag main_app.cookie_notice_acceptance_path, remote: true, authenticity_token: true, class: 'js-cookie-message' do %>
-      <p class="cookie-message__content">
-        <button class="cookie-message__close-button button"><%= t('footer.cookie_message.close_button') %></button>
-        <%= t('footer.cookie_message.body_html', url: t('footer.cookie_guide_link')) %>
-      </p>
-    <% end %>
-  </div>
-</div>
-<% end %>
-<% end %>
+<%# TODO: Remove the cookie message properly
+This is currently a quick and dirty removal but we will need to do this 
+by removing all the tests/scripts/styles associated with the component %>
+<%# render 'shared/cookie_message' %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -31,6 +31,7 @@ Rails.application.configure do
                                    modules/i18n.js
                                    modules/log.js
                                    modules/mas_collapsable.js
+                                   modules/mas_cookieController.js
                                    modules/mas_pubsub.js
                                    modules/mas_scrollTracking.js
                                    components/*.js

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -458,7 +458,7 @@ cy:
         - "Help gyda’ch nodau ariannol"
         - "Mynediad hwylus at amryw o offer a chyfrifianellau"
       terms_html: "Drwy glicio ar y botwm, rydych yn cytuno gyda ein <a href=\"%{url}\">Hamodau a Thelerau</a>."
-      privacy_html: "MoneyHelper <a href=\"%{url}\">Polisi Preifatrwydd</a>."
+      privacy_html: "HelpiwrArian <a href=\"%{url}\">Polisi Preifatrwydd</a>."
       label: Arwyddwch fi
       field_help_texts:
         first_name: Rhowch eich enw cyntaf

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -308,9 +308,9 @@ cy:
     accessibility: Hygyrchedd
     accessibility_link: /cy/corporate/hygyrchedd
     privacy_statement: Rhybudd preifatrwydd
-    privacy_statement_link: /cy/corporate/polisipreifatrwydd
+    privacy_statement_link: https://www.moneyhelper.org.uk/cy/privacy
     terms_and_conditions: Amodau a Thelerau
-    terms_and_conditions_link: /cy/corporate/telerau-ac-amodau
+    terms_and_conditions_link: https://www.moneyhelper.org.uk/cy/terms-and-conditions
     fincap: Galluogrwydd Ariannol
     fincap_link: http://www.fincap.org.uk/cymru
     jobs: Swyddi
@@ -458,7 +458,7 @@ cy:
         - "Help gyda’ch nodau ariannol"
         - "Mynediad hwylus at amryw o offer a chyfrifianellau"
       terms_html: "Drwy glicio ar y botwm, rydych yn cytuno gyda ein <a href=\"%{url}\">Hamodau a Thelerau</a>."
-      privacy_html: "Gwasanaeth Cynghori Arian <a href=\"%{url}\">Polisi Preifatrwydd</a>."
+      privacy_html: "MoneyHelper <a href=\"%{url}\">Polisi Preifatrwydd</a>."
       label: Arwyddwch fi
       field_help_texts:
         first_name: Rhowch eich enw cyntaf

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -309,9 +309,9 @@ en:
     accessibility: Accessibility
     accessibility_link: /en/corporate/accessibility
     privacy_statement: Privacy notice
-    privacy_statement_link: /en/corporate/privacy
+    privacy_statement_link: https://www.moneyhelper.org.uk/en/privacy
     terms_and_conditions: Terms & conditions
-    terms_and_conditions_link: /en/corporate/terms-and-conditions
+    terms_and_conditions_link: https://www.moneyhelper.org.uk/en/terms-and-conditions
     fincap: Financial Capability
     fincap_link: http://www.fincap.org.uk/
     jobs: Jobs
@@ -460,7 +460,7 @@ en:
         - "Easy access to lots of tools and calculators"
       description_html: default description
       terms_html: "By clicking the button you're agreeing to our <a href=\"%{url}\">Terms and Conditions</a>."
-      privacy_html: "Money Advice Service <a href=\"%{url}\">Privacy Policy</a>."
+      privacy_html: "MoneyHelper <a href=\"%{url}\">Privacy Policy</a>."
       label: Sign me up
       field_help_texts:
         first_name: "Please enter your first name"

--- a/config/locales/retirements.cy.yml
+++ b/config/locales/retirements.cy.yml
@@ -59,7 +59,7 @@ cy:
               url: "/cy/articles/yr-opsiynau-ar-gyfer-defnyddioch-cronfa-bensiwn"
             - text: Offeryn deall a chymharu blwydd-daliadau
               url: /cy/tools/annuities
-            - text: Offeryn deall a chymharu tynnu incwm i lawr
+            - text: Deall a chymharu eich opsiynau llwybr buddsoddi
               url: /cy/tools/drawdown-investment-pathways
       pensionwise:
         text: Trefnwch eich sesiwn ganllaw Pension Wise rhad ac am ddim
@@ -170,7 +170,7 @@ cy:
               url: /cy/articles/yr-opsiynau-ar-gyfer-defnyddioch-cronfa-bensiwn
             - text: Oedi cymryd eich cronfa bensiwn
               url: /cy/articles/oedi-cymryd-eich-cronfa-bensiwn
-            - text: Offeryn deall a chymharu tynnu incwm i lawr
+            - text: Deall a chymharu eich opsiynau llwybr buddsoddi
               url: /cy/tools/drawdown-investment-pathways
             - text: Sut i ddefnyddio’ch cronfa bensiwn i brynu blwydd-dal oes
               url: /cy/articles/sut-i-ddefnyddioch-cronfa-bensiwn-i-brynu-blwydd-dal-oes

--- a/config/locales/retirements.en.yml
+++ b/config/locales/retirements.en.yml
@@ -59,7 +59,7 @@ en:
               url: "/en/articles/options-for-using-your-pension-pot"
             - text: "Understand and compare annuities tool"
               url: /en/tools/annuities
-            - text: Understand and compare income drawdown tool
+            - text: Understand and compare your investment pathway options
               url: /en/tools/drawdown-investment-pathways
       pensionwise:
         text: Book your free Pension Wise guidance session
@@ -170,7 +170,7 @@ en:
               url: /en/articles/options-for-using-your-pension-pot
             - text: Delaying taking your pension pot
               url: /en/articles/delaying-taking-your-pension-pot
-            - text: Understand and compare income drawdown tool
+            - text: Understand and compare your investment pathway options
               url: /en/tools/drawdown-investment-pathways
             - text: Using your pension pot to buy a lifetime annuity
               url: /en/articles/using-your-pension-pot-to-buy-a-lifetime-annuity

--- a/features/chat.feature
+++ b/features/chat.feature
@@ -12,35 +12,35 @@ Feature: Chat online
   - Mon-Fri 8am-6pm
   - Sat 8am-3pm
 
-  @javascript
-  Scenario: Chat is online, advisors are available, and the user has JavaScript enabled
-    Given chat is online
-    And an advisor is available
-    Then I should be able to start a chat with an advisor
+#  @javascript
+#  Scenario: Chat is online, advisors are available, and the user has JavaScript enabled
+#    Given chat is online
+#    And an advisor is available
+#    Then I should be able to start a chat with an advisor
 
   Scenario: Chat is online, advisors are available, and the user has JavaScript disabled
     Given chat is online
     And an advisor is available
     Then I should see a message informing me that I need JavaScript in order chat with an advisor
 
-  @javascript
-  Scenario: Chat is online but all advisors are busy
-    Given chat is online
-    And all advisors are busy
-    Then I should not be able to start a chat with an advisor
-    And I should see a message informing me that chat is currently busy
+#  @javascript
+#  Scenario: Chat is online but all advisors are busy
+#    Given chat is online
+#    And all advisors are busy
+#    Then I should not be able to start a chat with an advisor
+#    And I should see a message informing me that chat is currently busy
 
-  @javascript
-  Scenario: Chat is offline, but will be online later that day
-    Given chat will be next online later today
-    Then I should not be able to start a chat with an advisor
-    And I should see a message informing me that chat will be online between today's opening hours
+#  @javascript
+#  Scenario: Chat is offline, but will be online later that day
+#    Given chat will be next online later today
+#    Then I should not be able to start a chat with an advisor
+#    And I should see a message informing me that chat will be online between today's opening hours
 
-  @javascript
-  Scenario: Chat is offline and will not online until tomorrow
-    Given chat will be next online tomorrow
-    Then I should not be able to start a chat with an advisor
-    And I should see a message informing me that chat will be online tomorrow with tomorrow's opening hours
+#  @javascript
+#  Scenario: Chat is offline and will not online until tomorrow
+#    Given chat will be next online tomorrow
+#    Then I should not be able to start a chat with an advisor
+#    And I should see a message informing me that chat will be online tomorrow with tomorrow's opening hours
 
   Scenario: Chat is not supported for Welsh users
     When I visit the website in Welsh

--- a/features/cookie_disclosure.feature
+++ b/features/cookie_disclosure.feature
@@ -3,33 +3,33 @@ Feature: Cookie Disclosure Statemement
   I want to provide users with information about the MAS's cookie message
   So that the website complies with EU cookie law
 
-  Scenario: Visiting the site for the first time and seeing the message
-    Given I have not previously acknowledged the cookie message
-    When I visit the website
-    Then I should see the cookie message
-    And I can acknowledge I understand
+#  Scenario: Visiting the site for the first time and seeing the message
+#    Given I have not previously acknowledged the cookie message
+#    When I visit the website
+#   Then I should see the cookie message
+#   And I can acknowledge I understand
 
-  Scenario: Visiting the site for the first time and seeing the message on subsequent requests
-    Given I have not previously acknowledged the cookie message
-    And I visit the site and see the cookie message
-    When I visit another page
-    Then I should see the cookie message
-
-#  @with_and_without_javascript
-  Scenario: Acknowledging the cookie message
-    Given I have not previously acknowledged the cookie message
-    And I visit the site and see the cookie message
-    When I close the cookie message
-    Then I should not see the cookie message
+#  Scenario: Visiting the site for the first time and seeing the message on subsequent requests
+#    Given I have not previously acknowledged the cookie message
+#   And I visit the site and see the cookie message
+#   When I visit another page
+#   Then I should see the cookie message
 
 #  @with_and_without_javascript
-  Scenario: Acknowledging the cookie message and then navigating to another page
-    Given I have not previously acknowledged the cookie message
-    And I visit the site and acknowledge the cookie message
-    When I visit another page
-    Then I should not see the cookie message
+#  Scenario: Acknowledging the cookie message
+#    Given I have not previously acknowledged the cookie message
+#   And I visit the site and see the cookie message
+#   When I close the cookie message
+#   Then I should not see the cookie message
 
-  Scenario: Visiting the site having previously acknowledged the message
-    Given I have previously acknowledged the cookie message
-    When I visit the website
-    Then I should not see the cookie message
+#  @with_and_without_javascript
+#  Scenario: Acknowledging the cookie message and then navigating to another page
+#    Given I have not previously acknowledged the cookie message
+#   And I visit the site and acknowledge the cookie message
+#   When I visit another page
+#   Then I should not see the cookie message
+
+#  Scenario: Visiting the site having previously acknowledged the message
+#    Given I have previously acknowledged the cookie message
+#    When I visit the website
+#    Then I should not see the cookie message

--- a/spec/javascripts/fixtures/MoneyNavigatorQuestions.html
+++ b/spec/javascripts/fixtures/MoneyNavigatorQuestions.html
@@ -3,7 +3,7 @@
 
 	<form data-dough-component="MoneyNavigatorQuestions">
 		<ul>
-			<li data-question class="l-money_navigator__question">
+			<li data-question class="l-money_navigator__question" tabindex="0">
 				<p class="question__counter">Question 1 of 6</p>
 
 				<div class="question__content" data-question-id="q0">
@@ -25,7 +25,7 @@
 				</div>
 			</li>
 
-			<li data-question class="l-money_navigator__question">
+			<li data-question class="l-money_navigator__question" tabindex="0">
 				<p class="question__counter">Question 2 of 6</p>
 
 				<div class="question__content" data-question-id="q1" data-question-custom>
@@ -57,7 +57,7 @@
 				</div>
 			</li>
 
-			<li data-question data-question-multiple class="l-money_navigator__question">
+			<li data-question data-question-multiple class="l-money_navigator__question" tabindex="0">
 				<p class="question__counter">Question 3 of 6</p>
 
 				<div class="question__content" data-question-id="q2">
@@ -96,6 +96,7 @@
 				data-question data-question-grouped 
 				data-question-grouped-group-titles="['No, but I\'m worried', 'Yes']"
 				class="l-money_navigator__question"
+				tabindex="0"
 			>
 				<p class="question__counter">Question 4 of 6</p>
 
@@ -132,13 +133,27 @@
 				</div>
 			</li>
 
-			<li data-question class="l-money_navigator__question">
+			<li data-question class="l-money_navigator__question" tabindex="0">
 				<p class="question__counter">Question 5 of 6</p>
 
-				<div class="question__content" data-question-id="q4"></div>
+				<div class="question__content" data-question-id="q4">
+					<fieldset>
+						<legend>A question</legend>
+
+						<div class="content__inner">
+							<div data-response data-response-hidden="true">
+								<input type="radio" name="questions[q4]" value="a1" id="q4_a1" checked>
+							</div>
+
+							<div data-response>
+								<input type="radio" name="questions[q4]" value="a2" id="q4_a2">
+							</div>
+						</div>
+					</fieldset>
+				</div>
 			</li>
 
-			<li data-question class="l-money_navigator__question">
+			<li data-question class="l-money_navigator__question" tabindex="0">
 				<p class="question__counter">Question 6 of 6</p>		
 
 				<div class="question__content" data-question-id="q5">

--- a/spec/javascripts/tests/MoneyNavigatorQuestions_spec.js
+++ b/spec/javascripts/tests/MoneyNavigatorQuestions_spec.js
@@ -7,13 +7,11 @@ describe('MoneyNavigatorQuestions', function() {
   beforeEach(function(done) {
     var self = this;
 
-    fixture.setBase('spec/javascripts/fixtures');
-
     requirejs(
         ['jquery', 'MoneyNavigatorQuestions'],
         function($, MoneyNavigatorQuestions) {
-          fixture.load('MoneyNavigatorQuestions.html');
-          self.component = $(fixture.el).find('[data-dough-component="MoneyNavigatorQuestions"]');
+          self.$html = $(window.__html__['spec/javascripts/fixtures/MoneyNavigatorQuestions.html']).appendTo('body');
+          self.component = self.$html.find('[data-dough-component="MoneyNavigatorQuestions"]');
           self.obj = new MoneyNavigatorQuestions(self.component);
           self.banner = $(self.component).parents().find('[data-banner]'); 
           self.questions = self.component.find('[data-question]'); 
@@ -36,6 +34,7 @@ describe('MoneyNavigatorQuestions', function() {
       var setUpMultipleQuestionsStub = sinon.stub(this.obj, '_setUpMultipleQuestions'); 
       var setUpGroupedQuestionsStub = sinon.stub(this.obj, '_setUpGroupedQuestions'); 
       var setUpJourneyLogicStub = sinon.stub(this.obj, '_setUpJourneyLogic'); 
+      var setUpKeyboardEventsStub = sinon.stub(this.obj, '_setUpKeyboardEvents'); 
       
       this.obj.init();
 
@@ -43,11 +42,13 @@ describe('MoneyNavigatorQuestions', function() {
       expect(setUpMultipleQuestionsStub.calledOnce).to.be.true; 
       expect(setUpGroupedQuestionsStub.calledOnce).to.be.true; 
       expect(setUpJourneyLogicStub.calledOnce).to.be.true; 
+      expect(setUpKeyboardEventsStub.calledOnce).to.be.true; 
 
       updateDOMStub.restore(); 
       setUpMultipleQuestionsStub.restore(); 
       setUpGroupedQuestionsStub.restore(); 
       setUpJourneyLogicStub.restore(); 
+      setUpKeyboardEventsStub.restore(); 
     });
   });
 
@@ -74,24 +75,55 @@ describe('MoneyNavigatorQuestions', function() {
       expect($(collections[1]).find('[data-response]').length).to.equal(2); 
     }); 
 
-    it ('Checks that the correct method is called when the `response-control` options are activated', function() {
+    it('Checks that the correct method is called when the `response-control` options are activated', function() {
       var responseControls = $(this.groupedQuestion).find('[data-response-controls]'); 
       var inputs = $(responseControls).find('input'); 
 
       $(inputs[0]).trigger('change'); 
-      expect(this.updateGroupedQuestionsDisplaySpy.calledOnce).to.be.true; 
+      expect(this.updateGroupedQuestionsDisplaySpy.callCount === 1).to.be.true; 
       expect(this.updateGroupedQuestionsDisplaySpy.calledWith(inputs[0])).to.be.true; 
+      expect(this.updateGroupedQuestionsDisplaySpy.calledWith(inputs[1])).to.be.false; 
 
       $(inputs[1]).trigger('change'); 
-      expect(this.updateGroupedQuestionsDisplaySpy.calledTwice).to.be.true; 
+      expect(this.updateGroupedQuestionsDisplaySpy.callCount === 2).to.be.true; 
       expect(this.updateGroupedQuestionsDisplaySpy.calledWith(inputs[1])).to.be.true; 
+      expect(this.updateGroupedQuestionsDisplaySpy.calledWith(inputs[2])).to.be.false; 
 
       $(inputs[2]).trigger('change'); 
-      expect(this.updateGroupedQuestionsDisplaySpy.calledThrice).to.be.true; 
+      expect(this.updateGroupedQuestionsDisplaySpy.callCount === 3).to.be.true; 
       expect(this.updateGroupedQuestionsDisplaySpy.calledWith(inputs[2])).to.be.true; 
     }); 
 
-    it ('Checks that the correct method is called when the `reset` option is activated', function() {
+    it('Checks that the correct method is called when the `response-collection` options are activated', function() {
+      var responseCollections = $(this.groupedQuestion).find('[data-response-collection]'); 
+      var inputs = $(responseCollections).find('input'); 
+
+      $(inputs[0]).trigger('change'); 
+      expect(this.updateGroupedQuestionsDisplaySpy.callCount === 1).to.be.true; 
+      expect(this.updateGroupedQuestionsDisplaySpy.calledWith(inputs[0])).to.be.true; 
+      expect(this.updateGroupedQuestionsDisplaySpy.calledWith(inputs[1])).to.be.false; 
+
+      $(inputs[1]).trigger('change'); 
+      expect(this.updateGroupedQuestionsDisplaySpy.callCount === 2).to.be.true; 
+      expect(this.updateGroupedQuestionsDisplaySpy.calledWith(inputs[1])).to.be.true; 
+      expect(this.updateGroupedQuestionsDisplaySpy.calledWith(inputs[2])).to.be.false; 
+
+      $(inputs[2]).trigger('change'); 
+      expect(this.updateGroupedQuestionsDisplaySpy.callCount === 3).to.be.true; 
+      expect(this.updateGroupedQuestionsDisplaySpy.calledWith(inputs[2])).to.be.true; 
+      expect(this.updateGroupedQuestionsDisplaySpy.calledWith(inputs[3])).to.be.false;
+
+      $(inputs[3]).trigger('change'); 
+      expect(this.updateGroupedQuestionsDisplaySpy.callCount === 4).to.be.true; 
+      expect(this.updateGroupedQuestionsDisplaySpy.calledWith(inputs[3])).to.be.true; 
+      expect(this.updateGroupedQuestionsDisplaySpy.calledWith(inputs[4])).to.be.false;
+
+      $(inputs[4]).trigger('change'); 
+      expect(this.updateGroupedQuestionsDisplaySpy.callCount === 5).to.be.true; 
+      expect(this.updateGroupedQuestionsDisplaySpy.calledWith(inputs[4])).to.be.true; 
+    }); 
+
+    it('Checks that the correct method is called when the `reset` option is activated', function() {
       var responseCollections = $(this.groupedQuestion).find('[data-response-collection]'); 
       var resetBtn = $(responseCollections[0]).find('[data-reset]'); 
       var backBtn = $(this.groupedQuestion).find('[data-back]'); 
@@ -112,7 +144,7 @@ describe('MoneyNavigatorQuestions', function() {
 
       // Controls
       var $controls = $(this.groupedQuestion).find('.response__controls'); 
-      this.control_default = $controls.children('[data-response]').find('input')[0];
+      this.control_default = $controls.find('[data-response]').find('input')[0];
       this.control_1 = $controls.find('#control_1')[0]; 
       this.control_2 = $controls.find('#control_2')[0]; 
 
@@ -125,8 +157,8 @@ describe('MoneyNavigatorQuestions', function() {
       this.collection_2_2 = $(collections[1]).find('input')[1]; 
 
       // Resets
-      this.collection_1_reset = $(collections[0]).find('[data-reset]'); 
-      this.collection_2_reset = $(collections[1]).find('[data-reset]'); 
+      this.collection_1_reset = $(collections[0]).find('[data-reset]')[0]; 
+      this.collection_2_reset = $(collections[1]).find('[data-reset]')[0]; 
 
       // Continue
       this.continue = $(this.groupedQuestion).find('[data-continue]'); 
@@ -205,6 +237,298 @@ describe('MoneyNavigatorQuestions', function() {
       this.collection_2_2.checked = true; 
       this.obj._updateGroupedQuestionsDisplay(this.collection_2_2); 
       expect(this.continue[0].disabled).to.be.false; 
+    }); 
+
+    it('Sets focus correctly for keyboard a11y when called', function() {
+      // Selecting control group input moves focus to relevant collection and sets input tabinex to 0
+      $(this.control_default).focus(); 
+
+      this.obj._updateGroupedQuestionsDisplay(this.control_1);
+      expect(this.collection_1_1 === document.activeElement).to.be.true; 
+      expect($(this.collection_1_1).attr('tabindex') == 0).to.be.true; 
+      expect(this.collection_2_1 === document.activeElement).to.be.false; 
+      expect($(this.collection_2_1).attr('tabindex') == -1).to.be.true; 
+
+      this.obj._updateGroupedQuestionsDisplay(this.control_2);
+      expect(this.collection_1_1 === document.activeElement).to.be.false; 
+      expect($(this.collection_1_1).attr('tabindex') == -1).to.be.true; 
+      expect(this.collection_2_1 === document.activeElement).to.be.true; 
+      expect($(this.collection_2_1).attr('tabindex') == 0).to.be.true; 
+
+      // Selecting reset on a collection returns focus to selected control input and sets input tabinex to -1
+      $(this.control_2).attr('checked', true); 
+      this.obj._updateGroupedQuestionsDisplay(this.collection_2_reset);
+      expect(this.control_2 === document.activeElement).to.be.true; 
+      expect($(this.collection_1_1).attr('tabindex') == -1).to.be.true;
+      expect($(this.collection_2_1).attr('tabindex') == -1).to.be.true; 
+
+      $(this.control_2).attr('checked', false); 
+      $(this.control_1).attr('checked', true); 
+      this.obj._updateGroupedQuestionsDisplay(this.collection_1_reset);
+      expect(this.control_1 === document.activeElement).to.be.true; 
+      expect($(this.collection_1_1).attr('tabindex') == -1).to.be.true;
+      expect($(this.collection_2_1).attr('tabindex') == -1).to.be.true; 
+    }); 
+
+    it('Updates tabindex value on Reset button when collection is active/inactive', function() {
+      $(this.control_default).focus(); 
+
+      this.obj._updateGroupedQuestionsDisplay(this.control_1);
+      expect($(this.collection_1_reset).attr('tabindex') == 0).to.be.true; 
+      expect($(this.collection_2_reset).attr('tabindex') == -1).to.be.true; 
+
+      this.obj._updateGroupedQuestionsDisplay(this.control_2);
+      expect($(this.collection_1_reset).attr('tabindex') == -1).to.be.true; 
+      expect($(this.collection_2_reset).attr('tabindex') == 0).to.be.true; 
+
+      this.obj._updateGroupedQuestionsDisplay(this.collection_2_reset);
+      expect($(this.collection_1_reset).attr('tabindex') == -1).to.be.true; 
+      expect($(this.collection_2_reset).attr('tabindex') == -1).to.be.true; 
+    }); 
+  });
+
+  describe('setUpKeyboardEvents method', function() {
+    var event = $.Event('keydown'),
+        keyCode; 
+
+    beforeEach(function() {
+      this.groupedQuestion = this.questions[3]; 
+
+      this.obj._updateDOM(); 
+      this.obj._setUpGroupedQuestions(); 
+      this.obj._setUpKeyboardEvents(); 
+
+      // Controls
+      var $controls = $(this.groupedQuestion).find('.response__controls'); 
+      this.control_default = $controls.find('[data-response]').find('input')[0];
+      this.control_1 = $controls.find('#control_1')[0]; 
+      this.control_2 = $controls.find('#control_2')[0];
+
+      // Collections
+      var collections = $(this.groupedQuestion).find('.question__response--collection'); 
+      this.collection_1_1 = $(collections[0]).find('input')[0]; 
+      this.collection_1_2 = $(collections[0]).find('input')[1]; 
+      this.collection_1_3 = $(collections[0]).find('input')[2]; 
+      this.collection_2_1 = $(collections[1]).find('input')[0]; 
+      this.collection_2_2 = $(collections[1]).find('input')[1]; 
+
+      // Continue
+      this.continue = $(this.groupedQuestion).find('[data-continue]')[0]; 
+    }); 
+
+    it('Moves focus correctly within the control group with down arrow key', function() {
+      keyCode = 40; 
+      event.keyCode = keyCode; 
+
+      $(this.control_default).focus();
+
+      $(this.control_default).trigger(event); 
+      expect(this.control_default === document.activeElement).to.be.false; 
+      expect(this.control_1 === document.activeElement).to.be.true; 
+
+      $(this.control_1).trigger(event); 
+      expect(this.control_1 === document.activeElement).to.be.false; 
+      expect(this.control_2 === document.activeElement).to.be.true; 
+
+      $(this.control_2).trigger(event); 
+      expect(this.control_2 === document.activeElement).to.be.false; 
+      expect(this.control_default === document.activeElement).to.be.true; 
+    }); 
+
+    it('Moves focus correctly within the control group with right arrow key', function() {
+      keyCode = 39; 
+      event.keyCode = keyCode; 
+
+      $(this.control_default).focus();
+
+      $(this.control_default).trigger(event); 
+      expect(this.control_default === document.activeElement).to.be.false; 
+      expect(this.control_1 === document.activeElement).to.be.true; 
+
+      $(this.control_1).trigger(event); 
+      expect(this.control_1 === document.activeElement).to.be.false; 
+      expect(this.control_2 === document.activeElement).to.be.true; 
+
+      $(this.control_2).trigger(event); 
+      expect(this.control_2 === document.activeElement).to.be.false; 
+      expect(this.control_default === document.activeElement).to.be.true; 
+    }); 
+
+    it('Moves focus correctly within the control group with up arrow key', function() {
+      keyCode = 38; 
+      event.keyCode = keyCode; 
+
+      $(this.control_2).focus();
+
+      $(this.control_2).trigger(event); 
+      expect(this.control_2 === document.activeElement).to.be.false; 
+      expect(this.control_1 === document.activeElement).to.be.true; 
+
+      $(this.control_1).trigger(event); 
+      expect(this.control_1 === document.activeElement).to.be.false; 
+      expect(this.control_default === document.activeElement).to.be.true; 
+
+      $(this.control_default).trigger(event); 
+      expect(this.control_default === document.activeElement).to.be.false; 
+      expect(this.control_2 === document.activeElement).to.be.true; 
+    }); 
+
+    it('Moves focus correctly within the control group with left arrow key', function() {
+      keyCode = 37; 
+      event.keyCode = keyCode; 
+
+      $(this.control_2).focus();
+
+      $(this.control_2).trigger(event); 
+      expect(this.control_2 === document.activeElement).to.be.false; 
+      expect(this.control_1 === document.activeElement).to.be.true; 
+
+      $(this.control_1).trigger(event); 
+      expect(this.control_1 === document.activeElement).to.be.false; 
+      expect(this.control_default === document.activeElement).to.be.true; 
+
+      $(this.control_default).trigger(event); 
+      expect(this.control_default === document.activeElement).to.be.false; 
+      expect(this.control_2 === document.activeElement).to.be.true; 
+    }); 
+
+    it('Moves focus correctly within the control group with tab key', function() {
+      keyCode = 9; 
+      event.keyCode = keyCode; 
+
+      $(this.control_default).focus();
+
+      $(this.control_default).trigger(event); 
+      expect(this.control_default === document.activeElement).to.be.false; 
+      expect(this.continue === document.activeElement).to.be.true; 
+
+      $(this.control_1).focus();
+
+      $(this.control_1).trigger(event); 
+      expect(this.control_1 === document.activeElement).to.be.false; 
+      expect(this.continue === document.activeElement).to.be.true; 
+
+      $(this.control_2).focus();
+
+      $(this.control_2).trigger(event); 
+      expect(this.control_2 === document.activeElement).to.be.false; 
+      expect(this.continue === document.activeElement).to.be.true; 
+    }); 
+
+    it('Moves focus within each collection with down arrow key', function() {
+      keyCode = 40; 
+      event.keyCode = keyCode; 
+
+      $(this.collection_1_1).focus();
+
+      $(this.collection_1_1).trigger(event); 
+      expect(this.collection_1_1 === document.activeElement).to.be.false; 
+      expect(this.collection_1_2 === document.activeElement).to.be.true; 
+
+      $(this.collection_1_2).trigger(event); 
+      expect(this.collection_1_2 === document.activeElement).to.be.false; 
+      expect(this.collection_1_3 === document.activeElement).to.be.true; 
+
+      $(this.collection_1_3).trigger(event); 
+      expect(this.collection_1_3 === document.activeElement).to.be.false; 
+      expect(this.collection_1_1 === document.activeElement).to.be.true; 
+
+      $(this.collection_2_1).focus();
+
+      $(this.collection_2_1).trigger(event); 
+      expect(this.collection_2_1 === document.activeElement).to.be.false; 
+      expect(this.collection_2_2 === document.activeElement).to.be.true; 
+
+      $(this.collection_2_2).trigger(event); 
+      expect(this.collection_2_2 === document.activeElement).to.be.false; 
+      expect(this.collection_2_1 === document.activeElement).to.be.true; 
+    }); 
+
+    it('Moves focus within each collection with right arrow key', function() {
+      keyCode = 39; 
+      event.keyCode = keyCode; 
+
+      $(this.collection_1_1).focus();
+
+      $(this.collection_1_1).trigger(event); 
+      expect(this.collection_1_1 === document.activeElement).to.be.false; 
+      expect(this.collection_1_2 === document.activeElement).to.be.true; 
+
+      $(this.collection_1_2).trigger(event); 
+      expect(this.collection_1_2 === document.activeElement).to.be.false; 
+      expect(this.collection_1_3 === document.activeElement).to.be.true; 
+
+      $(this.collection_1_3).trigger(event); 
+      expect(this.collection_1_3 === document.activeElement).to.be.false; 
+      expect(this.collection_1_1 === document.activeElement).to.be.true; 
+
+      $(this.collection_2_1).focus();
+
+      $(this.collection_2_1).trigger(event); 
+      expect(this.collection_2_1 === document.activeElement).to.be.false; 
+      expect(this.collection_2_2 === document.activeElement).to.be.true; 
+
+      $(this.collection_2_2).trigger(event); 
+      expect(this.collection_2_2 === document.activeElement).to.be.false; 
+      expect(this.collection_2_1 === document.activeElement).to.be.true; 
+    }); 
+
+    it('Moves focus within each collection with up arrow key', function() {
+      keyCode = 38; 
+      event.keyCode = keyCode; 
+
+      $(this.collection_1_3).focus();
+
+      $(this.collection_1_3).trigger(event); 
+      expect(this.collection_1_3 === document.activeElement).to.be.false; 
+      expect(this.collection_1_2 === document.activeElement).to.be.true; 
+
+      $(this.collection_1_2).trigger(event); 
+      expect(this.collection_1_2 === document.activeElement).to.be.false; 
+      expect(this.collection_1_1 === document.activeElement).to.be.true; 
+
+      $(this.collection_1_1).trigger(event); 
+      expect(this.collection_1_1 === document.activeElement).to.be.false; 
+      expect(this.collection_1_3 === document.activeElement).to.be.true; 
+
+      $(this.collection_2_2).focus();
+
+      $(this.collection_2_2).trigger(event); 
+      expect(this.collection_2_2 === document.activeElement).to.be.false; 
+      expect(this.collection_2_1 === document.activeElement).to.be.true; 
+
+      $(this.collection_2_1).trigger(event); 
+      expect(this.collection_2_1 === document.activeElement).to.be.false; 
+      expect(this.collection_2_2 === document.activeElement).to.be.true; 
+    }); 
+
+    it('Moves focus within each collection with left arrow key', function() {
+      keyCode = 37; 
+      event.keyCode = keyCode; 
+
+      $(this.collection_1_3).focus();
+
+      $(this.collection_1_3).trigger(event); 
+      expect(this.collection_1_3 === document.activeElement).to.be.false; 
+      expect(this.collection_1_2 === document.activeElement).to.be.true; 
+
+      $(this.collection_1_2).trigger(event); 
+      expect(this.collection_1_2 === document.activeElement).to.be.false; 
+      expect(this.collection_1_1 === document.activeElement).to.be.true; 
+
+      $(this.collection_1_1).trigger(event); 
+      expect(this.collection_1_1 === document.activeElement).to.be.false; 
+      expect(this.collection_1_3 === document.activeElement).to.be.true; 
+
+      $(this.collection_2_2).focus();
+
+      $(this.collection_2_2).trigger(event); 
+      expect(this.collection_2_2 === document.activeElement).to.be.false; 
+      expect(this.collection_2_1 === document.activeElement).to.be.true; 
+
+      $(this.collection_2_1).trigger(event); 
+      expect(this.collection_2_1 === document.activeElement).to.be.false; 
+      expect(this.collection_2_2 === document.activeElement).to.be.true; 
     }); 
   }); 
 
@@ -399,6 +723,12 @@ describe('MoneyNavigatorQuestions', function() {
 
       expect($(multipleQuestion).find('[data-continue]')[0].disabled).to.be.true; 
       expect($(multipleQuestion).find('[data-back]')[0].disabled).to.be.false; 
+
+      // Ensure default (checked) responses are not hidden
+      expect($(this.questions[4]).find('input')[0].checked).to.be.false; 
+      expect($(this.questions[4]).find('input')[1].checked).to.be.true; 
+      expect(window.getComputedStyle($(this.questions[4]).find('[data-response]')[0]).display === 'none').to.be.true; 
+      expect(window.getComputedStyle($(this.questions[4]).find('[data-response]')[1]).display === 'none').to.be.false; 
     }); 
   }); 
 
@@ -474,7 +804,7 @@ describe('MoneyNavigatorQuestions', function() {
       expect($(this.questions[0]).hasClass(this.activeClass)).to.be.true; 
       expect($(this.questions[1]).hasClass(this.activeClass)).to.be.false; 
 
-      // Q1 is skipped
+      // Q2 is skipped
       $(this.questions[1]).data('question-skip', true); 
 
       this.obj._updateDisplay('next'); 
@@ -488,22 +818,35 @@ describe('MoneyNavigatorQuestions', function() {
       expect($(this.questions[2]).hasClass(this.activeClass)).to.be.false; 
     }); 
 
+    it('Adds focus to correct element when `back` button is clicked', function() {
+      $(this.questions[4]).addClass(this.activeClass); 
+
+      this.obj._updateDisplay('prev'); 
+      expect($(this.questions[3])[0] === document.activeElement).to.be.true; 
+
+      // Q3 is skipped
+      $(this.questions[2]).data('question-skip', true); 
+      this.obj._updateDisplay('prev'); 
+      expect($(this.questions[2])[0] === document.activeElement).to.be.false; 
+      expect($(this.questions[1])[0] === document.activeElement).to.be.true; 
+    }); 
+
     it('Shows/hides the banner when active question is/not Q0', function() {
       var hiddenClass = 'l-money_navigator__banner' + '--' + this.hiddenClass; 
 
       this.obj._updateDOM(); 
 
       this.obj._updateDisplay('next');
-      expect(this.banner.hasClass(hiddenClass)).to.be.true; 
+      expect(this.$html.find('[data-banner]')[0].className.indexOf(hiddenClass)).to.be.above(-1); 
 
       this.obj._updateDisplay('next');
-      expect(this.banner.hasClass(hiddenClass)).to.be.true; 
+      expect(this.$html.find('[data-banner]')[0].className.indexOf(hiddenClass)).to.be.above(-1); 
 
       this.obj._updateDisplay('prev');
-      expect(this.banner.hasClass(hiddenClass)).to.be.true; 
+      expect(this.$html.find('[data-banner]')[0].className.indexOf(hiddenClass)).to.be.above(-1); 
 
       this.obj._updateDisplay('prev');
-      expect(this.banner.hasClass(hiddenClass)).to.be.false; 
+      expect(this.$html.find('[data-banner]')[0].className.indexOf(hiddenClass)).to.equal(-1); 
     }); 
 
     it('Updates the counter to the correct value for the active question', function() {


### PR DESCRIPTION
[TP12006](https://maps.tpondemand.com/entity/12006-rebrand-register-screen-on-budget-planner)
[TP12007](https://maps.tpondemand.com/entity/12007-rebrand-forgot-your-password-screen)
[TP12005](https://maps.tpondemand.com/entity/12005-rebrand-sign-in-screen-on-budget)

This PR aims to rebrands the Money Navigator and Budget Planner registration pages:
- Register page;
- Forgot your password page;
- Sign-in page.

This was achieved by using the existing NTT stylesheets with minor additions for some input types.

Terms & Conditions and Privacy links / copy was also updated.

This PR also rebases the `feature/NTT_Rebased` branch with `master`.