### PR TITLE
Scroll to iframe top when clicking "Back to top" links

### DIFF
--- a/app/assets/javascripts/syndication/iframeScroller.js
+++ b/app/assets/javascripts/syndication/iframeScroller.js
@@ -1,7 +1,15 @@
 document.addEventListener("DOMContentLoaded", function(event) {
-  // this only works because the parent in AEM receives the message
-  // and has code to act on it
-  if (window.parent && window.parent.postMessage) {
-    window.parent.postMessage({scrollToTop: true}, '*');
+  const sendScrollToTopMessage = () => {
+    if (window.parent && window.parent.postMessage) {
+      // this only works because the parent in AEM receives the message
+      // and has code to act on it
+      window.parent.postMessage({scrollToTop: true}, '*');
+    }
   }
+
+  sendScrollToTopMessage()
+
+  document.getElementsByClassName("back_to_top__link").forEach((element) => {
+    element.addEventListener("click", () => { sendScrollToTopMessage() })
+  })
 });

--- a/app/assets/javascripts/syndication/iframeScroller.js
+++ b/app/assets/javascripts/syndication/iframeScroller.js
@@ -1,5 +1,5 @@
 document.addEventListener("DOMContentLoaded", function(event) {
-  const sendScrollToTopMessage = () => {
+  function sendScrollToTopMessage () {
     if (window.parent && window.parent.postMessage) {
       // this only works because the parent in AEM receives the message
       // and has code to act on it
@@ -9,7 +9,9 @@ document.addEventListener("DOMContentLoaded", function(event) {
 
   sendScrollToTopMessage()
 
-  document.getElementsByClassName("back_to_top__link").forEach((element) => {
-    element.addEventListener("click", () => { sendScrollToTopMessage() })
-  })
+  var elements = document.getElementsByClassName("back_to_top__link")
+  for (var i = 0; i < elements.length; i++) {
+    var element = elements[i]
+    element.addEventListener("click", function() { sendScrollToTopMessage() })
+  }
 });


### PR DESCRIPTION
This PR adds javascript to intercept any clicks to "Back to top" style buttons and sends a message to the parent window (if any) to tell it to scroll the iframe to the top.

AEM will intercept this message and do the scrolling in javascript.

**Target Process ticket**

[Link to ticket](https://dev.azure.com.mcas.ms/moneyandpensionsservice/Digital%20Experience%20Platform%20-%20AEM/_workitems/edit/2497)

**Summary**

PACs Tool: Back to filters does not scroll parent

**QA / Testing**


- Go to this page: https://www.moneyhelper.org.uk/en/everyday-money/banking/use-our-compare-bank-account-fees-and-charges-tool
- Scroll all the way to the bottom of the page, then to the bottom of the iframe, and then press "Back to filters".
- You should now be scrolled to the top of the iframe.

**Checklist**

Make sure that when your PR is good to be reviewed you check the below checks:

+ [ ] Tests passed.
+ [ ] Rubocop is passing for this PR (or any other lint like JShint).
+ [ ] Code Climate passed for this PR.
+ [ ] Commit history reviewed (clear commit messages).
