### PR TITLE
Enable budget banner warning for pension calc

### DIFF
--- a/config/budget_warning_tools.yml
+++ b/config/budget_warning_tools.yml
@@ -1,2 +1,4 @@
 - /en/tools/redundancy-pay-calculator/
 - /cy/tools/cyfrifiannell-tal-diswyddo/
+- /en/tools/pension-calculator/
+- /cy/tools/cyfrifiannell-pensiwn/


### PR DESCRIPTION
This is during an investigation that's underway to determine
inaccuracies in this tool.