### PR TITLE
Adds `PostMessages` component to repo

### DIFF
--- a/app/assets/javascripts/require_config.js.erb
+++ b/app/assets/javascripts/require_config.js.erb
@@ -32,6 +32,7 @@
 //= depend_on_asset dough/assets/js/components/CovidBanner
 //= depend_on_asset dough/assets/js/components/DoughBaseComponent
 //= depend_on_asset dough/assets/js/components/PopupTip
+//= depend_on_asset dough/assets/js/components/PostMessages
 //= depend_on_asset dough/assets/js/components/RangeInput
 //= depend_on_asset dough/assets/js/components/TabSelector
 //= depend_on_asset dough/assets/js/components/FieldHelpText
@@ -121,6 +122,7 @@
     DoughBaseComponent: requirejs_path('dough/assets/js/components/DoughBaseComponent'),
     FieldHelpText: requirejs_path('dough/assets/js/components/FieldHelpText'),
     PopupTip: requirejs_path('dough/assets/js/components/PopupTip'),
+    PostMessages: requirejs_path('dough/assets/js/components/PostMessages'),
     RangeInput: requirejs_path('dough/assets/js/components/RangeInput'),
     TabSelector: requirejs_path('dough/assets/js/components/TabSelector'),
     Validation: requirejs_path('dough/assets/js/components/Validation'),


### PR DESCRIPTION
[TP-12641](https://maps.tpondemand.com/entity/12641-scroll-parent-page-to-top-when)

This work adds the PostMessages Dough component, extended in [PR346](https://github.com/moneyadviceservice/dough/pull/346), to the frontend app so that it is available to mounted tools.
