### PR TITLE
Fix issue with mounted tools

### DIFF
--- a/app/controllers/mount_controller.rb
+++ b/app/controllers/mount_controller.rb
@@ -2,6 +2,11 @@ class MountController < ApplicationController
   include Navigation
   before_action :set_categories
 
+  def canonical
+    nil
+  end
+  helper_method :canonical
+
   protected
 
   def alternate_url


### PR DESCRIPTION
The canonical was missing thus causing issues in production when mounted
a cost calculator builder derived tool. I'll come back and add
integration features around this so we don't regress in future.