### PR TITLE
Budget planner direct

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -136,7 +136,6 @@ group :test do
   gem 'selenium-webdriver'
   gem 'shoulda-matchers'
   gem 'site_prism'
-  gem 'sqlite3', '1.4.2'
   gem 'tidy-html5'
   gem 'timecop'
   gem 'uri', '0.10.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -259,7 +259,7 @@ GEM
     bowndler (1.0.2)
       thor
     builder (3.3.0)
-    byebug (10.0.2)
+    byebug (11.1.3)
     capybara (2.18.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -274,7 +274,7 @@ GEM
     cocoon (1.2.12)
     codeclimate-test-reporter (0.6.0)
       simplecov (>= 0.7.1, < 1.0.0)
-    coderay (1.1.2)
+    coderay (1.1.3)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -522,7 +522,7 @@ GEM
     mas-templating (1.0.0.18)
     meta-tags (2.19.0)
       actionpack (>= 3.2.0, < 7.2)
-    method_source (0.9.0)
+    method_source (1.1.0)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
@@ -579,17 +579,17 @@ GEM
       activemodel (~> 4.2)
       rest-client (~> 2.0)
     powerpack (0.1.1)
-    pry (0.11.3)
-      coderay (~> 1.1.0)
-      method_source (~> 0.9.0)
-    pry-byebug (3.6.0)
-      byebug (~> 10.0)
-      pry (~> 0.10)
-    pry-rails (0.3.6)
-      pry (>= 0.10.4)
-    pry-rescue (1.4.5)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
+    pry-rails (0.3.11)
+      pry (>= 0.13.0)
+    pry-rescue (1.6.0)
       interception (>= 0.5)
-      pry
+      pry (>= 0.12.0)
     psych (3.0.2)
     public_suffix (5.1.1)
     puma (6.4.2)
@@ -745,7 +745,6 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
-    sqlite3 (1.4.2)
     statsd-ruby (1.4.0)
     structured_warnings (0.4.0)
     sucker_punch (2.1.1)
@@ -904,7 +903,6 @@ DEPENDENCIES
   shoulda-matchers
   site_prism
   site_search (= 0.3.0)
-  sqlite3 (= 1.4.2)
   statsd-ruby
   sucker_punch
   syslog-logger

--- a/app/controllers/direct_budget_planner_controller.rb
+++ b/app/controllers/direct_budget_planner_controller.rb
@@ -1,0 +1,11 @@
+class DirectBudgetPlannerController < EmbeddedToolsController
+  BUDGET_PLANNER_SUMMARY_PATH = '/en/tools/budget-planner/budget/summary'.freeze
+
+  def new
+    return redirect_to BUDGET_PLANNER_SUMMARY_PATH if user_signed_in?
+
+    session[:user_return_to] = BUDGET_PLANNER_SUMMARY_PATH
+
+    redirect_to new_user_session_path
+  end
+end

--- a/app/controllers/direct_budget_planner_controller.rb
+++ b/app/controllers/direct_budget_planner_controller.rb
@@ -1,11 +1,26 @@
 class DirectBudgetPlannerController < EmbeddedToolsController
-  BUDGET_PLANNER_SUMMARY_PATH = '/en/tools/budget-planner/budget/summary'.freeze
+  ENGLISH_BUDGET_PLANNER_SUMMARY_PATH = '/en/tools/budget-planner/budget/summary'.freeze
+  WELSH_BUDGET_PLANNER_SUMMARY_PATH   = '/cy/tools/cynllunydd-cyllideb/budget/summary'.freeze
 
   def new
-    return redirect_to BUDGET_PLANNER_SUMMARY_PATH if user_signed_in?
+    return redirect_to summary_path_for(locale) if user_signed_in?
 
-    session[:user_return_to] = BUDGET_PLANNER_SUMMARY_PATH
+    session[:user_return_to] = summary_path_for(locale)
 
-    redirect_to new_user_session_path
+    redirect_to new_user_session_path(locale: locale)
+  end
+
+  private
+
+  def locale
+    I18n.locale
+  end
+
+  def summary_path_for(locale)
+    if locale == :en
+      ENGLISH_BUDGET_PLANNER_SUMMARY_PATH
+    else
+      WELSH_BUDGET_PLANNER_SUMMARY_PATH
+    end
   end
 end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -54,7 +54,7 @@
 
     <div class="registration__row">
       <div class="registration__field">
-        <%= f.submit t("authentication.sign_in_page.label"), class: "button button--primary" %>
+        <%= f.submit t("authentication.sign_in_page.label"), class: "button button--primary t-submit" %>
       </div>
     </div>
   <% end %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -59,6 +59,8 @@
     </div>
   <% end %>
 
+  <% unless ENV['DISALLOW_REGISTRATIONS'] %>
   <h2><%= t("authentication.sign_in_page.links.register_title") %></h2>
-  <p><%= raw authentication_sign_in_description new_registration_path(resource_name) %></p>
+  <p class="t-register"><%= raw authentication_sign_in_description new_registration_path(resource_name) %></p>
+  <% end %>
 </main>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,8 @@ Rails.application.routes.draw do
   scope '/:locale', locale: /en|cy/ do
     root 'home#show'
 
+    get '/direct/budget-planner', to: 'direct_budget_planner#new'
+
     get '/tools/car-costs-calculator', to: 'car_cost_tool#index'
     get '/tools/car-costs-calculator/*all', to: 'car_cost_tool#index'
     get '/tools/money-navigator-tool', to: 'money_navigator_tool#index'

--- a/features/support/ui/pages/sign_in.rb
+++ b/features/support/ui/pages/sign_in.rb
@@ -6,7 +6,7 @@ module UI::Pages
 
     element :email, "input[name='user[email]']"
     element :password, "input[name='user[password]']"
-    element :submit, "input[value='Sign in']"
+    element :submit, '.t-submit'
 
     element :forgot_password, ".registration__links a"
   end

--- a/spec/features/budget_planner_spec.rb
+++ b/spec/features/budget_planner_spec.rb
@@ -19,7 +19,23 @@ RSpec.feature 'Budget Planner' do
     end
   end
 
-  scenario 'Using the direct sign-in link successfully' do
+  scenario 'Using the direct sign-in link successfully in English' do
+    create_user_budget
+    visit '/en/direct/budget-planner'
+    sign_in_user
+
+    expect(@page.current_path).to eq('/en/tools/budget-planner/budget/summary')
+  end
+
+  scenario 'Using the direct sign-in link successfully in Welsh' do
+    create_user_budget
+    visit '/cy/direct/budget-planner'
+    sign_in_user
+
+    expect(@page.current_path).to eq('/cy/tools/cynllunydd-cyllideb/budget/summary')
+  end
+
+  def create_user_budget
     @user = create(:user)
 
     @budget = BudgetPlanner::Budget.new
@@ -28,16 +44,14 @@ RSpec.feature 'Budget Planner' do
     @budget.steps[1].categories[0].sources[0].value = 50.0
     @budget.user = @user
     @budget.save
+  end
 
-    visit '/en/direct/budget-planner'
-
+  def sign_in_user
     @page = UI::Pages::SignIn.new
     expect(@page).to be_displayed
 
     @page.email.set(@user.email)
     @page.password.set(@user.password)
     @page.submit.click
-
-    expect(@page.current_path).to eq('/en/tools/budget-planner/budget/summary')
   end
 end

--- a/spec/features/budget_planner_spec.rb
+++ b/spec/features/budget_planner_spec.rb
@@ -1,3 +1,5 @@
+require_relative '../../features/support/ui/pages/sign_in'
+
 RSpec.feature 'Budget Planner' do
   scenario 'The `noresize` param when set, persists across requests' do
     visit '/en/tools/budget-planner?noresize=true'
@@ -15,5 +17,27 @@ RSpec.feature 'Budget Planner' do
     page.all('form').each do |form|
       expect(form['action']).not_to end_with('?noresize=true')
     end
+  end
+
+  scenario 'Using the direct sign-in link successfully' do
+    @user = create(:user)
+
+    @budget = BudgetPlanner::Budget.new
+    @budget.data = BudgetPlanner::BudgetDataFactory.new.build('budget-planner')
+    @budget.steps.first.categories.first.sources.first.value = 2000.0
+    @budget.steps[1].categories[0].sources[0].value = 50.0
+    @budget.user = @user
+    @budget.save
+
+    visit '/en/direct/budget-planner'
+
+    @page = UI::Pages::SignIn.new
+    expect(@page).to be_displayed
+
+    @page.email.set(@user.email)
+    @page.password.set(@user.password)
+    @page.submit.click
+
+    expect(@page.current_path).to eq('/en/tools/budget-planner/budget/summary')
   end
 end

--- a/spec/features/budget_planner_spec.rb
+++ b/spec/features/budget_planner_spec.rb
@@ -1,6 +1,18 @@
 require_relative '../../features/support/ui/pages/sign_in'
 
 RSpec.feature 'Budget Planner' do
+  scenario 'disallowing registrations' do
+    visit '/en/users/sign_in'
+    expect(page).to have_css('.t-register')
+
+    ENV['DISALLOW_REGISTRATIONS'] = 'true'
+
+    visit '/en/users/sign_in'
+    expect(page).to_not have_css('.t-register')
+  ensure
+    ENV.delete('DISALLOW_REGISTRATIONS')
+  end
+
   scenario 'The `noresize` param when set, persists across requests' do
     visit '/en/tools/budget-planner?noresize=true'
 


### PR DESCRIPTION
Adds direct links to budget planner summaries in English and Welsh to allow customers to land on this page, authenticate and be directed deep into the budget planner to their budget summary page. This is to facilitate the transferral of their old budgets into the new budget planner.