### PR TITLE
Correct `X-Frame-Options` header

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -109,7 +109,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_syndicated_x_frame
-    response.headers['X-Frame-Options'] = 'ALLOWALL' if syndicated_tool_request?
+    response.headers.delete('X-Frame-Options') if syndicated_tool_request?
   end
 
   # This layout chops off the header and footer

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe ApplicationController, type: :controller do
       expect(subject).to render_template('layouts/syndicated')
     end
 
-    it 'sets x frame options to ALLOWALL' do
-      expect(subject.headers['X-Frame-Options']).to eql('ALLOWALL')
+    it 'strips the frame options header to allow all by default' do
+      expect(subject.headers['X-Frame-Options']).to be_nil
     end
   end
 


### PR DESCRIPTION
ALLOWALL is considered the default so we can strip the header from the response rather than providing the value. This resolves issues in various browsers that report this misconfiguration.