### PR TITLE
Configure syndicated logo per locale

### DIFF
--- a/app/assets/javascripts/syndication/tools.js.coffee
+++ b/app/assets/javascripts/syndication/tools.js.coffee
@@ -5,12 +5,20 @@
   targetSelector: "mas-widget"
   containerClass: "mas-widget-container"
   containerStyles: "width: 100%; margin: 0 auto;"
-  linkClass: "mas-widget-logo-link"
-  linkHref: "https://www.moneyhelper.org.uk/en"
-  linkTarget: "_blank"
-  logoSrc: "https://www.moneyhelper.org.uk/etc.clientlibs/maps/core/clientlibs/clientlib-base/resources/logos/logo-en-desktop.svg"
-  logoStyles: "display: block; margin-bottom: 8px; width: 300px"
-  logoAltText: "MoneyHelper"
+  en:
+    linkClass: "mas-widget-logo-link"
+    linkHref: "https://www.moneyhelper.org.uk/en"
+    linkTarget: "_blank"
+    logoSrc: "https://www.moneyhelper.org.uk/etc.clientlibs/maps/core/clientlibs/clientlib-base/resources/logos/logo-en-desktop.svg"
+    logoStyles: "display: block; margin-bottom: 8px; width: 300px"
+    logoAltText: "MoneyHelper"
+  cy:
+    linkClass: "mas-widget-logo-link"
+    linkHref: "https://www.moneyhelper.org.uk/cy"
+    linkTarget: "_blank"
+    logoSrc: "https://www.moneyhelper.org.uk/etc.clientlibs/maps/core/clientlibs/clientlib-base/resources/logos/logo-cy-desktop.svg"
+    logoStyles: "display: block; margin-bottom: 8px; width: 300px"
+    logoAltText: "HelpwrArian"
 
   toolConfig:
     employer_best_practices:

--- a/app/assets/javascripts/syndication/widget.js.coffee
+++ b/app/assets/javascripts/syndication/widget.js.coffee
@@ -7,7 +7,7 @@ class window.PartnerMAS.Widget
   render: ->
     this.setPartnerToolsURL()
     renderParts = []
-    renderParts.push(this.createLogo()) unless this.dataAttr("omit_logo")
+    renderParts.push(this.createLogo(masConfig.getLocale(@targetNode))) unless this.dataAttr("omit_logo")
     renderParts.push(this.createIFrame())
     renderParts.push(this.createGAIFrame()) if masConfig.gaIframeRequired(@targetNode)
     this.addToDocument this.createContainer(renderParts...)
@@ -40,10 +40,10 @@ class window.PartnerMAS.Widget
         </div>
         """
 
-  createLogo: ->
+  createLogo: (locale)->
     """
-        <a class='#{masConfig.linkClass}' href='#{masConfig.linkHref}' target='#{masConfig.linkTarget}'>
-          <img src='#{masConfig.logoSrc}' alt='#{masConfig.logoAltText}' style='#{masConfig.logoStyles}'/>
+        <a class='#{masConfig[locale].linkClass}' href='#{masConfig[locale].linkHref}' target='#{masConfig[locale].linkTarget}'>
+          <img src='#{masConfig[locale].logoSrc}' alt='#{masConfig[locale].logoAltText}' style='#{masConfig[locale].logoStyles}'/>
         </a>
         """
 


### PR DESCRIPTION
The logo when syndicated was never configured to determine the
contextual locale meaning it was displayed in the EN version when the
tools are syndicated CY.