### PR TITLE
Ignore the syndicated domain for redirections

### DIFF
--- a/lib/legacy_redirects.rb
+++ b/lib/legacy_redirects.rb
@@ -1,4 +1,4 @@
-LEGACY_MAS_WWW = %r{(www.)?moneyadviceservice.org.uk}.freeze
+LEGACY_MAS_WWW = %r{^(www.)?moneyadviceservice.org.uk}.freeze
 
 if Rails.env.production?
   r301 %r{^/assets/(.*)$}, '/a/$1'

--- a/spec/requests/legacy_redirects_spec.rb
+++ b/spec/requests/legacy_redirects_spec.rb
@@ -13,4 +13,15 @@ RSpec.describe 'Legacy redirects', type: :request do
       end
     end
   end
+
+  describe 'partner-tools subdomain syndicated tools regression' do
+    it 'does not redirect to the canonical when the host is syndicated' do
+      host! 'partner-tools.moneyadviceservice.org.uk'
+
+      get '/en/tools/budget-planner'
+
+      # redirecting to the cookies message verifies it didn't redirect to MH
+      expect(request).to redirect_to('/en/cookies_disabled?tool=budget-planner')
+    end
+  end
 end


### PR DESCRIPTION
This was missed in the previous changes as
`partner-tools.moneyadviceservice.org.uk` is still used for syndication and the matching for hosts in the redirection rules went from exact to a regex that wasn't anchored.

The regression test will also catch any issues around syndicated tool redirections in future.