### PR TITLE
Bump action_plans for redundancy calc banner

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,7 +80,7 @@ gem 'cream', '2.1.8'
 gem 'dough-ruby', github: 'moneyadviceservice/dough', branch: 'PostMessages_v5.45'
 gem 'mas-cms-client', '1.20.1'
 # Tools
-gem 'action_plans', github: 'moneyadviceservice/action_plans', ref: 'edb52f8'
+gem 'action_plans', github: 'moneyadviceservice/action_plans', ref: '9eef3fc'
 gem 'advice_plans', '~> 4.1.1'
 gem 'agreements', '~> 2.5.0'
 gem 'budget_planner', github: 'moneyadviceservice/budget_planner', ref: 'd72d455e'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,10 +6,10 @@ GIT
 
 GIT
   remote: https://github.com/moneyadviceservice/action_plans.git
-  revision: edb52f82363c8431c8572ab28c6cc5983c26bd17
-  ref: edb52f8
+  revision: 9eef3fcc2701d96b084edaa169172156ef78b885
+  ref: 9eef3fc
   specs:
-    action_plans (6.6.1)
+    action_plans (6.7.0)
       autoprefixer-rails
       dough-ruby (~> 5.0)
       draper


### PR DESCRIPTION
Removes the banner relating to Scotland as it's no longer needed.
