### PR TITLE
Bump redundancy calc for Scotland banner

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,7 +82,7 @@ gem 'dough-ruby', github: 'moneyadviceservice/dough', branch: 'PostMessages_v5.4
 gem 'mas-cms-client', '1.20.1'
 gem 'site_search', '0.3.0'
 # Tools
-gem 'action_plans', github: 'moneyadviceservice/action_plans', ref: '2d7c6df'
+gem 'action_plans', github: 'moneyadviceservice/action_plans', ref: 'e3b486b'
 gem 'advice_plans', '~> 4.1.1'
 gem 'agreements', '~> 2.5.0'
 gem 'budget_planner', github: 'moneyadviceservice/budget_planner', ref: '0efd1a9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,10 +6,10 @@ GIT
 
 GIT
   remote: https://github.com/moneyadviceservice/action_plans.git
-  revision: 2d7c6df40b98d55b79cc858b820f558126187fde
-  ref: 2d7c6df
+  revision: e3b486b029278b5a2f6450695f7267945e6f8fa9
+  ref: e3b486b
   specs:
-    action_plans (6.5.0)
+    action_plans (6.6.0)
       autoprefixer-rails
       dough-ruby (~> 5.0)
       draper


### PR DESCRIPTION
The tool is not accurate when the customer is a taxpayer in Scotland.
