### PR TITLE
TP-12090 Remove Cream 

### DIFF
--- a/config/initializers/warden_hooks.rb
+++ b/config/initializers/warden_hooks.rb
@@ -1,7 +1,5 @@
 Warden::Manager.after_set_user :except => :fetch do |record, warden, options|
   if warden.authenticated?(options[:scope])
-    Delayed::Job.enqueue(Jobs::UpdateUser.new(record.id),
-                         queue: 'frontend_crm')
     Devise::Utils.purge_custom_messages(warden.env['rack.session'])
   end
 end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -1,22 +1,8 @@
 RSpec.describe SessionsController, type: :controller do
   describe '#create' do
-    context 'when user has been updated in CRM' do
+    context 'when user has been updated' do
       let!(:user) { FactoryBot.create(:user) }
       let(:customer) { Core::Registry::Repository[:customer].customers.first }
-      let(:new_first_name) { 'Philip' }
-
-      before :each do
-        Core::Interactors::Customer::Creator.new(user).call
-        customer[:first_name] = new_first_name
-      end
-
-      it 'adds job to persist this to the database' do
-        @request.env['devise.mapping'] = Devise.mappings[:user]
-
-        expect do
-          post :create, user: { email: user.email, password: user.password }, locale: 'en'
-        end.to change { Delayed::Job.where("handler like '%UpdateUser%'").count }.by(1)
-      end
 
       it 'removes custom session messages' do
         session['authentication_sign_in_page_title'] = 'hello'

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -258,26 +258,4 @@ RSpec.describe User, type: :model do
       expect(subject.data_for_universal_credit?).to be false
     end
   end
-
-  describe 'callbacks' do
-    describe 'update_to_crm' do
-      before :each do
-        subject.save!
-      end
-
-      context 'when crm fields are modified' do
-        it 'notifies crm' do
-          subject.email = 'foo@example.com'
-          expect { subject.save! }.to change(Delayed::Job, :count).by(1)
-        end
-      end
-
-      context 'when non crm fields are modified' do
-        it 'does not notify crm' do
-          subject.sign_in_count = 125
-          expect { subject.save! }.to_not change(Delayed::Job, :count)
-        end
-      end
-    end
-  end
 end


### PR DESCRIPTION
[TP-12090](https://maps.tpondemand.com/entity/12090-email-feature-does-not-work)

CRM is no longer in use and contains no valid information
DelayedJob failed to send emails when attempting to fetch user information using Cream
Remove ActiveRecord hooks to communicate with Cream when user created/updated
Relevant tests