### PR TITLE
Remove syndicated logo for mortgage calculator

### DIFF
--- a/app/assets/javascripts/syndication/tools.js.coffee
+++ b/app/assets/javascripts/syndication/tools.js.coffee
@@ -184,6 +184,7 @@
         path: "cy/tools/cyfrifiannell-morgais"
       width: "100%"
       include_ga: false
+      omit_logo: true
       title: "Mortgage calculator"
 
     mortgage_calculator:
@@ -193,6 +194,7 @@
         path: "cy/tools/cyfrifiannell-morgais"
       width: "100%"
       include_ga: false
+      omit_logo: true
       title: "Mortgage calculator"
 
     stamp_duty:


### PR DESCRIPTION
This now redirects to the new tool and that has its own logo so we no longer need to display the large original logo.