### PR TITLE
Ensure emails use correct asset host

### DIFF
--- a/app/views/layouts/email.html.erb
+++ b/app/views/layouts/email.html.erb
@@ -79,7 +79,7 @@
               <br clear="all">
               <br clear="all">
               <%= link_to root_url(locale: I18n.locale), style: 'text-decoration: none;'  do %>
-                <img src="<%= asset_url("emails/moneyhelper_#{I18n.locale}.png") %>" alt="MoneyHelper Logo" border="0" class="col-3-img" hspace="0" id="logo" vspace="0" width="200" style="vertical-align:top; padding-bottom: 12px;">
+                <%= image_tag("emails/moneyhelper_#{I18n.locale}.png", alt: 'MoneyHelper logo', border: 0, class: 'col-3-img', hspace: 0, id: 'logo', style: 'vertical-align:top; padding-bottom:12px;', vspace: 0, width: 200  ) %>
               <% end %>
               <br clear="all">
               <br clear="all">

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -88,6 +88,7 @@ Rails.application.configure do
   config.session_store :active_record_store
 
   config.action_mailer.default_url_options = {:host => "#{ENV['MAS_ENVIRONMENT'] == 'qa' ? 'qa.test.' : 'partner-tools.'}moneyhelper.org.uk"}
+  config.action_mailer.asset_host = ENV['FRONTEND_ASSET_HOST_URL']
 
   # Custom configuration options for feedback settings
   config.feedback_delivery_method = :sendmail


### PR DESCRIPTION
These legacy versions of rails require the asset host to be specified
under the mailer config too.