### PR TITLE
12553 money navigator scroll on mobile

### DIFF
--- a/app/assets/javascripts/components/MoneyNavigatorResults.js
+++ b/app/assets/javascripts/components/MoneyNavigatorResults.js
@@ -30,6 +30,7 @@ define(['jquery', 'DoughBaseComponent', 'utilities'], function($, DoughBaseCompo
     this._updateDOM(); 
     this._setUpEvents(); 
     this._initialisedSuccess(initialised);
+    this.bodyHeight = document.body.clientHeight; 
   };
 
   MoneyNavigatorResults.prototype._updateDOM = function() {
@@ -71,12 +72,14 @@ define(['jquery', 'DoughBaseComponent', 'utilities'], function($, DoughBaseCompo
     }); 
 
     this.$headingTitles.parents('button').on('click', function(e) {
-      _this._showHeading(e.target); 
-    }); 
+      _this._showHeading(e.target);
+      _this._resizeContent(e.target);
+    });
 
     this.$headingContent.find('[data-overlay-hide]').on('click', function(e) {
       e.preventDefault(); 
       _this._hideHeading(e.target); 
+      _this._resizeContent();
     }); 
 
     this.$overlay.on('click', function() {
@@ -166,6 +169,27 @@ define(['jquery', 'DoughBaseComponent', 'utilities'], function($, DoughBaseCompo
     if (!this.$overlay.hasClass(this.hiddenClass)) {
       this.$overlay.addClass(this.hiddenClass); 
     }
+  }; 
+
+  MoneyNavigatorResults.prototype._resizeContent = function(target) {
+    if (target === undefined) {
+      document.body.style.height = 'auto';
+    } else {
+      var article = $(target).parents('[data-heading]')[0].querySelector('[data-heading-content]'); 
+      var size = this._getSize(article);
+
+      if (this.bodyHeight < size.height) {
+        document.body.style.height = size.height + 'px'; 
+      } else {
+        article.style.height = this.bodyHeight + 'px'; 
+      }
+    }
+  };
+
+  MoneyNavigatorResults.prototype._getSize = function(el) {
+    return {
+      height: el.getBoundingClientRect().height
+    };
   }
 
   return MoneyNavigatorResults; 

--- a/app/assets/stylesheets/layout/page_specific/_money_navigator_results.scss
+++ b/app/assets/stylesheets/layout/page_specific/_money_navigator_results.scss
@@ -504,17 +504,16 @@ $transition-time: 0.4s;
 				}
 
 				.heading__content {
-					position: fixed;
+					position: absolute;
 					top: 0%;
 					left: 0%;
-					height: 100%; 
+					height: auto; 
 					width: 100%;
 					padding: $baseline-unit * 8 $default-gutter * 4 $baseline-unit * 4;
 					z-index: 155; 
 					background: $color-white;
 					transition-property: top; 
-					transition-duration: $transition-time; 
-					overflow-y: scroll;
+					transition-duration: $transition-time;
 
 					@include respond-to($mq-s) {
 						padding-left: $default-gutter * 3.5;
@@ -579,6 +578,7 @@ $transition-time: 0.4s;
 				}
 
 				.heading__content--hidden {
+					position: fixed;
 					top: 100%;
 
 					@include respond-to($mq-l) {

--- a/spec/javascripts/fixtures/MoneyNavigatorResults.html
+++ b/spec/javascripts/fixtures/MoneyNavigatorResults.html
@@ -1,96 +1,92 @@
 <div>
 	<section data-dough-component="MoneyNavigatorResults">
-		<ul>
-			<li data-section id="S1">
-				<h3 class="section__title" data-section-title>
+		<ul class="sections__sections">
+			<li class="sections__section" data-section id="S1">
+				<h4 class="section__title" data-section-title>
 					<button>
 						<span>Payment holidays</span>
 					</button>
-				</h3>
+				</h4>
 
 				<div class="section__content">
-					<h4 style="height:19px;">What to do now your payment holiday has ended</h4>
-
-					<ul style="height:45px;">
-						<li data-heading id="S1_H1">
+					<ul class="sections__headings" style="height:45px;">
+						<li class="sections__heading" data-heading id="S1_H1">
 							<button>
-								<h5 data-heading-title>Mortgage payment holidays</h5>
+								<h6 data-heading-title>Mortgage payment holidays</h6>
 							</button>
 
-							<div class="heading__content" data-heading-content>
+							<article class="heading__content" data-heading-content style="height: 1609px; padding: 48px 0 24px;">
 								Content relating to section S1, heading H1.
 								<a data-overlay-hide></a>
-							</div>
+							</aricle>
 						</li>
 
-						<li data-heading id="S1_H2">
+						<li class="sections__heading" data-heading id="S1_H2">
 							<button>
-								<h5 data-heading-title>Personal loan payment holidays</h5>
+								<h6 data-heading-title>Personal loan payment holidays</h6>
 							</button>
 
-							<div class="heading__content" data-heading-content>
+							<article class="heading__content" data-heading-content style="height: 2093px; padding: 48px 0 24px;">
 								Content relating to section S1, heading H2.
 								<a data-overlay-hide></a>
-							</div>
+							</article>
 						</li>
 					</ul>
 				</div>
 			</li>
 
-			<li data-section id="S3">
-				<h3 class="section__title" data-section-title>
+			<li class="sections__section" data-section id="S3">
+				<h4 class="section__title" data-section-title>
 					<button>
 						<span>Money and work</span>					
 					</button>
-				</h3>
+				</h4>
 
 				<div class="section__content">
-					<ul style="height:32px;">
-						<li data-heading id="S3_H1">
+					<ul class="sections__headings" style="height:32px;">
+						<li class="sections__heading" data-heading id="S3_H1">
 							<button>
-								<h5 data-heading-title>Preparing for redundancy</h5>
+								<h6 data-heading-title>Preparing for redundancy</h6>
 							</button>
 
-							<div class="heading__content" data-heading-content>
+							<article class="heading__content" data-heading-content style="height: 2794px; padding: 48px 0 24px;">
 								Content relating to section S3, heading H1.
 								<a data-overlay-hide></a>
-							</div>
+							</article>
 						</li>
 					</ul>
 				</div>
 			</li>
 
-			<li data-section id="S4">
-				<h3 class="section__title" data-section-title>
+			<li class="sections__headings" data-section id="S4">
+				<h4 class="section__title" data-section-title>
 					<button>
 						<span>Staying on top of priority bills</span>					
 					</button>
-				</h3>
+				</h4>
 
 				<div class="section__content">
-					<h4>What to do if you're worried about priority bills</h4>
-
-					<ul>
-						<li data-heading id="S4_H2">
+					<ul class="sections__headings">
+						<li class="sections__heading" data-heading id="S4_H2">
 							<button>
-								<h5 data-heading-title>What to do about paying your gas or electricity bill</h5>
+								<h6 data-heading-title>What to do about paying your gas or electricity bill</h6>
 							</button>
 
-							<div class="heading__content" data-heading-content>
+							<article class="heading__content" data-heading-content style="height: 1560px; padding: 48px 0 24px;">
 								Content relating to section S4, heading H2.
 								<a data-overlay-hide></a>								
-							</div>
+							</article>
 						</li>
 
-						<li data-heading id="S4_H3">
+						<li class="sections__heading" data-heading id="S4_H3">
 							<button>
-								<h5 data-heading-title>What to do about payments to DWP/HMRC</h5>
+								<h6 data-heading-title>What to do about payments to DWP/HMRC</h6>
 							</button>
 
-							<div class="heading__content" data-heading-content>
+							<article class="heading__content" data-heading-content style="height: 1027px; padding: 48px 0 24px;">
 								Content relating to section S4, heading H3.
 								<a data-overlay-hide></a>								
-							</div>
+							</article>
 						</li>
 					</ul>
 				</div>

--- a/spec/javascripts/tests/MoneyNavigatorResults_spec.js
+++ b/spec/javascripts/tests/MoneyNavigatorResults_spec.js
@@ -23,6 +23,13 @@ describe('MoneyNavigatorResults', function() {
           self.collapsedClass = self.obj.collapsedClass; 
           self.doneSuffix = self.obj.doneSuffix; 
 
+          // TODO: Use these variables in setUpEvents method in favour of $headingTitles above
+          self.S1_H1_btn = self.component.find('#S1_H1').find('button');
+          self.S1_H2_btn = self.component.find('#S1_H2').find('button');
+          // self.S3_H1_btn = $('#S3_H1').find('button');
+          // self.S4_H2_btn = $('#S4_H2').find('button');
+          self.S4_H3_btn = self.component.find('#S4_H3').find('button');
+
           done();
         }, done);
   });
@@ -78,6 +85,7 @@ describe('MoneyNavigatorResults', function() {
       var toggleSectionSpy = sinon.stub(this.obj, '_toggleSection'); 
       var showHeadingSpy = sinon.spy(this.obj, '_showHeading'); 
       var hideHeadingSpy = sinon.spy(this.obj, '_hideHeading'); 
+      var resizeContentSpy = sinon.spy(this.obj, '_resizeContent'); 
       var sectionResizeStub = sinon.stub(this.obj, '_sectionResize'); 
       var printStub = sinon.stub(window, 'print'); 
       var section_0_btn = $(this.$sectionTitles[0]).find('button'); 
@@ -102,15 +110,23 @@ describe('MoneyNavigatorResults', function() {
 
       $(heading_0_btn).trigger('click'); 
       expect(showHeadingSpy.calledWith(heading_0_btn[0])).to.be.true; 
+      expect(resizeContentSpy.calledWith(heading_0_btn[0])).to.be.true; 
+      expect(resizeContentSpy.callCount).to.equal(1); 
 
       $(heading_2_btn).trigger('click'); 
       expect(showHeadingSpy.calledWith(heading_2_btn[0])).to.be.true; 
+      expect(resizeContentSpy.calledWith(heading_2_btn[0])).to.be.true; 
+      expect(resizeContentSpy.callCount).to.equal(2); 
 
       $(heading_4_btn).trigger('click'); 
       expect(showHeadingSpy.calledWith(heading_4_btn[0])).to.be.true; 
+      expect(resizeContentSpy.calledWith(heading_4_btn[0])).to.be.true; 
+      expect(resizeContentSpy.callCount).to.equal(3); 
 
       $(overlayHide).trigger('click');
       expect(hideHeadingSpy.calledWith(overlayHide[0])).to.be.true; 
+      expect(resizeContentSpy.calledWith()).to.be.true;
+      expect(resizeContentSpy.callCount).to.equal(4); 
 
       this.$overlay.trigger('click'); 
       expect(hideHeadingSpy.calledWith()).to.be.true; 
@@ -124,8 +140,34 @@ describe('MoneyNavigatorResults', function() {
       toggleSectionSpy.restore(); 
       showHeadingSpy.restore(); 
       hideHeadingSpy.restore(); 
+      resizeContentSpy.restore(); 
       sectionResizeStub.restore(); 
       printStub.restore(); 
+    }); 
+  });
+
+  describe('resizeContent method', function() {
+    it('Sets new value for height of body', function() {
+      var getSizeSpy = sinon.spy(this.obj, '_getSize');
+
+      this.obj._resizeContent();
+      expect(getSizeSpy.called).to.not.be.true; 
+
+      this.obj._resizeContent(this.S1_H1_btn[0]);
+      expect(getSizeSpy.calledWith(this.S1_H1_btn.parents('[data-heading]').find('[data-heading-content]')[0])).to.be.true;
+
+      this.obj._resizeContent(this.S4_H3_btn);
+      expect(getSizeSpy.calledWith(this.S4_H3_btn.parents('[data-heading]').find('[data-heading-content]')[0])).to.be.true;
+
+      getSizeSpy.restore(); 
+    });
+  });
+
+  // TODO: Fix this test
+  xdescribe('getSize method', function() {
+    it('Returns the correct value when given a target element', function() {
+      var value = this.obj._getSize(this.S1_H2_btn.parents('[data-heading]').find('[data-heading-content]'));
+      expect(value.height).to.equal(2165);
     }); 
   }); 
 


### PR DESCRIPTION
[TP-12553](https://maps.tpondemand.com/entity/12553-money-navigator-unable-to-fully-scroll)

This work addresses the problem on iOS devices that are unable to switch between scrolling contexts when rendering content within an iFrame. This is specific to the content in expandable sections on the results page of the money Navigator tool, activated by clicking on the headers such as "Getting back on track after a severe income drop" shown below. 

![image](https://user-images.githubusercontent.com/6080548/122453806-851f3a80-cfa2-11eb-80e9-652d86a8494e.png)

The solution adopted here is to dynamically resize the body element when the content is expanded so that it does not need to be scrolled. With this in place users of devices affected do not need to change their scrolling context and area able to view the full content. 

It is not a perfect solution and some other issues are raised by it: 
- the content cuts off when the page is resized
- the expanded content is short of the full page height when the height of the content is less than the height of containing page

There is a partial fix for the second of these issues in this PR but this will need to be revisited later in some further work. In the meantime this work should fix the issue as observed by iOS users and ensure the tool is useable by them. 