### PR TITLE
Update reset password email

### DIFF
--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -13,10 +13,10 @@
 
   <p><%= t("authentication.emails.reset_passwords.step_2")%></p>
 
-  <p><%= t("authentication.emails.reset_passwords.step_3")%></p>
+  <%= t("authentication.emails.reset_passwords.step_3_html")%>
 
   <p><%= t("authentication.emails.reset_passwords.expired_token_tip")%></p>
 
-  <p><%= t("authentication.emails.reset_passwords.expired_token_tip_steps_html", url: new_password_url(@resource, locale: I18n.locale))%></p>
+  <p><%= t("authentication.emails.reset_passwords.expired_token_tip_steps_html") %></p>
 
 <% end %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -87,7 +87,7 @@ Rails.application.configure do
   # Configure active record session store.
   config.session_store :active_record_store
 
-  config.action_mailer.default_url_options = {:host => "#{'qa.test.' if ENV['MAS_ENVIRONMENT'] == 'qa'}moneyadviceservice.org.uk"}
+  config.action_mailer.default_url_options = {:host => "#{ENV['MAS_ENVIRONMENT'] == 'qa' ? 'qa.test.' : 'www.'}moneyadviceservice.org.uk"}
 
   # Custom configuration options for feedback settings
   config.feedback_delivery_method = :sendmail

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -489,9 +489,10 @@ cy:
         step_1: 1) Ewch i'r dudalen hon ar wefan HelpwrArian. Peidiwch â disgwyl yn rhy hir cyn ailosod eich cyfrinair oherwydd bydd y ddolen hon yn dirwyn i ben am resymau diogelwch.
         link_label: Newid fy nghyfrinair
         step_2: 2) Meddyliwch am gyfrinair y byddwch yn ei gofio (ond nid pobl eraill) a'i deipio ar y wefan pan ofynnir i chi wneud hynny.
-        step_3: 3) Cewch eich arwyddo i mewn yn awtomatig fel y gallwch barhau i dderbyn cyngor gan HelpwrArian.
+        step_3_html: |
+          <p>3) Cewch eich arwyddo i mewn yn awtomatig fel y gallwch barhau i dderbyn cyngor gan HelpwrArian.</p>
         expired_token_tip: Beth i'w wneud os bydd eich dolen ailosod cyfrinair (uchod) wedi dirwyn i ben
-        expired_token_tip_steps_html: "Ewch yn ôl i'r dudalen <a href='%{url}'>Anghofio Cyfrinair</a> a theipiwch eich cyfeiriad e-bost unwaith eto fel y gallwn anfon un arall atoch."
+        expired_token_tip_steps_html: "Ewch yn ôl i'r dudalen <a href='https://www.moneyhelper.org.uk/cy/users/password'>Anghofio Cyfrinair</a> a theipiwch eich cyfeiriad e-bost unwaith eto fel y gallwn anfon un arall atoch."
     settings:
       title: Golygu fy ngosodiadau
       secondary_intro_html: 'Yn ôl i dudalen <a href="%{url}">fy nghyfrif</a>.'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -478,21 +478,23 @@ en:
       button_label: Change my password
     emails:
       layout:
-        purpose: You're receiving this email as you contacted MoneyHelper.
+        purpose: You're receiving this email as you contacted the Money Advice Service and MoneyHelper.
         greeting: Hello
         signature: Regards,
         sender: MoneyHelper
         contact_html: "This is an automatically generated email – please don't reply to it. To contact <a href='https://www.moneyhelper.org.uk' style='line-height: 22px ;color:#D64E04; font-family: Arial, sans-serif; font-weight: 500; text-decoration: none;'>MoneyHelper</a>, please call us on <a href='tel:+4408001387777' style='line-height: 22px ;color:#D64E04; font-family: Arial, sans-serif; font-weight: 500; text-decoration: none;'>0800&nbsp;138&nbsp;7777</a>"
-        terms_one: "Lines are open Monday to Friday 8am - 6pm, Saturday, Sunday & Bank Holidays Closed. Calls are recorded for training and quality purposes. No responsibility is accepted for loss or damage arising from viruses or changes made to this message after it was sent"
-        terms_two: "We are MoneyHelper, a limited company registered in England and Wales. Our registered office is at 120 Holborn, London, England EC1N 2TD."
+        terms_one: "Lines are open Monday to Friday 8am - 6pm, Closed: Saturday, Sunday & Bank Holidays. Calls are free and recorded for training and quality purposes. No responsibility is accepted for loss or damage arising from viruses or changes made to this message after it was sent"
+        terms_two: "MoneyHelper is owned and maintained by the Money and Pensions Service, an arm's-length body, sponsored by the Department for Work and Pensions. Our registered office is Holborn Centre, 120 Holborn, London, England EC1N 2TD."
       reset_passwords:
         intro:  You've told us that you've forgotten your password so we've sent you this automatic email to show you how to reset it.
         step_1: 1) Visit this page on MoneyHelper website. Don't wait too long to reset your password as this link will expire for security reasons.
         link_label: Change my password
         step_2: 2) Think of a password that you will remember (but others won't) and enter that in on the website when asked.
-        step_3: 3) You will be signed in automatically so you can carry on getting advice from MoneyHelper.
+        step_3_html: |
+          <p>3) You will be taken from the Money Advice Service website to the MoneyHelper website. From here, you can navigate to the tool to sign in with your new password.</p>
+          <p>Or go straight to your account using the <a href="https://www.moneyhelper.org.uk/en/users/sign-in">sign in page</a>.</p>
         expired_token_tip: "What to do if your reset password link (above) has expired:"
-        expired_token_tip_steps_html: 'Go back to the <a href="%{url}">Forgotten Password page</a> and input your email address again so that we can send you another one.'
+        expired_token_tip_steps_html: 'Go back to the <a href="https://www.moneyhelper.org.uk/en/users/password">Forgotten Password page</a> and input your email address again so that we can send you another one.'
     settings:
       title: Edit my settings
       secondary_intro_html: "Back to my <a href=\"%{url}\">account page</a>."


### PR DESCRIPTION
Alters embedded links to ensure they direct the customer to the correct,
Money Helper equivalent.

https://maps.tpondemand.com/entity/12762-update-password-reset-for-mas-tools