### PR TITLE
Don't add the `Secure` token to cookies

### DIFF
--- a/app/middleware/partner_tools_cookies.rb
+++ b/app/middleware/partner_tools_cookies.rb
@@ -14,9 +14,8 @@ class PartnerToolsCookies
 
       cookies.each do |cookie|
         next if cookie.blank?
-        next if cookie =~ /;\s*secure/i
 
-        cookie << '; Secure; SameSite=None'
+        cookie << '; SameSite=None'
       end
 
       headers['Set-Cookie'] = cookies.join(COOKIE_SEPARATOR)

--- a/spec/middleware/partner_tools_cookies_spec.rb
+++ b/spec/middleware/partner_tools_cookies_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe PartnerToolsCookies do
       allow_any_instance_of(Rack::Request).to receive(:ssl?) { true }
     end
 
-    it 'set secure and SameSite to None' do
+    it 'adds SameSite' do
       get '/'
-      expect(last_response.headers['Set-Cookie']).to eq "v=1; Secure; SameSite=None"
+      expect(last_response.headers['Set-Cookie']).to eq "v=1; SameSite=None"
     end
   end
 end


### PR DESCRIPTION
In production environments due to the configuration of `force_ssl` this is added by Rails automatically. There was some incompatibility with this middleware and the tweaked settings. We can now always assume the `Secure` token is added in the necessary environments.
