### PR TITLE
Budget planner retirement

### DIFF
--- a/app/assets/javascripts/syndication/tools.js.coffee
+++ b/app/assets/javascripts/syndication/tools.js.coffee
@@ -94,6 +94,7 @@
       width: "100%"
       height: "2500px"
       title: "Budget planner"
+      omit_logo: true
 
     budget_planner_incognito:
       en:
@@ -103,6 +104,7 @@
       width: "100%"
       height: "2500px"
       title: "Budget planner"
+      omit_logo: true
 
     back_to_school:
       en:

--- a/app/models/cookied_tool.rb
+++ b/app/models/cookied_tool.rb
@@ -13,11 +13,6 @@ class CookiedTool
 
   COOKIED_TOOLS = [
     CookiedTool.new(
-      landing_path: '/en/tools/budget-planner/',
-      tool: 'budget-planner',
-      canonical_url: 'https://www.moneyhelper.org.uk/en/everyday-money/budgeting/use-our-budget-planner'
-    ),
-    CookiedTool.new(
       landing_path: '/en/tools/credit-card-calculator/credit-card/',
       tool: 'credit-card-calculator',
       canonical_url: 'https://www.moneyhelper.org.uk/en/everyday-money/credit-and-purchases/use-our-credit-card-calculator'

--- a/lib/legacy_redirects.rb
+++ b/lib/legacy_redirects.rb
@@ -22,7 +22,6 @@ r301 %r{^/en/tools/mortgage-calculator/?(.*)}, 'https://tools.moneyhelper.org.uk
 r301 %r{^/en/tools/debt-advice-locator/?(.*)}, 'https://debt-advice-locator.moneyhelper.org.uk/en/question-1?isEmbedded=true', host: LEGACY_MAS_SYNDICATION
 r301 %r{^/en/tools/baby-money-timeline/?(.*)}, 'https://tool.moneyhelper.org.uk/en/baby-money-timeline?isEmbedded=true', host: LEGACY_MAS_SYNDICATION
 
-r301 %r{^/en/tools/budget-planner/?(.*)}, 'https://www.moneyhelper.org.uk/en/everyday-money/budgeting/budget-planner', host: LEGACY_MAS_WWW
 r301 %r{^/cy/tools/cynllunydd-cyllideb/?(.*)}, 'https://www.moneyhelper.org.uk/cy/everyday-money/budgeting/budget-planner', host: LEGACY_MAS_WWW
 r301 %r{^/en/tools/mortgage-calculator/?(.*)}, 'https://www.moneyhelper.org.uk/en/homes/buying-a-home/mortgage-calculator', host: LEGACY_MAS_WWW
 r301 %r{^/en/tools/house-buying/stamp-duty-calculator/?(.*)}, 'https://www.moneyhelper.org.uk/en/homes/buying-a-home/stamp-duty-calculator', host: LEGACY_MAS_WWW

--- a/lib/legacy_redirects.rb
+++ b/lib/legacy_redirects.rb
@@ -15,6 +15,8 @@ r301 %r{.*}, 'https://www.moneyhelper.org.uk/en/pensions-and-retirement/taking-y
 r301 %r{.*}, 'https://www.moneyhelper.org.uk/en/everyday-money?source=mas', host: 'yourmoney.moneyadviceservice.org.uk'
 r301 %r{.*}, 'https://www.moneyhelper.org.uk/en/benefits/universal-credit/money-manager?source=mas', host: 'obs.moneyadviceservice.org.uk'
 
+r301 %r{^/en/direct/budget-planner/?(.*)}, 'https://tools.moneyhelper.org.uk/en/budget-planner/income?isEmbedded=true'
+r301 %r{^/cy/direct/budget-planner/?(.*)}, 'https://tools.moneyhelper.org.uk/cy/budget-planner/income?isEmbedded=true'
 r301 %r{^/en/tools/budget-planner/?(.*)}, 'https://tools.moneyhelper.org.uk/en/budget-planner/income?isEmbedded=true', host: LEGACY_MAS_SYNDICATION
 r301 %r{^/en/tools/house-buying/stamp-duty-calculator/?(.*)}, 'https://tools.moneyhelper.org.uk/en/sdlt-calculator?isEmbedded=true', host: LEGACY_MAS_SYNDICATION
 r301 %r{^/en/tools/house-buying/land-and-buildings-transaction-tax-calculator-scotland/?(.*)}, 'https://tools.moneyhelper.org.uk/en/lbtt-calculator?isEmbedded=true', host: LEGACY_MAS_SYNDICATION

--- a/lib/legacy_redirects.rb
+++ b/lib/legacy_redirects.rb
@@ -15,6 +15,7 @@ r301 %r{.*}, 'https://www.moneyhelper.org.uk/en/pensions-and-retirement/taking-y
 r301 %r{.*}, 'https://www.moneyhelper.org.uk/en/everyday-money?source=mas', host: 'yourmoney.moneyadviceservice.org.uk'
 r301 %r{.*}, 'https://www.moneyhelper.org.uk/en/benefits/universal-credit/money-manager?source=mas', host: 'obs.moneyadviceservice.org.uk'
 
+r301 %r{^/en/tools/budget-planner/?(.*)}, 'https://tools.moneyhelper.org.uk/en/budget-planner/income?isEmbedded=true', host: LEGACY_MAS_SYNDICATION
 r301 %r{^/en/tools/house-buying/stamp-duty-calculator/?(.*)}, 'https://tools.moneyhelper.org.uk/en/sdlt-calculator?isEmbedded=true', host: LEGACY_MAS_SYNDICATION
 r301 %r{^/en/tools/house-buying/land-and-buildings-transaction-tax-calculator-scotland/?(.*)}, 'https://tools.moneyhelper.org.uk/en/lbtt-calculator?isEmbedded=true', host: LEGACY_MAS_SYNDICATION
 r301 %r{^/en/tools/mortgage-calculator/?(.*)}, 'https://tools.moneyhelper.org.uk/en/mortgage-calculator?isEmbedded=true', host: LEGACY_MAS_SYNDICATION

--- a/spec/features/budget_planner_spec.rb
+++ b/spec/features/budget_planner_spec.rb
@@ -30,40 +30,4 @@ RSpec.feature 'Budget Planner' do
       expect(form['action']).not_to end_with('?noresize=true')
     end
   end
-
-  scenario 'Using the direct sign-in link successfully in English' do
-    create_user_budget
-    visit '/en/direct/budget-planner'
-    sign_in_user
-
-    expect(@page.current_path).to eq('/en/tools/budget-planner/budget/summary')
-  end
-
-  scenario 'Using the direct sign-in link successfully in Welsh' do
-    create_user_budget
-    visit '/cy/direct/budget-planner'
-    sign_in_user
-
-    expect(@page.current_path).to eq('/cy/tools/cynllunydd-cyllideb/budget/summary')
-  end
-
-  def create_user_budget
-    @user = create(:user)
-
-    @budget = BudgetPlanner::Budget.new
-    @budget.data = BudgetPlanner::BudgetDataFactory.new.build('budget-planner')
-    @budget.steps.first.categories.first.sources.first.value = 2000.0
-    @budget.steps[1].categories[0].sources[0].value = 50.0
-    @budget.user = @user
-    @budget.save
-  end
-
-  def sign_in_user
-    @page = UI::Pages::SignIn.new
-    expect(@page).to be_displayed
-
-    @page.email.set(@user.email)
-    @page.password.set(@user.password)
-    @page.submit.click
-  end
 end

--- a/spec/requests/legacy_redirects_spec.rb
+++ b/spec/requests/legacy_redirects_spec.rb
@@ -2,6 +2,12 @@ RSpec.describe 'Legacy redirects', type: :request do
   describe 'legacy tools to new tools redirects' do
     before { host! 'partner-tools.moneyadviceservice.org.uk' }
 
+    it 'redirects to the new budget planner tool' do
+      get '/en/tools/budget-planner'
+
+      expect(request).to redirect_to('https://tools.moneyhelper.org.uk/en/budget-planner/income?isEmbedded=true')
+    end
+
     it 'redirects to the new baby money tool' do
       get '/en/tools/baby-money-timeline'
 
@@ -38,24 +44,10 @@ RSpec.describe 'Legacy redirects', type: :request do
       it 'redirects tools to the correct landing page' do
         host! host
 
-        get '/en/tools/budget-planner'
-        expect(request).to redirect_to('https://www.moneyhelper.org.uk/en/everyday-money/budgeting/budget-planner')
-
         # weird path from legacy campaigns
         get '///en/tools/money-navigator-tool'
         expect(request).to redirect_to('https://www.moneyhelper.org.uk/en/money-troubles/coronavirus/money-navigator-tool')
       end
-    end
-  end
-
-  describe 'partner-tools subdomain syndicated tools regression' do
-    it 'does not redirect to the canonical when the host is syndicated' do
-      host! 'partner-tools.moneyadviceservice.org.uk'
-
-      get '/en/tools/budget-planner'
-
-      # redirecting to the cookies message verifies it didn't redirect to MH
-      expect(request).to redirect_to('/en/cookies_disabled?tool=budget-planner')
     end
   end
 

--- a/spec/requests/tool_integration/budget_planner_spec.rb
+++ b/spec/requests/tool_integration/budget_planner_spec.rb
@@ -8,4 +8,17 @@ RSpec.describe 'Budget Planner', type: :request do
       specify { expect(response).to be_ok }
     end
   end
+
+
+  it 'redirects from the legacy direct sign-in link successfully in English' do
+    get '/en/direct/budget-planner'
+
+    expect(response).to redirect_to('https://tools.moneyhelper.org.uk/en/budget-planner/income?isEmbedded=true')
+  end
+
+  it 'redirects from the legacy direct sign-in link successfully in Welsh' do
+    get '/cy/direct/budget-planner'
+
+    expect(response).to redirect_to('https://tools.moneyhelper.org.uk/cy/budget-planner/income?isEmbedded=true')
+  end
 end

--- a/spec/requests/tool_integration/budget_planner_spec.rb
+++ b/spec/requests/tool_integration/budget_planner_spec.rb
@@ -8,33 +8,4 @@ RSpec.describe 'Budget Planner', type: :request do
       specify { expect(response).to be_ok }
     end
   end
-
-  context 'when syndicated with `noresize` but prior to cookie checks' do
-    it 'does not include the frame resizer' do
-      get '/en/tools/budget-planner', { noresize: true }
-
-      expect(response).to be_redirect
-      cookie_check_path = response.location
-      get cookie_check_path
-
-      expect(response).to be_redirect
-      expect(response.location).to end_with('/en/tools/budget-planner/?checked=true&noresize=true')
-    end
-  end
-
-  context 'when syndicated with `noresize`' do
-    it 'does not include the frame resizer' do
-      get '/en/tools/budget-planner', { checked: true, noresize: true }
-
-      expect(response.body).not_to include('window.iframeResizer')
-    end
-  end
-
-  context 'when syndicated normally' do
-    it 'includes the frame resizer' do
-      get '/en/tools/budget-planner?checked=true', {}
-
-      expect(response.body).to include('window.iframeResizer')
-    end
-  end
 end


### PR DESCRIPTION
This phase just includes the redirects to enable syndication in the legacy contexts. A follow up PR will actually remove any references to the budget planner and associated code/resources.