### PR TITLE
12490 money helper banner

### DIFF
--- a/app/assets/javascripts/components/GlobalNav.js
+++ b/app/assets/javascripts/components/GlobalNav.js
@@ -42,7 +42,16 @@ define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities', 'common'], 
    * Set up component
    */
   GlobalNav.prototype._bindEvents = function() {
-    $(window).on('resize', utilities.debounce($.proxy(this._setUpMobileAnimation, this), 100));
+    var _this = this;
+
+    $(window).on('resize', 
+      utilities.debounce(
+        function() {
+          _this._setUpMobileAnimation(); 
+          _this._setMenuPosition(); 
+        }, 100
+      )
+    )
   };
 
   /**
@@ -315,6 +324,8 @@ define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities', 'common'], 
       this.$globalNavClump.removeClass('is-active');
       $('body').removeClass('no-scroll');
     }
+
+    this._setMenuPosition(); 
   };
 
   GlobalNav.prototype._toggleMobileSubNav = function(index) {
@@ -335,6 +346,18 @@ define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities', 'common'], 
         $('[data-dough-subnav]').addClass('is-hidden');
       }, 400);
   };
+
+  GlobalNav.prototype._setMenuPosition = function() {
+    if (document.querySelector('header')) {
+      var headerRect = document.querySelector('header').getBoundingClientRect();
+
+      if (mediaQueries.atSmallViewport()) {
+        this.$globalNav.css('top', headerRect.bottom);
+      } else {
+        this.$globalNav.css('top', 0);      
+      }
+    }
+  }
 
   GlobalNav.prototype._openDesktopSubNav = function(index) {
     if (!this.$globalNav.hasClass('is-active')) {

--- a/app/assets/stylesheets/_print.scss
+++ b/app/assets/stylesheets/_print.scss
@@ -13,7 +13,7 @@
 
   // Hide unnecessary components
 
-  .l-maps_banner, 
+  .l-mh_banner, 
   .mobile-nav,
   .l-menu-nav,
   .l-search,

--- a/app/views/layouts/_application_shared.html.erb
+++ b/app/views/layouts/_application_shared.html.erb
@@ -8,7 +8,7 @@
   <a class="skip-to-link" href="<%= t('footer.accessibility_link') %>"><%= t('skip_links.to_accessibility_statement') %></a>
 
   <%= render 'shared/alerts' if alerts? %>
-  <%= render 'shared/maps_banner' %>
+  <%= render 'shared/mh_banner' %>
   <%= render 'shared/header' %>
   <%= render 'shared/global_nav' %>
   <%= render 'shared/no_js_nav' %>

--- a/app/views/layouts/error.html.erb
+++ b/app/views/layouts/error.html.erb
@@ -1,7 +1,5 @@
 <%= render layout: 'layouts/base' do %>
-
-  <%= render 'shared/maps_banner' %>
-
+  <%= render 'shared/mh_banner' %>
   <%= render 'shared/header' %>
 
   <div class="l-error-page">

--- a/app/views/layouts/pace.html.erb
+++ b/app/views/layouts/pace.html.erb
@@ -1,6 +1,5 @@
 <%= render layout: 'layouts/base' do %>
-  <%= render 'shared/maps_banner' %>
-
+  <%= render 'shared/mh_banner' %>
   <%= render 'pace/header' %>
 
   <%= yield %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,7 +1,5 @@
 <header 
-  class="l-header
-    <%= ' l-header--non-sticky' if hide_sticky_header? || hide_elements_irrelevant_for_third_parties? %>
-    <%= ' l-header--home' if show_home_banner? %>"
+  class="l-header <%= ' l-header--non-sticky' if hide_sticky_header? || hide_elements_irrelevant_for_third_parties? %>"
   role="banner"
 >
   <div class="l-constrained l-header__content">

--- a/app/views/shared/_mh_banner.html.erb
+++ b/app/views/shared/_mh_banner.html.erb
@@ -1,0 +1,9 @@
+<div class="l-mh_banner">
+  <div class="l-constrained">
+    <div class="l-mh_banner__content">
+        <p class="mh_banner__header"><%= t('mh_banner.header') %></p>
+        <p class="mh_banner__body"><%= t('mh_banner.body') %></p>
+        <div class="mh_banner__logo"></div>
+    </div>
+  </div>
+</div>

--- a/bower.json.erb
+++ b/bower.json.erb
@@ -12,7 +12,7 @@
     "jquery-ujs": "*",
     "jquery-migrate": "3.0.*",
     "bind-polyfill": "^1.0.0",
-    "yeast": "1.16.1", 
+    "yeast": "1.17.0",
     "advice_plans": "<%= gem_path('advice_plans') %>",
     "car_cost_tool": "<%= gem_path('car_cost_tool') %>",
     "debt_advice_locator": "<%= gem_path('debt_advice_locator') %>",
@@ -25,6 +25,7 @@
     "cost_calculator_builder": "<%= gem_path('cost_calculator_builder') %>"
   },
   "resolutions": {
-    "jquery": "3.3.*"
+    "jquery": "3.3.*", 
+    "yeast": "1.17.0"
   }
 }

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -282,10 +282,9 @@ cy:
       %201443%20827658%20%0ALlun%20i%20Wener%3A%208am-8pm%20%0ADydd%20Sadwrn%3A
       %209am-1pm%20%0ADydd%20Sul%20a%20Gwyliau%20Banc%3A%20ar%20gau
 
-  maps_banner:
-    mps_provided_1: Gwasanaeth Cynghori Ariannol
-    mps_provided_2: yn cael ei ddarparu gan
-    mps: Gwasanaeth Arian a Phensiynau
+  mh_banner: 
+    header: Rydym yn newid ein enw i HelpwrArian
+    body: Cyn bo hir bydd y Gwasanaeth Cynghori Ariannol yn dod yn HelpwrArian, y ffordd hawdd i gael help am ddim i’ch dewisiadau arian a phensiwn.
 
   covid_banner:
     head: Arweiniad Ariannol Coronafeirws

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -283,10 +283,9 @@ en:
       %20Friday%3A%208am-8pm%0ASaturday%3A%209am-1pm%0ASunday%20and%20Bank
       %20Holidays%3A%20closed
 
-  maps_banner:
-    mps_provided_1: The Money Advice
-    mps_provided_2: Service is provided by
-    mps: Money & Pensions Service
+  mh_banner: 
+    header: We're changing to MoneyHelper
+    body: Money Advice Service will soon become MoneyHelper, the easy way to get free help for your money and pensions.
 
   covid_banner:
     head: Coronavirus Money Guidance


### PR DESCRIPTION
[TP-12490](https://maps.tpondemand.com/entity/12490-moneyhelper-coming-soon-banner-on-mas)

This work adds a "Money Helper Coming Soon" banner to the MAS site that replaces the existing MAPS banner, to display as the screenshots below.

The styles are mostly on Yeast so that they can be shared across projects so there is an accompanying PR for the same piece of work at [PR65](https://github.com/moneyadviceservice/yeast/pull/65)


![image](https://user-images.githubusercontent.com/6080548/116667777-79e16280-a994-11eb-947c-94b330349518.png)

![image](https://user-images.githubusercontent.com/6080548/116668028-ce84dd80-a994-11eb-8bce-b22ddc1a7011.png)

![image](https://user-images.githubusercontent.com/6080548/116668277-1c99e100-a995-11eb-874d-a468c6a5b63f.png)
