### PR TITLE
Prepare the SDC and LBTT calcs for decommission

### DIFF
--- a/app/assets/javascripts/syndication/tools.js.coffee
+++ b/app/assets/javascripts/syndication/tools.js.coffee
@@ -203,6 +203,7 @@
       cy:
         path: "cy/tools/prynu-ty/cyfrifiannell-treth-stamp"
       include_ga: true
+      omit_logo: true
       title: "Stamp duty calculator"
 
     lbtt_calculator:
@@ -212,6 +213,7 @@
         path: "cy/tools/prynu-ty/cyfrifiannell-treth-trafodion-tir-ac-adeiladau-alban"
       width: "100%"
       include_ga: false
+      omit_logo: true
       title: "LBTT Calculator"
 
     mortgage_affordability_calculator:

--- a/lib/legacy_redirects.rb
+++ b/lib/legacy_redirects.rb
@@ -15,6 +15,8 @@ r301 %r{.*}, 'https://www.moneyhelper.org.uk/en/pensions-and-retirement/taking-y
 r301 %r{.*}, 'https://www.moneyhelper.org.uk/en/everyday-money?source=mas', host: 'yourmoney.moneyadviceservice.org.uk'
 r301 %r{.*}, 'https://www.moneyhelper.org.uk/en/benefits/universal-credit/money-manager?source=mas', host: 'obs.moneyadviceservice.org.uk'
 
+r301 %r{^/en/tools/house-buying/stamp-duty-calculator/?(.*)}, 'https://tools.moneyhelper.org.uk/en/embed/sdlt-calculator', host: LEGACY_MAS_SYNDICATION
+r301 %r{^/en/tools/house-buying/land-and-buildings-transaction-tax-calculator-scotland/?(.*)}, 'https://tools.moneyhelper.org.uk/en/embed/lbtt-calculator', host: LEGACY_MAS_SYNDICATION
 r301 %r{^/en/tools/mortgage-calculator/?(.*)}, 'https://tools.moneyhelper.org.uk/en/embed/mortgage-calculator', host: LEGACY_MAS_SYNDICATION
 
 r301 %r{^/en/tools/budget-planner/?(.*)}, 'https://www.moneyhelper.org.uk/en/everyday-money/budgeting/budget-planner', host: LEGACY_MAS_WWW

--- a/spec/requests/legacy_redirects_spec.rb
+++ b/spec/requests/legacy_redirects_spec.rb
@@ -7,6 +7,18 @@ RSpec.describe 'Legacy redirects', type: :request do
 
       expect(request).to redirect_to('https://tools.moneyhelper.org.uk/en/embed/mortgage-calculator')
     end
+
+    it 'redirects to the new stamp duty calculator' do
+      get '/en/tools/house-buying/stamp-duty-calculator'
+
+      expect(request).to redirect_to('https://tools.moneyhelper.org.uk/en/embed/sdlt-calculator')
+    end
+
+    it 'redirects to the new LBTT calculator' do
+      get '/en/tools/house-buying/land-and-buildings-transaction-tax-calculator-scotland'
+
+      expect(request).to redirect_to('https://tools.moneyhelper.org.uk/en/embed/lbtt-calculator')
+    end
   end
 
   ['www.moneyadviceservice.org.uk', 'moneyadviceservice.org.uk'].each do |host|


### PR DESCRIPTION
Redirects to their new tool counterparts and configures the logo to be ommitted in syndication.