### PR TITLE
Upgrade dough-ruby to fix broken email share links

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ gem 'websocket-extensions', '>= 0.1.5'
 # Dependencies
 gem 'adal', git: 'git@github.com:moneyadviceservice/azure-activedirectory-library-for-ruby'
 gem 'cream', '2.1.8'
-gem 'dough-ruby', git: 'git@github.com:moneyadviceservice/dough.git', branch: 'PostMessages_v5.45', ref: '2294f78'
+gem 'dough-ruby', git: 'git@github.com:moneyadviceservice/dough.git', branch: 'PostMessages_v5.45'
 gem 'mas-cms-client', '1.20.1'
 gem 'site_search', '0.3.0'
 # Tools

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,8 +15,7 @@ GIT
 
 GIT
   remote: git@github.com:moneyadviceservice/dough.git
-  revision: 2294f781317831d6e64b33fd2d63474ccce3c05b
-  ref: 2294f78
+  revision: da95aee3c884cd55a046960b01cedfbd7e56e307
   branch: PostMessages_v5.45
   specs:
     dough-ruby (5.45.0)


### PR DESCRIPTION
https://github.com/moneyadviceservice/dough/pull/348
