### PR TITLE
Redirect legacy mortgage calculator to new embed

### DIFF
--- a/lib/legacy_redirects.rb
+++ b/lib/legacy_redirects.rb
@@ -1,4 +1,5 @@
 LEGACY_MAS_WWW = %r{^(www.)?moneyadviceservice.org.uk}.freeze
+LEGACY_MAS_SYNDICATION = 'partner-tools.moneyadviceservice.org.uk'.freeze
 
 if Rails.env.production?
   r301 %r{^/assets/(.*)$}, '/a/$1'
@@ -13,6 +14,8 @@ r301 %r{.*}, 'https://www.moneyhelper.org.uk/en/family-and-care/divorce-and-sepa
 r301 %r{.*}, 'https://www.moneyhelper.org.uk/en/pensions-and-retirement/taking-your-pension/compare-annuities?source=mas', host: 'compare.moneyadviceservice.org.uk'
 r301 %r{.*}, 'https://www.moneyhelper.org.uk/en/everyday-money?source=mas', host: 'yourmoney.moneyadviceservice.org.uk'
 r301 %r{.*}, 'https://www.moneyhelper.org.uk/en/benefits/universal-credit/money-manager?source=mas', host: 'obs.moneyadviceservice.org.uk'
+
+r301 %r{^/en/tools/mortgage-calculator/?(.*)}, 'https://tools.moneyhelper.org.uk/en/embed/mortgage-calculator', host: LEGACY_MAS_SYNDICATION
 
 r301 %r{^/en/tools/budget-planner/?(.*)}, 'https://www.moneyhelper.org.uk/en/everyday-money/budgeting/budget-planner', host: LEGACY_MAS_WWW
 r301 %r{^/cy/tools/cynllunydd-cyllideb/?(.*)}, 'https://www.moneyhelper.org.uk/cy/everyday-money/budgeting/budget-planner', host: LEGACY_MAS_WWW

--- a/spec/requests/legacy_redirects_spec.rb
+++ b/spec/requests/legacy_redirects_spec.rb
@@ -1,4 +1,14 @@
 RSpec.describe 'Legacy redirects', type: :request do
+  describe 'legacy tools to new tools redirects' do
+    before { host! 'partner-tools.moneyadviceservice.org.uk' }
+
+    it 'redirects to the new mortgage calculator' do
+      get '/en/tools/mortgage-calculator'
+
+      expect(request).to redirect_to('https://tools.moneyhelper.org.uk/en/embed/mortgage-calculator')
+    end
+  end
+
   ['www.moneyadviceservice.org.uk', 'moneyadviceservice.org.uk'].each do |host|
     context "when requested from the legacy #{host} host" do
       it 'redirects tools to the correct landing page' do


### PR DESCRIPTION
When syndicated requests are made for the mortgage calculator, we redirect to the new tool URL.