### PR TITLE
Only check landing pages on GET

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -139,7 +139,7 @@ group :test do
   gem 'tidy-html5'
   gem 'timecop'
   gem 'vcr'
-  gem 'webmock'
+  gem 'webmock', '~> 3.5.0'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,8 +124,8 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.2, >= 1.2.10)
-    addressable (2.7.0)
-      public_suffix (>= 2.0.2, < 5.0)
+    addressable (2.8.1)
+      public_suffix (>= 2.0.2, < 6.0)
     advice_plans (4.1.1)
       dough-ruby (~> 5.36)
       friendly_id (>= 5.1.0)
@@ -215,8 +215,8 @@ GEM
       dough-ruby (~> 5.36)
       friendly_id (>= 5.1.0)
       rails (>= 4, < 5)
-    crack (0.4.3)
-      safe_yaml (~> 1.0.0)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     cream (2.1.8)
       faraday (>= 0.9)
@@ -423,7 +423,7 @@ GEM
       execjs (>= 1.2.9)
       sprockets (>= 2.0.3)
       tilt
-    hashdiff (0.3.7)
+    hashdiff (1.0.1)
     hashie (2.0.5)
     hike (1.2.3)
     historyjs-rails (1.0.1)
@@ -604,7 +604,7 @@ GEM
       interception (>= 0.5)
       pry
     psych (3.0.2)
-    public_suffix (4.0.1)
+    public_suffix (5.0.1)
     puma (6.0.0)
       nio4r (~> 2.0)
     quiz (1.4.0)
@@ -672,6 +672,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
+    rexml (3.2.5)
     roadie (2.4.3)
       actionmailer (> 3.0.0, < 5.0.0)
       css_parser (~> 1.3.4)
@@ -727,7 +728,6 @@ GEM
       json (~> 2.1)
       structured_warnings (~> 0.3)
     rubyzip (1.3.0)
-    safe_yaml (1.0.4)
     sass (3.2.19)
     sass-rails (4.0.5)
       railties (>= 4.0.0, < 5.0)
@@ -812,7 +812,7 @@ GEM
     vcr (4.0.0)
     warden (1.2.7)
       rack (>= 1.0)
-    webmock (3.3.0)
+    webmock (3.5.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
@@ -948,7 +948,7 @@ DEPENDENCIES
   uglifier
   universal_credit!
   vcr
-  webmock
+  webmock (~> 3.5.0)
   websocket-extensions (>= 0.1.5)
   whenever
   wpcc (~> 3.1.0)

--- a/app/controllers/embedded_tools_controller.rb
+++ b/app/controllers/embedded_tools_controller.rb
@@ -11,7 +11,7 @@ class EmbeddedToolsController < ApplicationController
   end
 
   def cookies_checked?
-    params[:checked] == 'true'
+    request.post? || params[:checked] == 'true'
   end
 
   def default_url_options(options = {})

--- a/spec/cassettes/webservices_capnetwork_co_uk/post/CAPDVLA_Webservice/CAPDVLA_asmx/DVLALookupVRM.yml
+++ b/spec/cassettes/webservices_capnetwork_co_uk/post/CAPDVLA_Webservice/CAPDVLA_asmx/DVLALookupVRM.yml
@@ -1,0 +1,90 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://webservices.capnetwork.co.uk/CAPDVLA_Webservice/CAPDVLA.asmx/DVLALookupVRM
+    body:
+      encoding: UTF-8
+      string: Password=ghaj7a&SubscriberID=170796&vrm=AC+63+UFO
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (darwin22 arm64) ruby/2.7.7p221
+      Content-Length:
+      - '49'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - webservices.capnetwork.co.uk
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/xml; charset=utf-8
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Tue, 07 Mar 2023 12:47:21 GMT
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<RESPONSE>\r\n  <SUCCESS>true</SUCCESS>\r\n
+        \ <ERRORMESSAGE>\r\n  </ERRORMESSAGE>\r\n  <TIMESTAMP>07/03/2023 12:47:21</TIMESTAMP>\r\n
+        \ <AUDITID>122509074</AUDITID>\r\n  <LOOKUP_VRM>AC 63 UFO</LOOKUP_VRM>\r\n
+        \ <LOOKUP_VIN />\r\n  <MONTHLYLOOKUPLIMITEXCEEDED>False</MONTHLYLOOKUPLIMITEXCEEDED>\r\n
+        \ <AUTOCORRECTED>False</AUTOCORRECTED>\r\n  <AUTOCORRECTEDREASON>\r\n  </AUTOCORRECTEDREASON>\r\n
+        \ <MATCHLEVEL>\r\n    <DVLA>1</DVLA>\r\n    <DVLAKEEPER>1</DVLAKEEPER>\r\n
+        \   <DVLABASIC>1</DVLABASIC>\r\n    <SMMT>0</SMMT>\r\n    <CAP>1</CAP>\r\n
+        \   <ALTERNATIVEVRMS>0</ALTERNATIVEVRMS>\r\n    <ALTERNATIVEDERIVATIVES>0</ALTERNATIVEDERIVATIVES>\r\n
+        \ </MATCHLEVEL>\r\n  <DATA>\r\n    <DVLA>\r\n      <VRM>AC63UFO</VRM>\r\n
+        \     <VIN>WDD2053872F826224</VIN>\r\n      <MANUFACTURER>MERCEDES-BENZ</MANUFACTURER>\r\n
+        \     <MODEL>AMG C 63 S PREMIUM + AUTO</MODEL>\r\n      <FUELTYPE>Petrol</FUELTYPE>\r\n
+        \     <BODYTYPE>Coupe</BODYTYPE>\r\n      <DOORS>2</DOORS>\r\n      <SEATING>4</SEATING>\r\n
+        \     <WHEELPLAN>2 Axle Rigid Body</WHEELPLAN>\r\n      <REGISTRATIONDATE>20181130</REGISTRATIONDATE>\r\n
+        \     <MANUFACTUREDDATE>20181130</MANUFACTUREDDATE>\r\n      <FIRSTREG_DATE>20181130</FIRSTREG_DATE>\r\n
+        \     <FIRSTREG_USEDBEFORE>0</FIRSTREG_USEDBEFORE>\r\n      <CO2>230</CO2>\r\n
+        \     <ENGINECAPACITY>3982</ENGINECAPACITY>\r\n      <ENGINENUMBER>17798060071786</ENGINENUMBER>\r\n
+        \     <ISSCRAPPED>No</ISSCRAPPED>\r\n      <SCRAPPEDDATE>\r\n      </SCRAPPEDDATE>\r\n
+        \     <ISEXPORTED>No</ISEXPORTED>\r\n      <EXPORTEDDATE>\r\n      </EXPORTEDDATE>\r\n
+        \     <ISIMPORTED>No</ISIMPORTED>\r\n      <IMPORTEDDATE>\r\n      </IMPORTEDDATE>\r\n
+        \     <COLOUR>BLACK</COLOUR>\r\n      <MASSINSERVICE>1820</MASSINSERVICE>\r\n
+        \     <MAXMASS>2205</MAXMASS>\r\n      <MAXNETPOWER>375</MAXNETPOWER>\r\n
+        \     <MAXTOW_BRAKED>\r\n      </MAXTOW_BRAKED>\r\n      <MAXTOW_UNBRAKED>\r\n
+        \     </MAXTOW_UNBRAKED>\r\n      <SOUNDLEVEL_STATIONARY>88</SOUNDLEVEL_STATIONARY>\r\n
+        \     <SOUNDLEVEL_ENGINE>3750</SOUNDLEVEL_ENGINE>\r\n      <SOUNDLEVEL_DRIVEBY>74</SOUNDLEVEL_DRIVEBY>\r\n
+        \     <PREVIOUSAQUISITION>20220413</PREVIOUSAQUISITION>\r\n      <PREVIOUSDISPOSAL>20220126</PREVIOUSDISPOSAL>\r\n
+        \     <PREVIOUSKEEPERS>1</PREVIOUSKEEPERS>\r\n      <CHERISHEDTRANSFERMARKER>Yes</CHERISHEDTRANSFERMARKER>\r\n
+        \     <TRANSFERDATE>20220418</TRANSFERDATE>\r\n    </DVLA>\r\n    <CAP>\r\n
+        \     <VEHICLETYPE_ID>1</VEHICLETYPE_ID>\r\n      <VEHICLETYPE>Car</VEHICLETYPE>\r\n
+        \     <CAPID>86391</CAPID>\r\n      <CAPCODE>MECC40PP32CPTA  2   </CAPCODE>\r\n
+        \     <ENHANCEDCAPCODE>0108639120191201201912010303424700072170</ENHANCEDCAPCODE>\r\n
+        \     <ENHANCEDCAPCODE_IDENTIFIER>010863912019120120191201</ENHANCEDCAPCODE_IDENTIFIER>\r\n
+        \     <ENHANCEDCAPCODE_TECNICAL>0303424700072170</ENHANCEDCAPCODE_TECNICAL>\r\n
+        \     <MANUFACTURER_CODE>5509</MANUFACTURER_CODE>\r\n      <MANUFACTURER>MERCEDES-BENZ</MANUFACTURER>\r\n
+        \     <RANGE_CODE>160</RANGE_CODE>\r\n      <RANGE>C CLASS</RANGE>\r\n      <MODEL_CODE>89965</MODEL_CODE>\r\n
+        \     <MODEL>C CLASS AMG COUPE</MODEL>\r\n      <MODELDATEDESC_SHORT>(18 ----)</MODELDATEDESC_SHORT>\r\n
+        \     <MODELDATEDESC_LONG>(2018 ----)</MODELDATEDESC_LONG>\r\n      <DERIVATIVE>C63
+        S Premium Plus 2dr 9G-Tronic</DERIVATIVE>\r\n      <DERIVATIVEDATEDESC_SHORT>(18
+        - 20)</DERIVATIVEDATEDESC_SHORT>\r\n      <DERIVATIVEDATEDESC_LONG>(2018 -
+        2020)</DERIVATIVEDATEDESC_LONG>\r\n      <INTRODUCED>20180901</INTRODUCED>\r\n
+        \     <DISCONTINUED>20201201</DISCONTINUED>\r\n      <RUNOUTDATE>20210531</RUNOUTDATE>\r\n
+        \     <DOORS>2</DOORS>\r\n      <DRIVETRAIN>Rear Wheel Drive</DRIVETRAIN>\r\n
+        \     <FUELDELIVERY>Turbo</FUELDELIVERY>\r\n      <TRANSMISSION>Automatic</TRANSMISSION>\r\n
+        \     <FUELTYPE>Petrol</FUELTYPE>\r\n      <PLATE>2018 68</PLATE>\r\n      <PLATE_SEQNO>118</PLATE_SEQNO>\r\n
+        \     <PLATE_YEAR>2018</PLATE_YEAR>\r\n      <PLATE_MONTH>9</PLATE_MONTH>\r\n
+        \   </CAP>\r\n  </DATA>\r\n</RESPONSE>"
+    http_version:
+  recorded_at: Tue, 07 Mar 2023 12:47:22 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/webservices_capnetwork_co_uk/post/CAPNVD_Webservice/CAPNVD_asmx/GetBulkTechnicalData.yml
+++ b/spec/cassettes/webservices_capnetwork_co_uk/post/CAPNVD_Webservice/CAPNVD_asmx/GetBulkTechnicalData.yml
@@ -1,0 +1,88 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://webservices.capnetwork.co.uk/CAPNVD_Webservice/CAPNVD.asmx/GetBulkTechnicalData
+    body:
+      encoding: UTF-8
+      string: Password=ghaj7a&Subscriber_ID=170796&Database=CAR&CAPIDList=86391&SpecDateList=&TechDataList=CO2%2C+CC%2C+MPG_COMBINED%2C+MPG_URBAN%2C+MPG_EXTRAURBAN&ReturnVehicleDescription=true&ReturnCAPcodeTechnicalItems=false&ReturnCostNew=true
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (darwin22 arm64) ruby/2.7.7p221
+      Content-Length:
+      - '232'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - webservices.capnetwork.co.uk
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/xml; charset=utf-8
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Tue, 07 Mar 2023 12:47:21 GMT
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<CAPDataSetResult xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"
+        xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns=\"http://www.capnetwork.co.uk/CAPNVD/\">\r\n
+        \ <Success>true</Success>\r\n  <FailMessage />\r\n  <Returned_DataSet>\r\n
+        \   <xs:schema id=\"TechData\" xmlns=\"\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\"
+        xmlns:msdata=\"urn:schemas-microsoft-com:xml-msdata\">\r\n      <xs:element
+        name=\"TechData\" msdata:IsDataSet=\"true\" msdata:UseCurrentLocale=\"true\">\r\n
+        \       <xs:complexType>\r\n          <xs:choice minOccurs=\"0\" maxOccurs=\"unbounded\">\r\n
+        \           <xs:element name=\"Tech_Table\">\r\n              <xs:complexType>\r\n
+        \               <xs:sequence>\r\n                  <xs:element name=\"CAPID\"
+        type=\"xs:int\" minOccurs=\"0\" />\r\n                  <xs:element name=\"SpecDate\"
+        type=\"xs:dateTime\" minOccurs=\"0\" />\r\n                  <xs:element name=\"Manufacturer\"
+        type=\"xs:string\" minOccurs=\"0\" />\r\n                  <xs:element name=\"Range\"
+        type=\"xs:string\" minOccurs=\"0\" />\r\n                  <xs:element name=\"Model\"
+        type=\"xs:string\" minOccurs=\"0\" />\r\n                  <xs:element name=\"Derivative\"
+        type=\"xs:string\" minOccurs=\"0\" />\r\n                  <xs:element name=\"ModIntroduced\"
+        type=\"xs:int\" minOccurs=\"0\" />\r\n                  <xs:element name=\"ModDiscontinued\"
+        type=\"xs:int\" minOccurs=\"0\" />\r\n                  <xs:element name=\"DerIntroducted\"
+        type=\"xs:dateTime\" minOccurs=\"0\" />\r\n                  <xs:element name=\"DerDiscontinued\"
+        type=\"xs:dateTime\" minOccurs=\"0\" />\r\n                  <xs:element name=\"BodyStyle\"
+        type=\"xs:string\" minOccurs=\"0\" />\r\n                  <xs:element name=\"Basic\"
+        type=\"xs:decimal\" minOccurs=\"0\" />\r\n                  <xs:element name=\"VAT\"
+        type=\"xs:decimal\" minOccurs=\"0\" />\r\n                  <xs:element name=\"CO2\"
+        type=\"xs:string\" minOccurs=\"0\" />\r\n                  <xs:element name=\"CC\"
+        type=\"xs:string\" minOccurs=\"0\" />\r\n                  <xs:element name=\"MPG_COMBINED\"
+        type=\"xs:string\" minOccurs=\"0\" />\r\n                  <xs:element name=\"MPG_URBAN\"
+        type=\"xs:string\" minOccurs=\"0\" />\r\n                  <xs:element name=\"MPG_EXTRAURBAN\"
+        type=\"xs:string\" minOccurs=\"0\" />\r\n                </xs:sequence>\r\n
+        \             </xs:complexType>\r\n            </xs:element>\r\n          </xs:choice>\r\n
+        \       </xs:complexType>\r\n      </xs:element>\r\n    </xs:schema>\r\n    <diffgr:diffgram
+        xmlns:msdata=\"urn:schemas-microsoft-com:xml-msdata\" xmlns:diffgr=\"urn:schemas-microsoft-com:xml-diffgram-v1\">\r\n
+        \     <TechData xmlns=\"\">\r\n        <Tech_Table diffgr:id=\"Tech_Table1\"
+        msdata:rowOrder=\"0\">\r\n          <CAPID>86391</CAPID>\r\n          <SpecDate>1900-01-01T00:00:00+00:00</SpecDate>\r\n
+        \         <Manufacturer>MERCEDES-BENZ</Manufacturer>\r\n          <Range>C
+        CLASS</Range>\r\n          <Model>C CLASS AMG COUPE</Model>\r\n          <Derivative>C63
+        S Premium Plus 2dr 9G-Tronic</Derivative>\r\n          <ModIntroduced>2018</ModIntroduced>\r\n
+        \         <ModDiscontinued>0</ModDiscontinued>\r\n          <DerIntroducted>2018-09-01T00:00:00+01:00</DerIntroducted>\r\n
+        \         <DerDiscontinued>2020-12-01T00:00:00+00:00</DerDiscontinued>\r\n
+        \         <BodyStyle>Coupe</BodyStyle>\r\n          <CO2>230                                               </CO2>\r\n
+        \         <CC>3982                                              </CC>\r\n
+        \         <MPG_COMBINED>28                                                </MPG_COMBINED>\r\n
+        \         <MPG_URBAN>20.2                                              </MPG_URBAN>\r\n
+        \         <MPG_EXTRAURBAN>36.2                                              </MPG_EXTRAURBAN>\r\n
+        \       </Tech_Table>\r\n      </TechData>\r\n    </diffgr:diffgram>\r\n  </Returned_DataSet>\r\n</CAPDataSetResult>"
+    http_version:
+  recorded_at: Tue, 07 Mar 2023 12:47:22 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/webservices_capnetwork_co_uk/post/CAPUsedValues_Webservice/capusedvalues_asmx/GetUsedValuation.yml
+++ b/spec/cassettes/webservices_capnetwork_co_uk/post/CAPUsedValues_Webservice/capusedvalues_asmx/GetUsedValuation.yml
@@ -1,0 +1,65 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://webservices.capnetwork.co.uk/CAPUsedValues_Webservice/capusedvalues.asmx/GetUsedValuation
+    body:
+      encoding: UTF-8
+      string: Password=ghaj7a&Subscriber_ID=170796&CAPID=86391&CAPCode=&Database=CAR&RegistrationDate=2018%2F11%2F30&DatasetDate=2014%2F04%2F01&JustCurrent=true&Mileage=40000
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (darwin22 arm64) ruby/2.7.7p221
+      Content-Length:
+      - '160'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - webservices.capnetwork.co.uk
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/xml; charset=utf-8
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Tue, 07 Mar 2023 12:47:22 GMT
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<CAPDataSetResult xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"
+        xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns=\"http://webservices.capnetwork.co.uk\">\r\n
+        \ <Success>true</Success>\r\n  <FailMessage />\r\n  <Returned_DataSet>\r\n
+        \   <xs:schema id=\"UsedValues\" xmlns=\"\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\"
+        xmlns:msdata=\"urn:schemas-microsoft-com:xml-msdata\">\r\n      <xs:element
+        name=\"UsedValues\" msdata:IsDataSet=\"true\" msdata:UseCurrentLocale=\"true\">\r\n
+        \       <xs:complexType>\r\n          <xs:choice minOccurs=\"0\" maxOccurs=\"unbounded\">\r\n
+        \           <xs:element name=\"Valuation\">\r\n              <xs:complexType>\r\n
+        \               <xs:sequence>\r\n                  <xs:element name=\"Retail\"
+        type=\"xs:int\" minOccurs=\"0\" />\r\n                  <xs:element name=\"Clean\"
+        type=\"xs:int\" minOccurs=\"0\" />\r\n                  <xs:element name=\"Average\"
+        type=\"xs:int\" minOccurs=\"0\" />\r\n                  <xs:element name=\"Below\"
+        type=\"xs:int\" minOccurs=\"0\" />\r\n                </xs:sequence>\r\n              </xs:complexType>\r\n
+        \           </xs:element>\r\n          </xs:choice>\r\n        </xs:complexType>\r\n
+        \     </xs:element>\r\n    </xs:schema>\r\n    <diffgr:diffgram xmlns:msdata=\"urn:schemas-microsoft-com:xml-msdata\"
+        xmlns:diffgr=\"urn:schemas-microsoft-com:xml-diffgram-v1\">\r\n      <UsedValues
+        xmlns=\"\">\r\n        <Valuation diffgr:id=\"Valuation1\" msdata:rowOrder=\"0\">\r\n
+        \         <Retail>43000</Retail>\r\n          <Clean>37500</Clean>\r\n          <Average>36200</Average>\r\n
+        \         <Below>34900</Below>\r\n        </Valuation>\r\n      </UsedValues>\r\n
+        \   </diffgr:diffgram>\r\n  </Returned_DataSet>\r\n</CAPDataSetResult>"
+    http_version:
+  recorded_at: Tue, 07 Mar 2023 12:47:22 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/webservices_capnetwork_co_uk/post/CAPVehicles_Webservice/capvehicles_asmx/GetCAPMan.yml
+++ b/spec/cassettes/webservices_capnetwork_co_uk/post/CAPVehicles_Webservice/capvehicles_asmx/GetCAPMan.yml
@@ -4,38 +4,40 @@ http_interactions:
     method: post
     uri: http://webservices.capnetwork.co.uk/CAPVehicles_Webservice/capvehicles.asmx/GetCAPMan
     body:
-      encoding: US-ASCII
-      string: Subscriber_ID=170796&Password=796MAS&Database=CAR&JustCurrentManufacturers=false&BodyStyleFilter=
+      encoding: UTF-8
+      string: Password=ghaj7a&Subscriber_ID=170796&Database=CAR&JustCurrentManufacturers=false&BodyStyleFilter=
     headers:
       Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (darwin22 arm64) ruby/2.7.7p221
       Content-Length:
       - '97'
       Content-Type:
       - application/x-www-form-urlencoded
-      User-Agent:
-      - Ruby
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - webservices.capnetwork.co.uk
   response:
     status:
       code: 200
       message: OK
     headers:
       Cache-Control:
-      - private, max-age=0
+      - private
+      Transfer-Encoding:
+      - chunked
       Content-Type:
       - text/xml; charset=utf-8
       Server:
-      - Microsoft-IIS/7.5
+      - Microsoft-IIS/8.5
       X-Aspnet-Version:
-      - 2.0.50727
+      - 4.0.30319
       X-Powered-By:
       - ASP.NET
       Date:
-      - Mon, 22 Sep 2014 12:29:12 GMT
-      Content-Length:
-      - '18105'
+      - Tue, 07 Mar 2023 12:47:21 GMT
     body:
       encoding: UTF-8
       string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<CAPDataSetResult xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"
@@ -61,191 +63,223 @@ http_interactions:
         \       </Table>\r\n        <Table diffgr:id=\"Table4\" msdata:rowOrder=\"3\">\r\n
         \         <CMan_Code>1</CMan_Code>\r\n          <CMan_Name>ALFA ROMEO               </CMan_Name>\r\n
         \       </Table>\r\n        <Table diffgr:id=\"Table5\" msdata:rowOrder=\"4\">\r\n
-        \         <CMan_Code>132</CMan_Code>\r\n          <CMan_Name>ASIA                     </CMan_Name>\r\n
+        \         <CMan_Code>89252</CMan_Code>\r\n          <CMan_Name>ALPINE                   </CMan_Name>\r\n
         \       </Table>\r\n        <Table diffgr:id=\"Table6\" msdata:rowOrder=\"5\">\r\n
+        \         <CMan_Code>132</CMan_Code>\r\n          <CMan_Name>ASIA                     </CMan_Name>\r\n
+        \       </Table>\r\n        <Table diffgr:id=\"Table7\" msdata:rowOrder=\"6\">\r\n
         \         <CMan_Code>140</CMan_Code>\r\n          <CMan_Name>ASTON MARTIN
-        \            </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table7\"
-        msdata:rowOrder=\"6\">\r\n          <CMan_Code>164</CMan_Code>\r\n          <CMan_Name>AUDI
-        \                    </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table8\"
-        msdata:rowOrder=\"7\">\r\n          <CMan_Code>607</CMan_Code>\r\n          <CMan_Name>AUSTIN
-        \                  </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table9\"
-        msdata:rowOrder=\"8\">\r\n          <CMan_Code>836</CMan_Code>\r\n          <CMan_Name>BENTLEY
-        \                 </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table10\"
-        msdata:rowOrder=\"9\">\r\n          <CMan_Code>869</CMan_Code>\r\n          <CMan_Name>BMW
+        \            </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table8\"
+        msdata:rowOrder=\"7\">\r\n          <CMan_Code>164</CMan_Code>\r\n          <CMan_Name>AUDI
+        \                    </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table9\"
+        msdata:rowOrder=\"8\">\r\n          <CMan_Code>607</CMan_Code>\r\n          <CMan_Name>AUSTIN
+        \                  </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table10\"
+        msdata:rowOrder=\"9\">\r\n          <CMan_Code>108431</CMan_Code>\r\n          <CMan_Name>BAC
         \                     </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table11\"
-        msdata:rowOrder=\"10\">\r\n          <CMan_Code>1280</CMan_Code>\r\n          <CMan_Name>BRISTOL
+        msdata:rowOrder=\"10\">\r\n          <CMan_Code>836</CMan_Code>\r\n          <CMan_Name>BENTLEY
         \                 </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table12\"
-        msdata:rowOrder=\"11\">\r\n          <CMan_Code>15172</CMan_Code>\r\n          <CMan_Name>CADILLAC
-        \                </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table13\"
-        msdata:rowOrder=\"12\">\r\n          <CMan_Code>22158</CMan_Code>\r\n          <CMan_Name>CATERHAM
-        \                </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table14\"
-        msdata:rowOrder=\"13\">\r\n          <CMan_Code>15155</CMan_Code>\r\n          <CMan_Name>CHEVROLET
-        \               </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table15\"
-        msdata:rowOrder=\"14\">\r\n          <CMan_Code>14786</CMan_Code>\r\n          <CMan_Name>CHRYSLER
-        \                </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table16\"
-        msdata:rowOrder=\"15\">\r\n          <CMan_Code>1333</CMan_Code>\r\n          <CMan_Name>CITROEN
-        \                 </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table17\"
-        msdata:rowOrder=\"16\">\r\n          <CMan_Code>1910</CMan_Code>\r\n          <CMan_Name>COLEMAN
-        MILNE            </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table18\"
-        msdata:rowOrder=\"17\">\r\n          <CMan_Code>34179</CMan_Code>\r\n          <CMan_Name>CORVETTE
-        \                </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table19\"
-        msdata:rowOrder=\"18\">\r\n          <CMan_Code>1925</CMan_Code>\r\n          <CMan_Name>DACIA
-        \                   </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table20\"
-        msdata:rowOrder=\"19\">\r\n          <CMan_Code>1933</CMan_Code>\r\n          <CMan_Name>DAEWOO
-        \                  </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table21\"
-        msdata:rowOrder=\"20\">\r\n          <CMan_Code>1962</CMan_Code>\r\n          <CMan_Name>DAIHATSU
-        \                </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table22\"
-        msdata:rowOrder=\"21\">\r\n          <CMan_Code>2102</CMan_Code>\r\n          <CMan_Name>DAIMLER
-        \                 </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table23\"
-        msdata:rowOrder=\"22\">\r\n          <CMan_Code>19490</CMan_Code>\r\n          <CMan_Name>DE
-        TOMASO                </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table24\"
-        msdata:rowOrder=\"23\">\r\n          <CMan_Code>32717</CMan_Code>\r\n          <CMan_Name>DODGE
+        msdata:rowOrder=\"11\">\r\n          <CMan_Code>869</CMan_Code>\r\n          <CMan_Name>BMW
+        \                     </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table13\"
+        msdata:rowOrder=\"12\">\r\n          <CMan_Code>95220</CMan_Code>\r\n          <CMan_Name>BMW
+        ALPINA               </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table14\"
+        msdata:rowOrder=\"13\">\r\n          <CMan_Code>1280</CMan_Code>\r\n          <CMan_Name>BRISTOL
+        \                 </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table15\"
+        msdata:rowOrder=\"14\">\r\n          <CMan_Code>109123</CMan_Code>\r\n          <CMan_Name>BYD
+        \                     </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table16\"
+        msdata:rowOrder=\"15\">\r\n          <CMan_Code>15172</CMan_Code>\r\n          <CMan_Name>CADILLAC
+        \                </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table17\"
+        msdata:rowOrder=\"16\">\r\n          <CMan_Code>22158</CMan_Code>\r\n          <CMan_Name>CATERHAM
+        \                </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table18\"
+        msdata:rowOrder=\"17\">\r\n          <CMan_Code>15155</CMan_Code>\r\n          <CMan_Name>CHEVROLET
+        \               </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table19\"
+        msdata:rowOrder=\"18\">\r\n          <CMan_Code>14786</CMan_Code>\r\n          <CMan_Name>CHRYSLER
+        \                </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table20\"
+        msdata:rowOrder=\"19\">\r\n          <CMan_Code>1333</CMan_Code>\r\n          <CMan_Name>CITROEN
+        \                 </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table21\"
+        msdata:rowOrder=\"20\">\r\n          <CMan_Code>1910</CMan_Code>\r\n          <CMan_Name>COLEMAN
+        MILNE            </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table22\"
+        msdata:rowOrder=\"21\">\r\n          <CMan_Code>34179</CMan_Code>\r\n          <CMan_Name>CORVETTE
+        \                </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table23\"
+        msdata:rowOrder=\"22\">\r\n          <CMan_Code>93381</CMan_Code>\r\n          <CMan_Name>CUPRA
+        \                   </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table24\"
+        msdata:rowOrder=\"23\">\r\n          <CMan_Code>1925</CMan_Code>\r\n          <CMan_Name>DACIA
         \                   </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table25\"
-        msdata:rowOrder=\"24\">\r\n          <CMan_Code>18833</CMan_Code>\r\n          <CMan_Name>EAGLE
-        \                   </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table26\"
-        msdata:rowOrder=\"25\">\r\n          <CMan_Code>47084</CMan_Code>\r\n          <CMan_Name>FARBIO
-        \                  </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table27\"
-        msdata:rowOrder=\"26\">\r\n          <CMan_Code>26370</CMan_Code>\r\n          <CMan_Name>FBS
-        \                     </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table28\"
-        msdata:rowOrder=\"27\">\r\n          <CMan_Code>2148</CMan_Code>\r\n          <CMan_Name>FERRARI
-        \                 </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table29\"
-        msdata:rowOrder=\"28\">\r\n          <CMan_Code>2193</CMan_Code>\r\n          <CMan_Name>FIAT
+        msdata:rowOrder=\"24\">\r\n          <CMan_Code>1933</CMan_Code>\r\n          <CMan_Name>DAEWOO
+        \                  </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table26\"
+        msdata:rowOrder=\"25\">\r\n          <CMan_Code>1962</CMan_Code>\r\n          <CMan_Name>DAIHATSU
+        \                </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table27\"
+        msdata:rowOrder=\"26\">\r\n          <CMan_Code>2102</CMan_Code>\r\n          <CMan_Name>DAIMLER
+        \                 </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table28\"
+        msdata:rowOrder=\"27\">\r\n          <CMan_Code>19490</CMan_Code>\r\n          <CMan_Name>DE
+        TOMASO                </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table29\"
+        msdata:rowOrder=\"28\">\r\n          <CMan_Code>98212</CMan_Code>\r\n          <CMan_Name>DFSK
         \                    </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table30\"
-        msdata:rowOrder=\"29\">\r\n          <CMan_Code>2514</CMan_Code>\r\n          <CMan_Name>FORD
-        \                    </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table31\"
-        msdata:rowOrder=\"30\">\r\n          <CMan_Code>2129</CMan_Code>\r\n          <CMan_Name>F.S.O.
-        \                  </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table32\"
-        msdata:rowOrder=\"31\">\r\n          <CMan_Code>4256</CMan_Code>\r\n          <CMan_Name>HONDA
-        \                   </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table33\"
-        msdata:rowOrder=\"32\">\r\n          <CMan_Code>41146</CMan_Code>\r\n          <CMan_Name>HUMMER
-        \                  </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table34\"
-        msdata:rowOrder=\"33\">\r\n          <CMan_Code>4537</CMan_Code>\r\n          <CMan_Name>HYUNDAI
-        \                 </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table35\"
-        msdata:rowOrder=\"34\">\r\n          <CMan_Code>47841</CMan_Code>\r\n          <CMan_Name>INFINITI
-        \                </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table36\"
-        msdata:rowOrder=\"35\">\r\n          <CMan_Code>26492</CMan_Code>\r\n          <CMan_Name>INVICTA
-        \                 </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table37\"
-        msdata:rowOrder=\"36\">\r\n          <CMan_Code>4681</CMan_Code>\r\n          <CMan_Name>ISUZU
-        \                   </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table38\"
-        msdata:rowOrder=\"37\">\r\n          <CMan_Code>4721</CMan_Code>\r\n          <CMan_Name>JAGUAR
-        \                  </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table39\"
-        msdata:rowOrder=\"38\">\r\n          <CMan_Code>1283</CMan_Code>\r\n          <CMan_Name>JEEP
-        \                    </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table40\"
-        msdata:rowOrder=\"39\">\r\n          <CMan_Code>19946</CMan_Code>\r\n          <CMan_Name>JENSEN
-        \                  </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table41\"
-        msdata:rowOrder=\"40\">\r\n          <CMan_Code>4835</CMan_Code>\r\n          <CMan_Name>KIA
-        \                     </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table42\"
-        msdata:rowOrder=\"41\">\r\n          <CMan_Code>49348</CMan_Code>\r\n          <CMan_Name>KTM
-        \                     </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table43\"
-        msdata:rowOrder=\"42\">\r\n          <CMan_Code>4895</CMan_Code>\r\n          <CMan_Name>LADA
-        \                    </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table44\"
-        msdata:rowOrder=\"43\">\r\n          <CMan_Code>5007</CMan_Code>\r\n          <CMan_Name>LAMBORGHINI
-        \             </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table45\"
-        msdata:rowOrder=\"44\">\r\n          <CMan_Code>5012</CMan_Code>\r\n          <CMan_Name>LANCIA
-        \                  </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table46\"
-        msdata:rowOrder=\"45\">\r\n          <CMan_Code>5088</CMan_Code>\r\n          <CMan_Name>LAND
-        ROVER               </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table47\"
-        msdata:rowOrder=\"46\">\r\n          <CMan_Code>5171</CMan_Code>\r\n          <CMan_Name>LEXUS
-        \                   </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table48\"
-        msdata:rowOrder=\"47\">\r\n          <CMan_Code>23324</CMan_Code>\r\n          <CMan_Name>LIGIER
-        \                  </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table49\"
-        msdata:rowOrder=\"48\">\r\n          <CMan_Code>5182</CMan_Code>\r\n          <CMan_Name>LOTUS
-        \                   </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table50\"
-        msdata:rowOrder=\"49\">\r\n          <CMan_Code>32074</CMan_Code>\r\n          <CMan_Name>LTI
-        \                     </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table51\"
-        msdata:rowOrder=\"50\">\r\n          <CMan_Code>5212</CMan_Code>\r\n          <CMan_Name>MARCOS
-        \                  </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table52\"
-        msdata:rowOrder=\"51\">\r\n          <CMan_Code>26096</CMan_Code>\r\n          <CMan_Name>MARLIN
-        \                  </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table53\"
-        msdata:rowOrder=\"52\">\r\n          <CMan_Code>5238</CMan_Code>\r\n          <CMan_Name>MASERATI
-        \                </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table54\"
-        msdata:rowOrder=\"53\">\r\n          <CMan_Code>25833</CMan_Code>\r\n          <CMan_Name>MAYBACH
-        \                 </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table55\"
-        msdata:rowOrder=\"54\">\r\n          <CMan_Code>5261</CMan_Code>\r\n          <CMan_Name>MAZDA
-        \                   </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table56\"
-        msdata:rowOrder=\"55\">\r\n          <CMan_Code>5509</CMan_Code>\r\n          <CMan_Name>MERCEDES-BENZ
-        \           </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table57\"
-        msdata:rowOrder=\"56\">\r\n          <CMan_Code>22417</CMan_Code>\r\n          <CMan_Name>MG
+        msdata:rowOrder=\"29\">\r\n          <CMan_Code>32717</CMan_Code>\r\n          <CMan_Name>DODGE
+        \                   </CMan_Name>\r\n        </Table>\r\n        <Table diffgr:id=\"Table31\"
+        msdata:rowOrder=\"30\">\r\n          <CMan_Code>73811</CMan_Code>\r\n          <CMan_Name>DS
         \                      </CMan_Name>\r\n        </Table>\r\n        <Table
-        diffgr:id=\"Table58\" msdata:rowOrder=\"57\">\r\n          <CMan_Code>44394</CMan_Code>\r\n
+        diffgr:id=\"Table32\" msdata:rowOrder=\"31\">\r\n          <CMan_Code>18833</CMan_Code>\r\n
+        \         <CMan_Name>EAGLE                    </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table33\" msdata:rowOrder=\"32\">\r\n          <CMan_Code>47084</CMan_Code>\r\n
+        \         <CMan_Name>FARBIO                   </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table34\" msdata:rowOrder=\"33\">\r\n          <CMan_Code>26370</CMan_Code>\r\n
+        \         <CMan_Name>FBS                      </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table35\" msdata:rowOrder=\"34\">\r\n          <CMan_Code>2148</CMan_Code>\r\n
+        \         <CMan_Name>FERRARI                  </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table36\" msdata:rowOrder=\"35\">\r\n          <CMan_Code>2193</CMan_Code>\r\n
+        \         <CMan_Name>FIAT                     </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table37\" msdata:rowOrder=\"36\">\r\n          <CMan_Code>2514</CMan_Code>\r\n
+        \         <CMan_Name>FORD                     </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table38\" msdata:rowOrder=\"37\">\r\n          <CMan_Code>2129</CMan_Code>\r\n
+        \         <CMan_Name>F.S.O.                   </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table39\" msdata:rowOrder=\"38\">\r\n          <CMan_Code>103856</CMan_Code>\r\n
+        \         <CMan_Name>GENESIS                  </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table40\" msdata:rowOrder=\"39\">\r\n          <CMan_Code>107405</CMan_Code>\r\n
+        \         <CMan_Name>GWM ORA                  </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table41\" msdata:rowOrder=\"40\">\r\n          <CMan_Code>4256</CMan_Code>\r\n
+        \         <CMan_Name>HONDA                    </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table42\" msdata:rowOrder=\"41\">\r\n          <CMan_Code>41146</CMan_Code>\r\n
+        \         <CMan_Name>HUMMER                   </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table43\" msdata:rowOrder=\"42\">\r\n          <CMan_Code>4537</CMan_Code>\r\n
+        \         <CMan_Name>HYUNDAI                  </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table44\" msdata:rowOrder=\"43\">\r\n          <CMan_Code>107322</CMan_Code>\r\n
+        \         <CMan_Name>INEOS                    </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table45\" msdata:rowOrder=\"44\">\r\n          <CMan_Code>47841</CMan_Code>\r\n
+        \         <CMan_Name>INFINITI                 </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table46\" msdata:rowOrder=\"45\">\r\n          <CMan_Code>26492</CMan_Code>\r\n
+        \         <CMan_Name>INVICTA                  </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table47\" msdata:rowOrder=\"46\">\r\n          <CMan_Code>4681</CMan_Code>\r\n
+        \         <CMan_Name>ISUZU                    </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table48\" msdata:rowOrder=\"47\">\r\n          <CMan_Code>4721</CMan_Code>\r\n
+        \         <CMan_Name>JAGUAR                   </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table49\" msdata:rowOrder=\"48\">\r\n          <CMan_Code>1283</CMan_Code>\r\n
+        \         <CMan_Name>JEEP                     </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table50\" msdata:rowOrder=\"49\">\r\n          <CMan_Code>19946</CMan_Code>\r\n
+        \         <CMan_Name>JENSEN                   </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table51\" msdata:rowOrder=\"50\">\r\n          <CMan_Code>4835</CMan_Code>\r\n
+        \         <CMan_Name>KIA                      </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table52\" msdata:rowOrder=\"51\">\r\n          <CMan_Code>49348</CMan_Code>\r\n
+        \         <CMan_Name>KTM                      </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table53\" msdata:rowOrder=\"52\">\r\n          <CMan_Code>4895</CMan_Code>\r\n
+        \         <CMan_Name>LADA                     </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table54\" msdata:rowOrder=\"53\">\r\n          <CMan_Code>5007</CMan_Code>\r\n
+        \         <CMan_Name>LAMBORGHINI              </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table55\" msdata:rowOrder=\"54\">\r\n          <CMan_Code>5012</CMan_Code>\r\n
+        \         <CMan_Name>LANCIA                   </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table56\" msdata:rowOrder=\"55\">\r\n          <CMan_Code>5088</CMan_Code>\r\n
+        \         <CMan_Name>LAND ROVER               </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table57\" msdata:rowOrder=\"56\">\r\n          <CMan_Code>86761</CMan_Code>\r\n
+        \         <CMan_Name>LEVC                     </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table58\" msdata:rowOrder=\"57\">\r\n          <CMan_Code>5171</CMan_Code>\r\n
+        \         <CMan_Name>LEXUS                    </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table59\" msdata:rowOrder=\"58\">\r\n          <CMan_Code>23324</CMan_Code>\r\n
+        \         <CMan_Name>LIGIER                   </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table60\" msdata:rowOrder=\"59\">\r\n          <CMan_Code>5182</CMan_Code>\r\n
+        \         <CMan_Name>LOTUS                    </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table61\" msdata:rowOrder=\"60\">\r\n          <CMan_Code>32074</CMan_Code>\r\n
+        \         <CMan_Name>LTI                      </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table62\" msdata:rowOrder=\"61\">\r\n          <CMan_Code>80426</CMan_Code>\r\n
+        \         <CMan_Name>MAHINDRA                 </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table63\" msdata:rowOrder=\"62\">\r\n          <CMan_Code>5212</CMan_Code>\r\n
+        \         <CMan_Name>MARCOS                   </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table64\" msdata:rowOrder=\"63\">\r\n          <CMan_Code>26096</CMan_Code>\r\n
+        \         <CMan_Name>MARLIN                   </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table65\" msdata:rowOrder=\"64\">\r\n          <CMan_Code>5238</CMan_Code>\r\n
+        \         <CMan_Name>MASERATI                 </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table66\" msdata:rowOrder=\"65\">\r\n          <CMan_Code>109015</CMan_Code>\r\n
+        \         <CMan_Name>MAXUS                    </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table67\" msdata:rowOrder=\"66\">\r\n          <CMan_Code>25833</CMan_Code>\r\n
+        \         <CMan_Name>MAYBACH                  </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table68\" msdata:rowOrder=\"67\">\r\n          <CMan_Code>5261</CMan_Code>\r\n
+        \         <CMan_Name>MAZDA                    </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table69\" msdata:rowOrder=\"68\">\r\n          <CMan_Code>77092</CMan_Code>\r\n
+        \         <CMan_Name>MCLAREN                  </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table70\" msdata:rowOrder=\"69\">\r\n          <CMan_Code>5509</CMan_Code>\r\n
+        \         <CMan_Name>MERCEDES-BENZ            </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table71\" msdata:rowOrder=\"70\">\r\n          <CMan_Code>22417</CMan_Code>\r\n
+        \         <CMan_Name>MG                       </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table72\" msdata:rowOrder=\"71\">\r\n          <CMan_Code>44394</CMan_Code>\r\n
         \         <CMan_Name>MG MOTOR UK              </CMan_Name>\r\n        </Table>\r\n
-        \       <Table diffgr:id=\"Table59\" msdata:rowOrder=\"58\">\r\n          <CMan_Code>61511</CMan_Code>\r\n
+        \       <Table diffgr:id=\"Table73\" msdata:rowOrder=\"72\">\r\n          <CMan_Code>61511</CMan_Code>\r\n
         \         <CMan_Name>MIA                      </CMan_Name>\r\n        </Table>\r\n
-        \       <Table diffgr:id=\"Table60\" msdata:rowOrder=\"59\">\r\n          <CMan_Code>22491</CMan_Code>\r\n
+        \       <Table diffgr:id=\"Table74\" msdata:rowOrder=\"73\">\r\n          <CMan_Code>22491</CMan_Code>\r\n
         \         <CMan_Name>MICROCAR                 </CMan_Name>\r\n        </Table>\r\n
-        \       <Table diffgr:id=\"Table61\" msdata:rowOrder=\"60\">\r\n          <CMan_Code>22439</CMan_Code>\r\n
+        \       <Table diffgr:id=\"Table75\" msdata:rowOrder=\"74\">\r\n          <CMan_Code>22439</CMan_Code>\r\n
         \         <CMan_Name>MINI                     </CMan_Name>\r\n        </Table>\r\n
-        \       <Table diffgr:id=\"Table62\" msdata:rowOrder=\"61\">\r\n          <CMan_Code>6058</CMan_Code>\r\n
+        \       <Table diffgr:id=\"Table76\" msdata:rowOrder=\"75\">\r\n          <CMan_Code>6058</CMan_Code>\r\n
         \         <CMan_Name>MITSUBISHI               </CMan_Name>\r\n        </Table>\r\n
-        \       <Table diffgr:id=\"Table63\" msdata:rowOrder=\"62\">\r\n          <CMan_Code>6402</CMan_Code>\r\n
+        \       <Table diffgr:id=\"Table77\" msdata:rowOrder=\"76\">\r\n          <CMan_Code>101681</CMan_Code>\r\n
+        \         <CMan_Name>MOKE                     </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table78\" msdata:rowOrder=\"77\">\r\n          <CMan_Code>6402</CMan_Code>\r\n
         \         <CMan_Name>MORGAN                   </CMan_Name>\r\n        </Table>\r\n
-        \       <Table diffgr:id=\"Table64\" msdata:rowOrder=\"63\">\r\n          <CMan_Code>6425</CMan_Code>\r\n
+        \       <Table diffgr:id=\"Table79\" msdata:rowOrder=\"78\">\r\n          <CMan_Code>6425</CMan_Code>\r\n
         \         <CMan_Name>NISSAN                   </CMan_Name>\r\n        </Table>\r\n
-        \       <Table diffgr:id=\"Table65\" msdata:rowOrder=\"64\">\r\n          <CMan_Code>25853</CMan_Code>\r\n
+        \       <Table diffgr:id=\"Table80\" msdata:rowOrder=\"79\">\r\n          <CMan_Code>25853</CMan_Code>\r\n
         \         <CMan_Name>NOBLE                    </CMan_Name>\r\n        </Table>\r\n
-        \       <Table diffgr:id=\"Table66\" msdata:rowOrder=\"65\">\r\n          <CMan_Code>7093</CMan_Code>\r\n
+        \       <Table diffgr:id=\"Table81\" msdata:rowOrder=\"80\">\r\n          <CMan_Code>7093</CMan_Code>\r\n
         \         <CMan_Name>OPEL                     </CMan_Name>\r\n        </Table>\r\n
-        \       <Table diffgr:id=\"Table67\" msdata:rowOrder=\"66\">\r\n          <CMan_Code>14186</CMan_Code>\r\n
+        \       <Table diffgr:id=\"Table82\" msdata:rowOrder=\"81\">\r\n          <CMan_Code>14186</CMan_Code>\r\n
         \         <CMan_Name>PERODUA                  </CMan_Name>\r\n        </Table>\r\n
-        \       <Table diffgr:id=\"Table68\" msdata:rowOrder=\"67\">\r\n          <CMan_Code>7104</CMan_Code>\r\n
+        \       <Table diffgr:id=\"Table83\" msdata:rowOrder=\"82\">\r\n          <CMan_Code>7104</CMan_Code>\r\n
         \         <CMan_Name>PEUGEOT                  </CMan_Name>\r\n        </Table>\r\n
-        \       <Table diffgr:id=\"Table69\" msdata:rowOrder=\"68\">\r\n          <CMan_Code>40214</CMan_Code>\r\n
+        \       <Table diffgr:id=\"Table84\" msdata:rowOrder=\"83\">\r\n          <CMan_Code>40214</CMan_Code>\r\n
         \         <CMan_Name>PGO                      </CMan_Name>\r\n        </Table>\r\n
-        \       <Table diffgr:id=\"Table70\" msdata:rowOrder=\"69\">\r\n          <CMan_Code>7983</CMan_Code>\r\n
+        \       <Table diffgr:id=\"Table85\" msdata:rowOrder=\"84\">\r\n          <CMan_Code>97846</CMan_Code>\r\n
+        \         <CMan_Name>POLESTAR                 </CMan_Name>\r\n        </Table>\r\n
+        \       <Table diffgr:id=\"Table86\" msdata:rowOrder=\"85\">\r\n          <CMan_Code>7983</CMan_Code>\r\n
         \         <CMan_Name>PORSCHE                  </CMan_Name>\r\n        </Table>\r\n
-        \       <Table diffgr:id=\"Table71\" msdata:rowOrder=\"70\">\r\n          <CMan_Code>61676</CMan_Code>\r\n
+        \       <Table diffgr:id=\"Table87\" msdata:rowOrder=\"86\">\r\n          <CMan_Code>61676</CMan_Code>\r\n
         \         <CMan_Name>PRINDIVILLE              </CMan_Name>\r\n        </Table>\r\n
-        \       <Table diffgr:id=\"Table72\" msdata:rowOrder=\"71\">\r\n          <CMan_Code>8083</CMan_Code>\r\n
+        \       <Table diffgr:id=\"Table88\" msdata:rowOrder=\"87\">\r\n          <CMan_Code>8083</CMan_Code>\r\n
         \         <CMan_Name>PROTON                   </CMan_Name>\r\n        </Table>\r\n
-        \       <Table diffgr:id=\"Table73\" msdata:rowOrder=\"72\">\r\n          <CMan_Code>8205</CMan_Code>\r\n
+        \       <Table diffgr:id=\"Table89\" msdata:rowOrder=\"88\">\r\n          <CMan_Code>8205</CMan_Code>\r\n
         \         <CMan_Name>RELIANT                  </CMan_Name>\r\n        </Table>\r\n
-        \       <Table diffgr:id=\"Table74\" msdata:rowOrder=\"73\">\r\n          <CMan_Code>8219</CMan_Code>\r\n
+        \       <Table diffgr:id=\"Table90\" msdata:rowOrder=\"89\">\r\n          <CMan_Code>8219</CMan_Code>\r\n
         \         <CMan_Name>RENAULT                  </CMan_Name>\r\n        </Table>\r\n
-        \       <Table diffgr:id=\"Table75\" msdata:rowOrder=\"74\">\r\n          <CMan_Code>8927</CMan_Code>\r\n
+        \       <Table diffgr:id=\"Table91\" msdata:rowOrder=\"90\">\r\n          <CMan_Code>8927</CMan_Code>\r\n
         \         <CMan_Name>ROLLS-ROYCE              </CMan_Name>\r\n        </Table>\r\n
-        \       <Table diffgr:id=\"Table76\" msdata:rowOrder=\"75\">\r\n          <CMan_Code>8959</CMan_Code>\r\n
+        \       <Table diffgr:id=\"Table92\" msdata:rowOrder=\"91\">\r\n          <CMan_Code>8959</CMan_Code>\r\n
         \         <CMan_Name>ROVER                    </CMan_Name>\r\n        </Table>\r\n
-        \       <Table diffgr:id=\"Table77\" msdata:rowOrder=\"76\">\r\n          <CMan_Code>9572</CMan_Code>\r\n
+        \       <Table diffgr:id=\"Table93\" msdata:rowOrder=\"92\">\r\n          <CMan_Code>9572</CMan_Code>\r\n
         \         <CMan_Name>SAAB                     </CMan_Name>\r\n        </Table>\r\n
-        \       <Table diffgr:id=\"Table78\" msdata:rowOrder=\"77\">\r\n          <CMan_Code>36183</CMan_Code>\r\n
+        \       <Table diffgr:id=\"Table94\" msdata:rowOrder=\"93\">\r\n          <CMan_Code>36183</CMan_Code>\r\n
         \         <CMan_Name>SAN                      </CMan_Name>\r\n        </Table>\r\n
-        \       <Table diffgr:id=\"Table79\" msdata:rowOrder=\"78\">\r\n          <CMan_Code>9905</CMan_Code>\r\n
+        \       <Table diffgr:id=\"Table95\" msdata:rowOrder=\"94\">\r\n          <CMan_Code>9905</CMan_Code>\r\n
         \         <CMan_Name>SAO                      </CMan_Name>\r\n        </Table>\r\n
-        \       <Table diffgr:id=\"Table80\" msdata:rowOrder=\"79\">\r\n          <CMan_Code>9909</CMan_Code>\r\n
+        \       <Table diffgr:id=\"Table96\" msdata:rowOrder=\"95\">\r\n          <CMan_Code>9909</CMan_Code>\r\n
         \         <CMan_Name>SEAT                     </CMan_Name>\r\n        </Table>\r\n
-        \       <Table diffgr:id=\"Table81\" msdata:rowOrder=\"80\">\r\n          <CMan_Code>10172</CMan_Code>\r\n
+        \       <Table diffgr:id=\"Table97\" msdata:rowOrder=\"96\">\r\n          <CMan_Code>10172</CMan_Code>\r\n
         \         <CMan_Name>SKODA                    </CMan_Name>\r\n        </Table>\r\n
-        \       <Table diffgr:id=\"Table82\" msdata:rowOrder=\"81\">\r\n          <CMan_Code>21223</CMan_Code>\r\n
+        \       <Table diffgr:id=\"Table98\" msdata:rowOrder=\"97\">\r\n          <CMan_Code>21223</CMan_Code>\r\n
         \         <CMan_Name>SMART                    </CMan_Name>\r\n        </Table>\r\n
-        \       <Table diffgr:id=\"Table83\" msdata:rowOrder=\"82\">\r\n          <CMan_Code>10236</CMan_Code>\r\n
+        \       <Table diffgr:id=\"Table99\" msdata:rowOrder=\"98\">\r\n          <CMan_Code>10236</CMan_Code>\r\n
         \         <CMan_Name>SSANGYONG                </CMan_Name>\r\n        </Table>\r\n
-        \       <Table diffgr:id=\"Table84\" msdata:rowOrder=\"83\">\r\n          <CMan_Code>10251</CMan_Code>\r\n
+        \       <Table diffgr:id=\"Table100\" msdata:rowOrder=\"99\">\r\n          <CMan_Code>10251</CMan_Code>\r\n
         \         <CMan_Name>SUBARU                   </CMan_Name>\r\n        </Table>\r\n
-        \       <Table diffgr:id=\"Table85\" msdata:rowOrder=\"84\">\r\n          <CMan_Code>10383</CMan_Code>\r\n
+        \       <Table diffgr:id=\"Table101\" msdata:rowOrder=\"100\">\r\n          <CMan_Code>10383</CMan_Code>\r\n
         \         <CMan_Name>SUZUKI                   </CMan_Name>\r\n        </Table>\r\n
-        \       <Table diffgr:id=\"Table86\" msdata:rowOrder=\"85\">\r\n          <CMan_Code>10513</CMan_Code>\r\n
+        \       <Table diffgr:id=\"Table102\" msdata:rowOrder=\"101\">\r\n          <CMan_Code>10513</CMan_Code>\r\n
         \         <CMan_Name>TALBOT                   </CMan_Name>\r\n        </Table>\r\n
-        \       <Table diffgr:id=\"Table87\" msdata:rowOrder=\"86\">\r\n          <CMan_Code>19775</CMan_Code>\r\n
+        \       <Table diffgr:id=\"Table103\" msdata:rowOrder=\"102\">\r\n          <CMan_Code>19775</CMan_Code>\r\n
         \         <CMan_Name>TATA                     </CMan_Name>\r\n        </Table>\r\n
-        \       <Table diffgr:id=\"Table88\" msdata:rowOrder=\"87\">\r\n          <CMan_Code>36389</CMan_Code>\r\n
+        \       <Table diffgr:id=\"Table104\" msdata:rowOrder=\"103\">\r\n          <CMan_Code>36389</CMan_Code>\r\n
         \         <CMan_Name>TD CARS                  </CMan_Name>\r\n        </Table>\r\n
-        \       <Table diffgr:id=\"Table89\" msdata:rowOrder=\"88\">\r\n          <CMan_Code>51182</CMan_Code>\r\n
+        \       <Table diffgr:id=\"Table105\" msdata:rowOrder=\"104\">\r\n          <CMan_Code>51182</CMan_Code>\r\n
         \         <CMan_Name>TESLA                    </CMan_Name>\r\n        </Table>\r\n
-        \       <Table diffgr:id=\"Table90\" msdata:rowOrder=\"89\">\r\n          <CMan_Code>10519</CMan_Code>\r\n
+        \       <Table diffgr:id=\"Table106\" msdata:rowOrder=\"105\">\r\n          <CMan_Code>10519</CMan_Code>\r\n
         \         <CMan_Name>TOYOTA                   </CMan_Name>\r\n        </Table>\r\n
-        \       <Table diffgr:id=\"Table91\" msdata:rowOrder=\"90\">\r\n          <CMan_Code>10949</CMan_Code>\r\n
+        \       <Table diffgr:id=\"Table107\" msdata:rowOrder=\"106\">\r\n          <CMan_Code>10949</CMan_Code>\r\n
         \         <CMan_Name>TVR                      </CMan_Name>\r\n        </Table>\r\n
-        \       <Table diffgr:id=\"Table92\" msdata:rowOrder=\"91\">\r\n          <CMan_Code>10968</CMan_Code>\r\n
+        \       <Table diffgr:id=\"Table108\" msdata:rowOrder=\"107\">\r\n          <CMan_Code>10968</CMan_Code>\r\n
         \         <CMan_Name>VAUXHALL                 </CMan_Name>\r\n        </Table>\r\n
-        \       <Table diffgr:id=\"Table93\" msdata:rowOrder=\"92\">\r\n          <CMan_Code>12243</CMan_Code>\r\n
+        \       <Table diffgr:id=\"Table109\" msdata:rowOrder=\"108\">\r\n          <CMan_Code>12243</CMan_Code>\r\n
         \         <CMan_Name>VOLKSWAGEN               </CMan_Name>\r\n        </Table>\r\n
-        \       <Table diffgr:id=\"Table94\" msdata:rowOrder=\"93\">\r\n          <CMan_Code>12764</CMan_Code>\r\n
+        \       <Table diffgr:id=\"Table110\" msdata:rowOrder=\"109\">\r\n          <CMan_Code>12764</CMan_Code>\r\n
         \         <CMan_Name>VOLVO                    </CMan_Name>\r\n        </Table>\r\n
-        \       <Table diffgr:id=\"Table95\" msdata:rowOrder=\"94\">\r\n          <CMan_Code>22120</CMan_Code>\r\n
+        \       <Table diffgr:id=\"Table111\" msdata:rowOrder=\"110\">\r\n          <CMan_Code>22120</CMan_Code>\r\n
         \         <CMan_Name>WESTFIELD                </CMan_Name>\r\n        </Table>\r\n
-        \       <Table diffgr:id=\"Table96\" msdata:rowOrder=\"95\">\r\n          <CMan_Code>13642</CMan_Code>\r\n
+        \       <Table diffgr:id=\"Table112\" msdata:rowOrder=\"111\">\r\n          <CMan_Code>13642</CMan_Code>\r\n
         \         <CMan_Name>YUGO                     </CMan_Name>\r\n        </Table>\r\n
         \     </NewDataSet>\r\n    </diffgr:diffgram>\r\n  </Returned_DataSet>\r\n</CAPDataSetResult>"
     http_version:
-  recorded_at: Mon, 22 Sep 2014 12:29:21 GMT
-recorded_with: VCR 2.9.2
+  recorded_at: Tue, 07 Mar 2023 12:47:21 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/webservices_capnetwork_co_uk/post/captco_webservice/CAPTCO_Webservice_asmx/GetTCO.yml
+++ b/spec/cassettes/webservices_capnetwork_co_uk/post/captco_webservice/CAPTCO_Webservice_asmx/GetTCO.yml
@@ -1,0 +1,53 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://webservices.capnetwork.co.uk/captco_webservice/CAPTCO_Webservice.asmx/GetTCO
+    body:
+      encoding: UTF-8
+      string: Password=ghaj7a&SubscriberID=170796&Database=CAR&CapId=86391&RegistrationDate=2018%2F11%2F30&PurchaseCost=43000.0&FinanceAPR=0&Deposit=0&CurrentMileage=40&AnnualMileage=10&LengthOfOwnership=12&UserAge=30&UserPostCode=N1+1AA&AnnualInsurance=0
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (darwin22 arm64) ruby/2.7.7p221
+      Content-Length:
+      - '241'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - webservices.capnetwork.co.uk
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/xml; charset=utf-8
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Tue, 07 Mar 2023 12:47:22 GMT
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<TCOResult xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"
+        xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns=\"http://webservices.capnetwork.co.uk\">\r\n
+        \ <Success>true</Success>\r\n  <FailMessage />\r\n  <TotalCostOfOwnership>15514.67</TotalCostOfOwnership>\r\n
+        \ <TotalMonthlyRunningCosts>1292.89</TotalMonthlyRunningCosts>\r\n  <RunningCostsPerMile>1.55</RunningCostsPerMile>\r\n
+        \ <FuelCosts>2400.67</FuelCosts>\r\n  <Depreciation>11300</Depreciation>\r\n
+        \ <ServiceAndMaintenance>1649.00</ServiceAndMaintenance>\r\n  <InsuranceGroup>50E</InsuranceGroup>\r\n
+        \ <Insurance>0.00</Insurance>\r\n  <CostNew>77818.00</CostNew>\r\n  <DeliveryCost>660.0000</DeliveryCost>\r\n
+        \ <RoadTax>165.00</RoadTax>\r\n  <PurchasePrice>43000.00</PurchasePrice>\r\n</TCOResult>"
+    http_version:
+  recorded_at: Tue, 07 Mar 2023 12:47:22 GMT
+recorded_with: VCR 4.0.0

--- a/spec/features/car_cost_tool_spec.rb
+++ b/spec/features/car_cost_tool_spec.rb
@@ -1,0 +1,10 @@
+RSpec.feature 'Car cost tool' do
+  scenario 'Functions after a successful cookie check', vcr: true do
+    visit '/en/tools/car-costs-calculator/?checked=true'
+
+    fill_in 'vrm', with: 'AC63 UFO'
+    click_on 'Add car'
+
+    expect(page).to have_text('C63 S Premium Plus 2dr 9G-Tronic')
+  end
+end

--- a/spec/requests/tool_integration/car_cost_tool_spec.rb
+++ b/spec/requests/tool_integration/car_cost_tool_spec.rb
@@ -1,5 +1,8 @@
 RSpec.describe 'Car Cost Tool', type: :request do
-  %W[/cy/tools/#{ToolMountPoint::CarCostTool::CY_ID}].each do |path|
+  %W[
+    /en/tools/#{ToolMountPoint::CarCostTool::EN_ID}?checked=true
+    /cy/tools/#{ToolMountPoint::CarCostTool::CY_ID}
+  ].each do |path|
     describe path do
       before do
         get path


### PR DESCRIPTION
We were indiscriminantly checking before any action, for those tools
that were configured for cookie checks. Instead, we ought to only check
on GET requests. This was causing complications with the car cost
calculator particularly. This commit adds VCR recorded responses from
the CAP API that appear to contain secrets but do not, since the API
requires other secrets to function that are not included in the outputs.