### PR TITLE
Updates list of necessary cookies to add informizely

### DIFF
--- a/app/assets/javascripts/modules/mas_cookieController.js
+++ b/app/assets/javascripts/modules/mas_cookieController.js
@@ -90,7 +90,7 @@ var CookieController = function (opts) {
 }
 
 CookieController.prototype.addNecessaryCookies = function() {
-  this.config.necessaryCookies.push('action-plan-*');
+  this.config.necessaryCookies = ['action-plan-*', '_iz_uh_ps_', '_iz_sd_ss_'];
 }
 
 CookieController.prototype.addBranding = function() {


### PR DESCRIPTION
[TP-12241](https://maps.tpondemand.com/entity/12241-bug-civic-cookie-module-breaks-informizely)

This work addresses a problem we have been encountering with the Informizely survey panel. This (according to our analytics data) is not consistently appearing on the site. The problem seems to be that Civic, the cookie control module we introduced recently, requires some cookies to be set and these are being blocked by Civic. Since the survey form is considered to be an essential part of the site the solution for this is to add the Informizely cookies to the 'necessaryCookies' object in Civic.

This PR reflects this change. 