### PR TITLE
Permit signout via GET

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -224,7 +224,7 @@ Devise.setup do |config|
   # config.navigational_formats = ['*/*', :html]
 
   # The default HTTP method used to sign out a resource. Default is :delete.
-  config.sign_out_via = :delete
+  config.sign_out_via = %i(get delete)
 
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting


### PR DESCRIPTION
This can solve the phantom requests issues after signing out using
specific versions of safari.