### PR TITLE
[TP-12233] Applies fix for DAL search by town not working

### DIFF
--- a/app/assets/javascripts/modules/mas_cookieController.js
+++ b/app/assets/javascripts/modules/mas_cookieController.js
@@ -90,7 +90,12 @@ var CookieController = function (opts) {
 }
 
 CookieController.prototype.addNecessaryCookies = function() {
-  this.config.necessaryCookies = ['action-plan-*', '_iz_uh_ps_', '_iz_sd_ss_'];
+  this.config.necessaryCookies = [
+    'action-plan-*', // Redundancy Pay Calculator
+    '__zjc*',        // Debt Advice Locator
+    '_iz_uh_ps_',    // Informizely
+    '_iz_sd_ss_'     // Informizely
+  ];
 }
 
 CookieController.prototype.addBranding = function() {


### PR DESCRIPTION
[TP-12233](https://maps.tpondemand.com/entity/12233-dalt-search-by-town-not-working)

This adds a reference to the cookie `__zjc*` to the Civic `necessaryCookies` array. 

This is an attempt to fix a problem on the Debt Advice Locator whereby the Search feature sometimes fails. It seems that this cookie is being set to expire immediately by a script that is being injected into the DOM. Although the cause of this is not clear it seems likely that it is because this cookie is not allowed by the Civic implementation. 

This may not fix the problem but we have agreed to try this to observe the effect on this tool in the live environment. 
