### PR TITLE
Only include launch scripts for first-party

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,10 @@
 module ApplicationHelper
+  def include_adobe_analytics_scripts?(request)
+    return false unless Rails.env.production? && ENV['INCLUDE_AEM_ANALYTICS'] == 'true'
+
+    request.original_url.match?(/partner-tools.moneyhelper.org.uk/)
+  end
+
   def css(line_numbers: false, &block)
     source = strip_leading_indentation_from_source(capture(&block))
     tokens = Rouge::Lexers::CSS.lex(source)

--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -53,7 +53,7 @@
       Any JS that is required before DOM is created should be in this block
       includes feature detection, analytics setup, JSON bootstrap %>
 
-  <% if Rails.env.production? && ENV['INCLUDE_AEM_ANALYTICS'] == 'true' %>
+  <% if include_adobe_analytics_scripts?(request) %>
   <script type="text/javascript" src="//assets.adobedtm.com/c3a3920a84ef/2104df5e2099/launch-a40370bb1e84.min.js" async></script>
   <script type="text/javascript" src="//www.moneyhelper.org.uk/etc.clientlibs/maps/core/clientlibs/clientlib-digitaldata.min.536e82a039f309f9f59b3e9e3dab024f.js" defer></script>
   <% end %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -28,4 +28,27 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
   end
+
+  describe 'include_adobe_analytics_scripts?' do
+    before do
+      ENV['INCLUDE_AEM_ANALYTICS'] = 'true'
+      allow(Rails).to receive(:env) { 'production'.inquiry }
+    end
+
+    context 'when the host is incorrect' do
+      it 'returns false' do
+        req = double(original_url: 'https://partner-tools.moneyadviceservice.org.uk/en/tools/meh')
+
+        expect(helper.include_adobe_analytics_scripts?(req)).to be false
+      end
+    end
+
+    context 'when the host is correct' do
+      it 'returns true' do
+        req = double(original_url: 'https://partner-tools.moneyhelper.org.uk/en/tools/meh')
+
+        expect(helper.include_adobe_analytics_scripts?(req)).to be true
+      end
+    end
+  end
 end


### PR DESCRIPTION
These should not be included when displaying in a syndicated context for a third party.
