### PR TITLE
Add a retry to the Karma test run

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -23,13 +23,7 @@ bowndler update --production --config.interactive=false
 
 npm install -q
 
-./node_modules/karma/bin/karma start spec/javascripts/karma.conf.js 2> /dev/null
-if [ $? -eq 0 ]
-then
-    echo "Karma tests passed!"
-else
-    echo "Karma tests couldn't run, probably phantomjs being stupid" >&2
-fi
+./node_modules/karma/bin/karma start spec/javascripts/karma.conf.js
 
 bundle exec rspec spec --format html --out tmp/spec.html --format RspecJunitFormatter --profile --format progress --deprecation-out log/rspec_deprecations.txt
 bundle exec cucumber

--- a/test.sh
+++ b/test.sh
@@ -23,7 +23,9 @@ bowndler update --production --config.interactive=false
 
 npm install -q
 
-./node_modules/karma/bin/karma start spec/javascripts/karma.conf.js
+for i in 1 2 3 4 5; do
+  ./node_modules/karma/bin/karma start spec/javascripts/karma.conf.js && break
+done
 
 bundle exec rspec spec --format html --out tmp/spec.html --format RspecJunitFormatter --profile --format progress --deprecation-out log/rspec_deprecations.txt
 bundle exec cucumber


### PR DESCRIPTION
This is because a bug in Karma is causing the tests to fail on occasion. This only occurs on slower CPUs (like in CI).


Also, remove redundant logging.


