### PR TITLE
Force builds for Nokogiri

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -15,6 +15,8 @@ CI_EXECUTOR_NUMBER=${EXECUTOR_NUMBER-0}
 # remove prior dirty packaged gems e.g. build.sh
 rm -rf vendor/cache .bundle/config
 
+# due to glibc being lesser than the required for nokogiri pre-build extensions
+bundle config force_ruby_platform true
 bundle install --jobs $BUNDLE_JOBS
 bower cache clean
 rm -rf vendor/assets/bower_components


### PR DESCRIPTION
This is due to our environments having a lesser glibc version.