### PR TITLE
Bump budget planner for spreadsheet fixes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,14 +146,14 @@ GEM
     bowndler (1.0.2)
       thor
     bson (4.12.1)
-    budget_planner (6.0.1)
+    budget_planner (6.0.2)
       i18n-js (= 3.0.0.mas)
       js-routes (= 1.1.2)
       mas-mailer (~> 0.3)
       modernizr-rails (~> 2.6.2)
       rails (>= 4, < 5)
       sass-rails
-      spreadsheet
+      spreadsheet (= 1.2.8)
     builder (3.2.4)
     byebug (10.0.2)
     capybara (2.18.0)
@@ -457,7 +457,7 @@ GEM
     letter_opener (1.6.0)
       launchy (~> 2.2)
     link_header (0.0.8)
-    loofah (2.13.0)
+    loofah (2.14.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -726,7 +726,7 @@ GEM
       capybara (~> 2.7)
     site_search (0.3.0)
       algoliasearch
-    spreadsheet (1.3.0)
+    spreadsheet (1.2.8)
       ruby-ole
     sprockets (2.12.5)
       hike (~> 1.2)


### PR DESCRIPTION
The spreadsheet dependency broke how excel exports of budgets are
generated. Pinning that dependency seems to resolve the issues.