### PR TITLE
Account improvements

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -4,7 +4,14 @@ class PasswordsController < Devise::PasswordsController
   private
 
   def after_resetting_password_path_for(*)
-    session[:user_return_to] || root_path
+    case session[:user_return_to]
+    when /money-manager/
+      money_helper_url_for('/en/benefits/universal-credit/money-manager-my-profile')
+    when /budget-planner/
+      money_helper_url_for('/en/everyday-money/budgeting/budget-planner-my-profile')
+    else
+      money_helper_url_for('/en/users/my-profile')
+    end
   end
 
   def set_flash_message(key, kind, options = {})
@@ -12,5 +19,9 @@ class PasswordsController < Devise::PasswordsController
 
     flash[:success] = flash[:notice]
     flash.delete(:notice)
+  end
+
+  def money_helper_url_for(path)
+    "#{ENV.fetch('MONEY_HELPER_URL')}#{path}"
   end
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -29,7 +29,7 @@ class RegistrationsController < Devise::RegistrationsController
   private
 
   def after_sign_up_path_for(*)
-    session[:user_return_to] || root_path
+    session[:user_return_to] || edit_profile_path
   end
 
   def configure_permitted_parameters

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -27,14 +27,10 @@ class SessionsController < Devise::SessionsController
   end
 
   def after_sign_in_path_for(*)
-    last_known_path_or_root_path
+    session[:user_return_to] || edit_profile_path
   end
 
-  def after_sign_out_path_for(*)
-    last_known_path_or_root_path
-  end
-
-  def last_known_path_or_root_path
-    session[:user_return_to] || root_path
+  def after_sign_out_path_for(resource_name)
+    session[:user_return_to] || new_session_path(resource_name)
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -87,7 +87,20 @@ Rails.application.configure do
   # Configure active record session store.
   config.session_store :active_record_store
 
-  config.action_mailer.default_url_options = {:host => "#{ENV['MAS_ENVIRONMENT'] == 'qa' ? 'qa.test.' : 'partner-tools.'}moneyhelper.org.uk"}
+  config.action_mailer.default_url_options = {
+    protocol: 'https',
+    host: case ENV['MAS_ENVIRONMENT']
+          when 'production'
+            'partner-tools'
+          when 'uat'
+            'uat-partner-tools'
+          when 'staging'
+            'staging-partner-tools'
+          else
+            'qa.test'
+          end + '.moneyhelper.org.uk'
+  }
+
   config.action_mailer.asset_host = ENV['FRONTEND_ASSET_HOST_URL']
 
   # Custom configuration options for feedback settings

--- a/features/step_definitions/change_password_steps.rb
+++ b/features/step_definitions/change_password_steps.rb
@@ -1,6 +1,11 @@
 Then(/^I should be able to change my password$/) do
   change_password_page.password.set 'securePassword'
   change_password_page.password_confirmation.set 'securePassword'
-  change_password_page.submit.click 
-  step 'I should be signed in'
+
+  # rack-test does not handle external redirects so verify this way
+  begin
+    change_password_page.submit.click
+  rescue ActionController::RoutingError
+    expect(current_url).to eq('https://www.moneyhelper.org.uk/en/users/my-profile')
+  end
 end

--- a/features/step_definitions/registration_steps.rb
+++ b/features/step_definitions/registration_steps.rb
@@ -36,7 +36,7 @@ Then(/^I should (?:be|remain) signed out$/) do
 end
 
 Then(/^I should be at the home page$/) do
-  expect(page.current_path).to eql('/en')
+  expect(page.current_path).to eql('/en/users/profile/edit')
 end
 
 Then(/^I should see an "(.*?)" notification$/) do |notification|


### PR DESCRIPTION
Various improvements to the accounts and tools integrations:

Resolve redirects after account actions

Ensure we never attempt to redirect back to the root path when an account
action is completed. The root path will always be a partner tools URL that
then issues further redirects back to MoneyHelper. In the case of password
resets, we need to redirect back into the embedded environment as due to
constraints when passing tokens via AEM pages, we have to link directly to
the password reset journey outside of AEM and redirect back into it upon
successful reset.

Improve resolution of mailer URLs

This will ensure that production-like environments can resolve to the 
correct URL required for completing the password reset journey and others.