### PR TITLE
Redundancy pay scotland

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,7 +80,7 @@ gem 'cream', '2.1.8'
 gem 'dough-ruby', github: 'moneyadviceservice/dough', branch: 'PostMessages_v5.45'
 gem 'mas-cms-client', '1.20.1'
 # Tools
-gem 'action_plans', github: 'moneyadviceservice/action_plans', ref: '9eef3fc'
+gem 'action_plans', github: 'moneyadviceservice/action_plans', ref: '071e3c3c'
 gem 'advice_plans', '~> 4.1.1'
 gem 'agreements', '~> 2.5.0'
 gem 'budget_planner', github: 'moneyadviceservice/budget_planner', ref: 'd72d455e'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,10 +6,10 @@ GIT
 
 GIT
   remote: https://github.com/moneyadviceservice/action_plans.git
-  revision: 9eef3fcc2701d96b084edaa169172156ef78b885
-  ref: 9eef3fc
+  revision: 071e3c3c81b878a99e732ba7d27fb1b55a45d174
+  ref: 071e3c3c
   specs:
-    action_plans (6.7.0)
+    action_plans (6.8.0)
       autoprefixer-rails
       dough-ruby (~> 5.0)
       draper

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181127152000) do
+ActiveRecord::Schema.define(version: 20250107135912) do
 
   create_table "action_plans_expense_items", force: :cascade do |t|
     t.string  "kind",       limit: 256,             null: false
@@ -50,7 +50,7 @@ ActiveRecord::Schema.define(version: 20181127152000) do
     t.string   "package_salary_period",   limit: 255
     t.integer  "package_duration_units",  limit: 4
     t.string   "package_duration_period", limit: 255
-    t.boolean  "northern_ireland"
+    t.integer  "residence",               limit: 4
   end
 
   create_table "action_plans_redundancy_tasks", force: :cascade do |t|


### PR DESCRIPTION
Adds the correct taxation for customers completing the redundancy pay calculator and identifying as Scottish tax payers.