### PR TITLE
Add `rack` to the LTS source block and bump

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 source "https://gems.railslts.com" do
   gem 'rails', '~> 4.2.11'
+  gem 'rack'
   gem 'actionmailer',     require: false
   gem 'actionpack',       require: false
   gem 'activemodel',      require: false
@@ -76,7 +77,6 @@ gem 'opening_hours'
 gem 'rollbar'
 gem 'psych', '>= 2.0.5' # https://www.ruby-lang.org/en/news/2014/03/29/heap-overflow-in-yaml-uri-escape-parsing-cve-2014-2525/
 gem 'puma'
-gem 'rack', github: 'rails-lts/rack', branch: 'lts-1-6-stable'
 gem 'rack-rewrite'
 gem 'recaptcha', require: 'recaptcha/rails'
 gem 'redcarpet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,13 +53,6 @@ GIT
       sass-rails
       sprockets (< 4)
 
-GIT
-  remote: https://github.com/rails-lts/rack.git
-  revision: 93aa66af110260f0e154a7e9a6b694df6434565e
-  branch: lts-1-6-stable
-  specs:
-    rack (1.6.13.17)
-
 GEM
   remote: https://rubygems.org/
   remote: https://gems.railslts.com/
@@ -509,6 +502,7 @@ GEM
       friendly_id (>= 5.0)
       rails (>= 4, < 5)
     racc (1.8.1)
+    rack (1.6.13.27)
     rack-accept (0.4.5)
       rack (>= 0.4)
     rack-livereload (0.3.17)


### PR DESCRIPTION
This was a few versions behind and had some patches to CVEs that we needed.
