### PR TITLE
Adds necessary cookies array to module

### DIFF
--- a/app/assets/javascripts/modules/mas_cookieController.js
+++ b/app/assets/javascripts/modules/mas_cookieController.js
@@ -1,9 +1,10 @@
 var defaults = {
   theme: 'light', 
   optionalCookies: [],
+  necessaryCookies: [], 
   text: {}, 
   branding: {}
-};
+}
 
 var CookieController = function (opts) {
   this.config = Object.assign(defaults, opts);
@@ -83,9 +84,14 @@ var CookieController = function (opts) {
   }
 
   this.addOptionalCookies();
+  this.addNecessaryCookies(); 
   this.addText();
   this.addBranding();
-};
+}
+
+CookieController.prototype.addNecessaryCookies = function() {
+  this.config.necessaryCookies.push('action-plan-*');
+}
 
 CookieController.prototype.addBranding = function() {
   var textStrings = this.textStrings[this.locale];


### PR DESCRIPTION
[TP-12186](https://maps.tpondemand.com/entity/12186-bug-civic-cookie-module-breaks-redundancy)

This makes a small addition to the recently implemented cookie module to add an array of necessary cookies and to include in that a cookie that is necessary for the Redundancy Pay Calculator to function correctly. 
