### PR TITLE
Make email address case insensitive when signing in

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -93,6 +93,13 @@ class User < ActiveRecord::Base
     send(method) if respond_to?(method)
   end
 
+  def self.find_for_authentication(tainted_conditions)
+    if tainted_conditions.key?(:email)
+      tainted_conditions[:email] = tainted_conditions[:email].strip.downcase
+    end
+    find_first_by_auth_conditions(tainted_conditions)
+  end
+
   private
 
   def compute_blind_index

--- a/features/sign_in.feature
+++ b/features/sign_in.feature
@@ -19,6 +19,10 @@ Feature: Sign in
     Then I should remain signed out
     And  I should receive a "Invalid email or password." validation message
 
+  Scenario: Sign in with email address with different case
+    When I sign in with the same email address ALL IN UPPERCASE
+    Then I should be signed in
+
   Scenario: Sign in elsewhere
     Given I am signed in
     When  I sign in elsewhere

--- a/features/step_definitions/sign_in_steps.rb
+++ b/features/step_definitions/sign_in_steps.rb
@@ -15,6 +15,15 @@ When(/^I (?:sign|am signed) in$/) do
   sign_in_page.submit.click
 end
 
+When("I sign in with the same email address ALL IN UPPERCASE") do
+  @user = @user || create(:user)
+
+  sign_in_page.load(locale: 'en')
+  sign_in_page.email.set @user.email.upcase
+  sign_in_page.password.set @user.password
+  sign_in_page.submit.click
+end
+
 Then(/^I should receive a "(.*?)" notification$/) do |notification|
   expect(page.html).to include(notification)
 end


### PR DESCRIPTION
Devise `case_insensitive_keys` doesn't work with `attr_encrypted` for some reason.

This fix just overrides devise User finder and drops the email case.
