### PR TITLE
Add flash messages to syndicated layout

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -1,6 +1,13 @@
 class PasswordsController < Devise::PasswordsController
   skip_before_action :store_location
 
+  # default this as syndicated for now to ensure flash is added
+  # but in theory we ought to default this across the board now
+  # since tools and content are only ever embedded or 'syndicated'
+  def syndicated_tool_request?
+    true
+  end
+
   private
 
   def after_resetting_password_path_for(*)

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -4,7 +4,7 @@
   <p><%= t("authentication.edit_password_page.steps") %></p>
 
   <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, class: 'form' }) do |f| %>
-    <%= devise_error_messages! %>
+    <%= render "devise/shared/error_messages", resource: resource %>
     <%= f.hidden_field :reset_password_token %>
 
     <div class="registration__row">

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -8,7 +8,7 @@
   <p><%= t("authentication.reset_password_page.instructions") %></p>
 
   <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: 'form' }) do |f| %>
-    <%= devise_error_messages! %>
+    <%= render "devise/shared/error_messages", resource: resource %>
 
     <div class="registration__row">
       <div class="registration__field">

--- a/app/views/layouts/syndicated.html.erb
+++ b/app/views/layouts/syndicated.html.erb
@@ -1,5 +1,6 @@
 <%= render layout: 'layouts/base' do %>
   <a class="skip-to-link" href="<%= t('footer.accessibility_link') %>">Accessibility Statement</a>
 
+  <%= render 'shared/alerts' if alerts? %>
   <%= yield %>
 <% end %>


### PR DESCRIPTION
Flash messages were never added to syndicated tools so in certain cases actions
could be confusing to the end user. For example, during the password reset
journey the customer submits their email and is then redirected to the sign in
page, without any further notification context. Adding the flash messages means
the user is well informed.