### PR TITLE
Enable bower cache

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -34,10 +34,6 @@ echo "Running Bundle package"
 echo "----"
 time bundle package --all
 
-echo "Purging bower components"
-echo "----"
-[ -d vendor/assets/bower_components ] && rm -r vendor/assets/bower_components
-
 echo "Running Bower update (via bowndler)"
 echo "----"
 time bowndler update --production --config.interactive=false

--- a/build.sh
+++ b/build.sh
@@ -34,10 +34,6 @@ echo "Running Bundle package"
 echo "----"
 time bundle package --all
 
-echo "Running Bower cache clean"
-echo "----"
-time bower cache clean
-
 echo "Purging bower components"
 echo "----"
 [ -d vendor/assets/bower_components ] && rm -r vendor/assets/bower_components

--- a/build.sh
+++ b/build.sh
@@ -34,6 +34,10 @@ echo "Running Bundle package"
 echo "----"
 time bundle package --all
 
+echo "Purging bower components"
+echo "----"
+[ -d vendor/assets/bower_components ] && rm -r vendor/assets/bower_components
+
 echo "Running Bower update (via bowndler)"
 echo "----"
 time bowndler update --production --config.interactive=false

--- a/test.sh
+++ b/test.sh
@@ -18,6 +18,7 @@ rm -rf vendor/cache .bundle/config
 # due to glibc being lesser than the required for nokogiri pre-build extensions
 bundle config build.nokogiri --use-system-libraries
 bundle install --jobs $BUNDLE_JOBS
+rm -rf vendor/assets/bower_components
 bowndler update --production --config.interactive=false
 
 npm install -q

--- a/test.sh
+++ b/test.sh
@@ -18,7 +18,6 @@ rm -rf vendor/cache .bundle/config
 # due to glibc being lesser than the required for nokogiri pre-build extensions
 bundle config build.nokogiri --use-system-libraries
 bundle install --jobs $BUNDLE_JOBS
-bower cache clean
 rm -rf vendor/assets/bower_components
 bowndler update --production --config.interactive=false
 

--- a/test.sh
+++ b/test.sh
@@ -18,7 +18,6 @@ rm -rf vendor/cache .bundle/config
 # due to glibc being lesser than the required for nokogiri pre-build extensions
 bundle config build.nokogiri --use-system-libraries
 bundle install --jobs $BUNDLE_JOBS
-rm -rf vendor/assets/bower_components
 bowndler update --production --config.interactive=false
 
 npm install -q


### PR DESCRIPTION
- Don't purge bower cache on every build
- Don't purge bower components

I'm not sure why these changes were introduced (8 and 7 years ago respectively), but I don't believe we need them.