### PR TITLE
Switch test DB to MySQL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,19 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_DB: mas_test
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+        ports:
+          - '3306:3306'
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
     env:
       RAILS_ENV: test
       ALGOLIA_APP_ID: test
@@ -38,6 +51,6 @@ jobs:
       - name: Install bowndler packages
         run: bin/bowndler update
       - name: Set up database schema
-        run: bin/rake db:schema:load
+        run: bin/rake db:create db:schema:load
       - name: Run tests
         run: bin/rake

--- a/config/database.yml
+++ b/config/database.yml
@@ -7,10 +7,14 @@ development:
   encoding: utf8
 
 test:
-  adapter: sqlite3
-  database: db/test.sqlite3
+  adapter: mysql2
+  host: 127.0.0.1
+  username: root
+  database: cms_test
   pool: 5
   timeout: 5000
+  encoding: utf8
+  port: 3306
 
 production:
   adapter: mysql2

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -43,7 +43,6 @@ end
 
 AfterConfiguration do
   DatabaseCleaner.clean
-  ActiveRecord::Tasks::DatabaseTasks.load_schema(:ruby, ENV['SCHEMA'])
 
   Core::Registry::Repository[:customer] = Core::Repository::Customers::Fake.new
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -90,7 +90,6 @@ RSpec.configure do |c|
 
   c.before(:suite) do
     DatabaseCleaner.clean
-    ActiveRecord::Tasks::DatabaseTasks.load_schema_current(:ruby, ENV['SCHEMA'])
 
     Core::Registry::Repository[:customer] = Core::Repository::Customers::Fake.new
   end


### PR DESCRIPTION
This was always targetting sqlite and I never really understood why. It
makes sense for these tests to run in parity with the dev/production
environment and leverage the same DB. This also fixes an issue with
sqlite that's currently affecting us in CI.