### PR TITLE
Update Action Plans for YE-2021

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,7 +77,7 @@ gem 'dough-ruby', git: 'git@github.com:moneyadviceservice/dough.git', branch: 'T
 gem 'mas-cms-client', '1.20.1'
 gem 'site_search', '0.3.0'
 # Tools
-gem 'action_plans', '~> 5.5.0'
+gem 'action_plans', '~> 5.6.0'
 gem 'advice_plans', '~> 4.1.1'
 gem 'agreements', '~> 2.5.0'
 gem 'budget_planner', '~> 5.7.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,7 @@ GEM
   remote: https://gems.railslts.com/
   remote: http://gems.dev.mas.local/
   specs:
-    action_plans (5.5.0)
+    action_plans (5.6.0)
       autoprefixer-rails
       dough-ruby (~> 5.0)
       draper
@@ -806,7 +806,7 @@ PLATFORMS
   x86_64-darwin-20
 
 DEPENDENCIES
-  action_plans (~> 5.5.0)
+  action_plans (~> 5.6.0)
   actionmailer!
   actionpack!
   actionview!


### PR DESCRIPTION
[TP-12016](https://maps.tpondemand.com/entity/12016-redundancy-pay-calculator-ye-updates-calculations)

Update Rates
Update JSA
Update Age calculation to use .floor instead of .round
Update test suite
Fix rubocop version