### PR TITLE
Removes the redundancy pay banner

### DIFF
--- a/config/budget_warning_tools.yml
+++ b/config/budget_warning_tools.yml
@@ -1,2 +1,1 @@
-- /en/tools/redundancy-pay-calculator/
-- /cy/tools/cyfrifiannell-tal-diswyddo/
+--


### PR DESCRIPTION
This was updated for 23/24 so is accurate and no longer needs the banner.