### PR TITLE
Workaround for IE11 bug where <img> inside <label> doesn't work

### DIFF
--- a/app/assets/javascripts/modules/IE11ImageLabelFix.js
+++ b/app/assets/javascripts/modules/IE11ImageLabelFix.js
@@ -1,0 +1,48 @@
+define(["module"], function (module) {
+  "use strict";
+
+  function getInternetExplorerVersion() {
+    var rv = -1;
+    if (navigator.appName == "Microsoft Internet Explorer") {
+      var ua = navigator.userAgent;
+      var re = new RegExp("MSIE ([0-9]{1,}[\\.0-9]{0,})");
+      if (re.exec(ua) != null) rv = parseFloat(RegExp.$1);
+    } else if (navigator.appName == "Netscape") {
+      var ua = navigator.userAgent;
+      var re = new RegExp("Trident/.*rv:([0-9]{1,}[\\.0-9]{0,})");
+      if (re.exec(ua) != null) rv = parseFloat(RegExp.$1);
+    }
+    return rv;
+  }
+
+  window.onload = function () {
+    if (getInternetExplorerVersion()) {
+      var labels = document.getElementsByTagName("label");
+      for (var i = 0; i < labels.length; i++) {
+        var label = labels[i];
+        var labelImages = label.getElementsByTagName("img");
+
+        for (var a = 0; a < labelImages.length; a++) {
+          var labelImage = labelImages[a];
+          labelImage.forid = label.htmlFor;
+          labelImage.onclick = function () {
+            var e = document.getElementById(this.forid);
+            switch (e.type) {
+              case "radio":
+                e.checked |= 1;
+                break;
+              case "checkbox":
+                e.checked = !e.checked;
+                break;
+              case "text":
+              case "password":
+              case "textarea":
+                e.focus();
+                break;
+            }
+          };
+        }
+      }
+    }
+  };
+});

--- a/app/assets/javascripts/modules/common.js
+++ b/app/assets/javascripts/modules/common.js
@@ -1,6 +1,6 @@
 // MAS.bootstrap.I18n_locale == en || cy == file path in require config
 define(
-  ['jquery', 'globals', 'pubsub', 'log', 'i18n'],
+  ['jquery', 'globals', 'pubsub', 'log', 'i18n', 'IE11ImageLabelFix'],
   function($, globals, pubsub, log, i18n) {
     'use strict';
 

--- a/app/assets/javascripts/require_config.js.erb
+++ b/app/assets/javascripts/require_config.js.erb
@@ -11,6 +11,7 @@
 //= depend_on_asset modules/common
 //= depend_on_asset modules/log
 //= depend_on_asset modules/i18n
+//= depend_on_asset modules/IE11ImageLabelFix
 
 //= depend_on_asset modules/mas_pubsub
 //= depend_on_asset modules/mas_scrollTracking
@@ -67,6 +68,7 @@
       common: requirejs_path('modules/common'),
       globals: requirejs_path('modules/globals'),
       i18n: requirejs_path('modules/i18n'),
+      IE11ImageLabelFix: requirejs_path('modules/IE11ImageLabelFix'),
       log: requirejs_path('modules/log'),
       pubsub: requirejs_path('modules/mas_pubsub'),
       scrollTracking: requirejs_path('modules/mas_scrollTracking'),

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -32,6 +32,7 @@ Rails.application.configure do
                                    modules/log.js
                                    modules/mas_collapsable.js
                                    modules/mas_cookieController.js
+                                   modules/IE11ImageLabelFix.js
                                    modules/mas_pubsub.js
                                    modules/mas_scrollTracking.js
                                    modules/mas_cookieController.js

--- a/spec/javascripts/test-main.js
+++ b/spec/javascripts/test-main.js
@@ -25,6 +25,7 @@ require.config({
     common: 'app/assets/javascripts/modules/common',
     log: 'app/assets/javascripts/modules/log',
     i18n: 'app/assets/javascripts/modules/i18n',
+    IE11ImageLabelFix: 'app/assets/javascripts/modules/IE11ImageLabelFix',
 
     pubsub: 'app/assets/javascripts/modules/mas_pubsub',
     scrollTracking: 'app/assets/javascripts/modules/mas_scrollTracking',


### PR DESCRIPTION
Images inside labels don't trigger the input specified in for="". This works around that.

References:

  - https://snook.ca/archives/javascript/using_images_as
  - https://stackoverflow.com/questions/17907445/how-to-detect-ie11

Ticket: https://dev.azure.com.mcas.ms/moneyandpensionsservice/Digital%20Experience%20Platform%20-%20AEM/_boards/board/t/Team%201%20(Core%20Capability)/Stories/?workitem=3694

- [x] Tested in `IE11` on `UAT`
