### PR TITLE
Ready the baby money timeline for the new tool

### DIFF
--- a/app/assets/javascripts/syndication/tools.js.coffee
+++ b/app/assets/javascripts/syndication/tools.js.coffee
@@ -39,6 +39,7 @@
       height: "800px"
       include_ga: false
       title: "Baby money timeline"
+      omit_logo: true
 
     baby_timeline_mumsnet:
       en:
@@ -47,6 +48,7 @@
       height: "800px"
       include_ga: false
       title: "Baby money timeline"
+      omit_logo: true
 
     debt_test:
       en:

--- a/lib/legacy_redirects.rb
+++ b/lib/legacy_redirects.rb
@@ -19,6 +19,7 @@ r301 %r{^/en/tools/house-buying/stamp-duty-calculator/?(.*)}, 'https://tools.mon
 r301 %r{^/en/tools/house-buying/land-and-buildings-transaction-tax-calculator-scotland/?(.*)}, 'https://tools.moneyhelper.org.uk/en/lbtt-calculator?isEmbedded=true', host: LEGACY_MAS_SYNDICATION
 r301 %r{^/en/tools/mortgage-calculator/?(.*)}, 'https://tools.moneyhelper.org.uk/en/mortgage-calculator?isEmbedded=true', host: LEGACY_MAS_SYNDICATION
 r301 %r{^/en/tools/debt-advice-locator/?(.*)}, 'https://debt-advice-locator.moneyhelper.org.uk/en/question-1?isEmbedded=true', host: LEGACY_MAS_SYNDICATION
+r301 %r{^/en/tools/baby-money-timeline/?(.*)}, 'https://tool.moneyhelper.org.uk/en/baby-money-timeline?isEmbedded=true', host: LEGACY_MAS_SYNDICATION
 
 r301 %r{^/en/tools/budget-planner/?(.*)}, 'https://www.moneyhelper.org.uk/en/everyday-money/budgeting/budget-planner', host: LEGACY_MAS_WWW
 r301 %r{^/cy/tools/cynllunydd-cyllideb/?(.*)}, 'https://www.moneyhelper.org.uk/cy/everyday-money/budgeting/budget-planner', host: LEGACY_MAS_WWW

--- a/spec/requests/legacy_redirects_spec.rb
+++ b/spec/requests/legacy_redirects_spec.rb
@@ -2,6 +2,12 @@ RSpec.describe 'Legacy redirects', type: :request do
   describe 'legacy tools to new tools redirects' do
     before { host! 'partner-tools.moneyadviceservice.org.uk' }
 
+    it 'redirects to the new baby money tool' do
+      get '/en/tools/baby-money-timeline'
+
+      expect(request).to redirect_to('https://tool.moneyhelper.org.uk/en/baby-money-timeline?isEmbedded=true')
+    end
+
     it 'redirects to the new debt advice locator' do
       get '/en/tools/debt-advice-locator'
 


### PR DESCRIPTION
Omits the legacy logo in syndication and redirects to the new tool so
syndication with the legacy snippet works seamlessly.