### PR TITLE
Adds `target="_blank"` to links

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -292,9 +292,9 @@ cy:
     accessibility: Hygyrchedd
     accessibility_link: /cy/corporate/hygyrchedd
     privacy_statement: Rhybudd preifatrwydd
-    privacy_statement_link: https://www.moneyhelper.org.uk/cy/privacy
+    privacy_statement_link: https://www.moneyhelper.org.uk/cy/about-us/privacy-and-legal/privacy-notice
     terms_and_conditions: Amodau a Thelerau
-    terms_and_conditions_link: https://www.moneyhelper.org.uk/cy/terms-and-conditions
+    terms_and_conditions_link: https://www.moneyhelper.org.uk/cy/about-us/privacy-and-legal/terms-and-conditions
     fincap: Galluogrwydd Ariannol
     fincap_link: http://www.fincap.org.uk/cymru
     jobs: Swyddi
@@ -441,8 +441,8 @@ cy:
         - "Cadwch eich Cynllunydd Cyllideb neu Reolwr arian a chadwch eich crynodeb o’ch gwariant wrth law"
         - "Help gyda’ch nodau ariannol"
         - "Mynediad hwylus at amryw o offer a chyfrifianellau"
-      terms_html: 'Drwy glicio ar y botwm, rydych yn cytuno gyda ein <a href="%{url}">Hamodau a Thelerau</a>.'
-      privacy_html: 'HelpiwrArian <a href="%{url}">Polisi Preifatrwydd</a>.'
+      terms_html: 'Drwy glicio ar y botwm, rydych yn cytuno gyda ein <a target="_blank" href="%{url}">Hamodau a Thelerau</a>.'
+      privacy_html: 'HelpiwrArian <a target="_blank" href="%{url}">Polisi Preifatrwydd</a>.'
       label: Arwyddwch fi
       field_help_texts:
         first_name: Rhowch eich enw cyntaf

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -292,9 +292,9 @@ en:
     accessibility: Accessibility
     accessibility_link: /en/corporate/accessibility
     privacy_statement: Privacy notice
-    privacy_statement_link: https://www.moneyhelper.org.uk/en/privacy
+    privacy_statement_link: https://www.moneyhelper.org.uk/en/about-us/privacy-and-legal/privacy-notice
     terms_and_conditions: Terms & conditions
-    terms_and_conditions_link: https://www.moneyhelper.org.uk/en/terms-and-conditions
+    terms_and_conditions_link: https://www.moneyhelper.org.uk/en/about-us/privacy-and-legal/terms-and-conditions
     fincap: Financial Capability
     fincap_link: http://www.fincap.org.uk/
     jobs: Jobs
@@ -442,8 +442,8 @@ en:
         - "Help with your money goals"
         - "Easy access to lots of tools and calculators"
       description_html: default description
-      terms_html: "By clicking the button you're agreeing to our <a href=\"%{url}\">Terms and Conditions</a>."
-      privacy_html: "MoneyHelper <a href=\"%{url}\">Privacy Policy</a>."
+      terms_html: "By clicking the button you're agreeing to our <a target=\"_blank\" href=\"%{url}\">Terms and Conditions</a>."
+      privacy_html: "MoneyHelper <a target=\"_blank\" href=\"%{url}\">Privacy Policy</a>."
       label: Sign me up
       field_help_texts:
         first_name: "Please enter your first name"


### PR DESCRIPTION
[TP-12596](https://maps.tpondemand.com/entity/12596-registration-page-open-links-in-a)

This adds the `target` attribute to the `Terms and Conditions` and `Privacy Policy` links on the registration page and sets this to `_blank` to allow these links to open in new tabs. 

![image](https://user-images.githubusercontent.com/6080548/120470045-010e6580-c39b-11eb-9238-9a88e3b58351.png)
